### PR TITLE
Fix modal card footer borders being removed

### DIFF
--- a/src/components/ExpandableCard.vue
+++ b/src/components/ExpandableCard.vue
@@ -38,7 +38,7 @@
                     <slot name='description'></slot>
                 </div>
             </div>
-            <footer class='card-footer' v-show='visible'>
+            <footer class='card-footer card-footer-borderless' v-show='visible'>
                 <slot></slot>
                 <div class="is-divider"></div>
             </footer>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -57,7 +57,7 @@
     }
 }
 
-.card .card-footer, .card .card-footer-item {
+.card-footer-borderless, .card-footer-borderless .card-footer-item {
     border: none !important;
     // these two lines allow the hover effect's pseudo-element to position itself behind the element's text, with a bit of a margin
     position: relative;


### PR DESCRIPTION
Rather than removing the border from all cards, remove only for `.card-footer-borderless`

Dark theme (Will be using different colours as of #298)
![image](https://user-images.githubusercontent.com/6081834/93359032-8097eb00-f885-11ea-8bcb-7e9e96c25db6.png)

Light theme (Will look the same as of #298)
![image](https://user-images.githubusercontent.com/6081834/93359089-8c83ad00-f885-11ea-9c07-237178ef9f93.png)
