### PR TITLE
Improve clarity of mod lists

### DIFF
--- a/src/components/ExpandableCard.vue
+++ b/src/components/ExpandableCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="border-at-bottom">
-        <div class='card is-shadowless' :class="{'disabled-card': !enabled, 'expanded-card': visible}">
+        <div class='card is-shadowless' :class="{'disabled-card': !enabled}">
             <a @click='toggleVisibility()'>
                 <header class='card-header is-shadowless' :id='id'>
                     <div class='card-header-icon mod-logo' v-if="image !== ''">

--- a/src/components/ExpandableCard.vue
+++ b/src/components/ExpandableCard.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="border-at-bottom">
-        <div class='card is-shadowless'>
+        <div class='card is-shadowless' :class="{'disabled-card': !enabled, 'expanded-card': visible}">
             <a @click='toggleVisibility()'>
                 <header class='card-header is-shadowless' :id='id'>
-                    <div class='card-header-icon' v-if="image !== ''">
+                    <div class='card-header-icon mod-logo' v-if="image !== ''">
                         <figure class='image is-48x48 image-parent'>
                             <img :src='image' alt='Mod Logo' class='image-overlap'/>
                             <img v-if="funkyMode" src='../assets/funky_mode.png' alt='Mod Logo' class='image-overlap'/>
@@ -79,6 +79,9 @@ export default class ExpandableCard extends Vue {
 
     @Prop({default: false})
     darkTheme: boolean | undefined;
+
+    @Prop({default: true})
+    enabled: boolean | undefined;
 
     // Keep track of visibility
     visible: boolean | undefined = false;

--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -129,7 +129,8 @@
                 :manualSortUp="index > 0"
                 :manualSortDown="index < searchableModList.length - 1"
                 :darkTheme="settings.darkTheme"
-                :expandedByDefault="settings.expandedCards">
+                :expandedByDefault="settings.expandedCards"
+                :enabled="key.isEnabled()">
                 <template v-slot:title>
                     <span :class="['selectable', {'has-tooltip-left': getTooltipText(key).length > 2}]" :data-tooltip="getTooltipText(key).length > 0 ? getTooltipText(key) : null">
                         <span v-if="key.isDeprecated()" class="tag is-danger">
@@ -138,12 +139,14 @@
                         <span v-if="!key.isEnabled()" class="tag is-warning">
                             Disabled
                         </span>&nbsp;
-                        <template v-if="key.isEnabled()">
-                            {{key.getDisplayName()}} by {{key.getAuthorName()}}
-                        </template>
-                        <template v-else>
-                            <strike class='selectable'>{{key.getDisplayName()}} by {{key.getAuthorName()}}</strike>
-                        </template>
+                        <span class="card-title">
+                            <template v-if="key.isEnabled()">
+                                {{key.getDisplayName()}} <span class="card-byline">by {{key.getAuthorName()}}</span>
+                            </template>
+                            <template v-else>
+                                <strike class='selectable'>{{key.getDisplayName()}} <span class="card-byline">by {{key.getAuthorName()}}</span></strike>
+                            </template>
+                        </span>
                     </span>
                 </template>
                 <template v-slot:other-icons>
@@ -166,13 +169,12 @@
                     <a class='card-footer-item' @click="enableMod(key)" v-else>Enable</a>
                 </template>
                 <a class='card-footer-item' @click="viewDependencyList(key)">View associated</a>
-                <span class='card-footer-item'>
-										<i class='fas fa-code-branch'>&nbsp;&nbsp;</i>
-										<Link :url="`${key.getWebsiteUrl()}${key.getVersionNumber().toString()}`"
-                                              :target="'external'">
-											{{key.getVersionNumber().toString()}}
-										</Link>
-									</span>
+                <Link :url="`${key.getWebsiteUrl()}${key.getVersionNumber().toString()}`"
+                      :target="'external'"
+                      class="card-footer-item">
+                        <i class='fas fa-code-branch'>&nbsp;&nbsp;</i>
+                        {{key.getVersionNumber().toString()}}
+                </Link>
                 <a class='card-footer-item' v-if="!isLatest(key)" @click="updateMod(key)">Update</a>
                 <a class='card-footer-item' v-if="getMissingDependencies(key).length > 0"
                    @click="downloadDependency(getMissingDependencies(key)[0])">

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -19,15 +19,15 @@
 									<span v-if="key.isPinned()" class='has-tooltip-left'
                                           data-tooltip='Pinned on Thunderstore'>
 										<span class="tag is-info">Pinned</span>&nbsp;
-										<span class="selectable">{{key.getName()}} by {{key.getOwner()}}</span>
+										<span class="selectable">{{key.getName()}} <span class="card-byline">by {{key.getOwner()}}</span></span>
 									</span>
                     <span v-else-if="isModDeprecated(key)" class='has-tooltip-left'
                           data-tooltip='This mod is potentially broken'>
 										<span class="tag is-danger">Deprecated</span>&nbsp;
-										<strike class="selectable">{{key.getName()}} by {{key.getOwner()}}</strike>
+										<strike class="selectable">{{key.getName()}} <span class="card-byline">by {{key.getOwner()}}</span></strike>
 									</span>
                     <span v-else class='selectable'>
-										{{key.getName()}} by {{key.getOwner()}}
+										{{key.getName()}} <span class="card-byline">by {{key.getOwner()}}</span>
 									</span>
                 </template>
                 <template v-slot:other-icons>
@@ -38,14 +38,12 @@
 									</span>
                 </template>
                 <template v-slot:description>
-                    <p><strong>Last updated: {{getReadableDate(key.getDateUpdated())}}</strong></p>
+                    <p class='card-timestamp'><strong>Last updated:</strong> {{getReadableDate(key.getDateUpdated())}}</p>
                 </template>
                 <a class='card-footer-item' @click='showDownloadModal(key)'>Download</a>
-                <div class='card-footer-item'>
-                    <Link :url="key.getPackageUrl()" :target="'external'">
-                        View on Thunderstore
-                    </Link>
-                </div>
+                <Link :url="key.getPackageUrl()" :target="'external'" class='card-footer-item'>
+                    View on Thunderstore
+                </Link>
                 <div class='card-footer-item non-selectable'>
                     <span><i class='fas fa-download'/> {{key.getTotalDownloads()}}</span>
                 </div>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -51,6 +51,46 @@
     border: 0 !important;
 }
 
+.disabled-card {
+    .mod-logo, .card-title, .card-content {
+        opacity: 0.6;
+    }
+}
+
+.card .card-footer, .card .card-footer-item {
+    border: none !important;
+    // these two lines allow the hover effect's pseudo-element to position itself behind the element's text, with a bit of a margin
+    position: relative;
+    z-index: 1;
+}
+
+.card-footer-item:not(.non-selectable) {
+    &:hover, &:active, &:focus {
+        color: #fff;
+        // use a psuedo-element for the hover effect
+        &::before {
+            content: "";
+            display: block;
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            width: calc(100% - 20px);
+            height: calc(100% - 20px);
+            z-index: -1;
+            background-color: #3273dc;
+            border-radius: 4px;
+        }
+    }
+}
+
+.card-byline, .card-timestamp {
+    color: #858585;
+}
+
+.card-timestamp strong {
+    color: inherit;
+}
+
 .is-text {
     color: inherit;
     &--bold {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -65,26 +65,32 @@
 }
 
 .card-footer-item:not(.non-selectable) {
+
+    &::before {
+        content: "";
+        display: block;
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        width: calc(100% - 20px);
+        height: calc(100% - 20px);
+        z-index: -1;
+        background-color: transparent;
+        border: 1px solid #efefef;
+        border-radius: 4px;
+    }
+
     &:hover, &:active, &:focus {
-        color: #fff;
-        // use a psuedo-element for the hover effect
+        color: #ffffff;
         &::before {
-            content: "";
-            display: block;
-            position: absolute;
-            top: 10px;
-            left: 10px;
-            width: calc(100% - 20px);
-            height: calc(100% - 20px);
-            z-index: -1;
             background-color: #3273dc;
-            border-radius: 4px;
+            border: 0;
         }
     }
 }
 
 .card-byline, .card-timestamp {
-    color: #858585;
+    color: #6b6464;
 }
 
 .card-timestamp strong {

--- a/src/statics/superhero.bulma.css
+++ b/src/statics/superhero.bulma.css
@@ -52,6 +52,10 @@
     background-color: #1f2d3b;
 }
 
+.card-footer-item:not(.non-selectable)::before {
+    border-color: #374765;
+}
+
 .card-footer-item:not(.non-selectable):hover::before, 
 .card-footer-item:not(.non-selectable):active::before, 
 .card-footer-item:not(.non-selectable):focus::before {
@@ -59,7 +63,7 @@
 }
 
 .card-byline, .card-timestamp {
-    color: #7e8a98;
+    color: #86919e;
 }
 
 .button, .input, .pagination-link, .notification {

--- a/src/statics/superhero.bulma.css
+++ b/src/statics/superhero.bulma.css
@@ -52,6 +52,16 @@
     background-color: #1f2d3b;
 }
 
+.card-footer-item:not(.non-selectable):hover::before, 
+.card-footer-item:not(.non-selectable):active::before, 
+.card-footer-item:not(.non-selectable):focus::before {
+    background: #374765;
+}
+
+.card-byline, .card-timestamp {
+    color: #7e8a98;
+}
+
 .button, .input, .pagination-link, .notification {
     border-radius: 4px;
 }


### PR DESCRIPTION
Closes #296 

### Vue:
- Store "enabled" state on `ExpandableCard` instance
- Add `.disabled-card` ~~and `.expanded-card`~~ classes to `ExpandableCard` component based on states
- Add `.mod-logo` class to the mod logo element
- Add `span.card-title` and `span.card-byline` elements to `slot:title`
- Add `.card-footer-item` class to mod footer links, remove `span.card-footer-item` wrappers
- Add `.card-timestamp` class to "last updated: <timestamp" in online mod list
- Only use `<strong>` on the "last updated:" label in the card timestamp

### CSS:
- Use partial transparency for `.mod-logo`, `.card-title`, and `.card-content` in disabled cards
- Remove border from card footer items
- Add a hover/active/focus effect for selectable card footer items
- Use a weaker colour for card bylines and timestamps

## Screenshots

### Light Theme
Local mod list
![image](https://user-images.githubusercontent.com/6081834/92680691-db55b200-f36e-11ea-98c3-d276957be4ff.png)

Online mod list
![image](https://user-images.githubusercontent.com/6081834/92680703-e577b080-f36e-11ea-8777-5da58940b8c7.png)

### Dark Theme
Local mod list
![image](https://user-images.githubusercontent.com/6081834/92680622-ab0e1380-f36e-11ea-8a1e-f18392d45056.png)

Online mod list
![image](https://user-images.githubusercontent.com/6081834/92680656-c1b46a80-f36e-11ea-87dd-a4c1ccd164ab.png)
