### PR TITLE
Fix exported profiles containing full path to config

### DIFF
--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -146,7 +146,11 @@ export default class ProfileModList {
         const exportPath = path.join(exportDirectory, `${Profile.getActiveProfile().getProfileName()}.r2z`);
         const zip = new AdmZip();
         zip.addFile('export.r2x', Buffer.from(yaml.stringify(exportFormat)));
-        zip.addLocalFolder(path.join(Profile.getActiveProfile().getPathOfProfile(), 'BepInEx', 'config'), 'config');
+        const configDir = path.join(Profile.getActiveProfile().getPathOfProfile(), 'BepInEx', 'config')
+        const cwd = process.cwd();
+        process.chdir(configDir);
+        zip.addLocalFolder(".", 'config/');
+        process.chdir(cwd);
         zip.writeZip(exportPath);
         spawn('powershell.exe', ['explorer', `/select,${exportPath}`]);
     }


### PR DESCRIPTION
When exporting a profile, temporarily switch the working directory to the config path, so the full path is not included in the exported zip.

Fixes #141