### PR TITLE
Search bar refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "vue-class-component": "^7.1.0",
         "vue-i18n": "^8.0.0",
         "vue-property-decorator": "^8.3.0",
+        "vuedraggable": "^2.24.1",
         "yaml": "^1.7.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "bulma": "^0.8.0",
         "bulma-divider": "^0.2.0",
         "bulma-steps": "^2.2.1",
+        "bulma-switch": "^2.0.0",
         "bulma-tooltip": "^3.0.2",
         "dot-prop": "^5.2.0",
         "electron-updater": "^4.2.0",

--- a/src/components/ExternalLink.vue
+++ b/src/components/ExternalLink.vue
@@ -19,7 +19,7 @@
     import { spawn } from "child_process";
 
     @Component
-    export default class Link extends Vue {
+    export default class ExternalLink extends Vue {
 
         @Prop({default: ''})
         url: string | undefined;

--- a/src/components/ExternalLink.vue
+++ b/src/components/ExternalLink.vue
@@ -5,8 +5,8 @@
     <a v-else-if="target !== null" @click="openLink()" class='target-link'>
         <slot></slot>
     </a>
-    <router-link v-else-if="target === null" tag="div" :to="url">
-        <a class='target-link'>
+    <router-link v-else-if="target === null" tag="div" :to="url" class='target-link'>
+        <a>
             <slot></slot>
         </a>
     </router-link>

--- a/src/components/all.ts
+++ b/src/components/all.ts
@@ -1,14 +1,15 @@
-import Hero from './Hero.vue';
-import Progress from './Progress.vue';
-import Link from './Link.vue';
 import ExpandableCard from './ExpandableCard.vue';
+import ExternalLink from './ExternalLink.vue';
+import Hero from './Hero.vue';
 import Modal from './Modal.vue';
+import Progress from './Progress.vue';
 
 export * from "./cards/all";
 export {
-    Hero, 
-    Progress, 
-    Link,
+    Hero,
+    Progress,
+    ExternalLink,
     ExpandableCard,
     Modal
-}
+};
+

--- a/src/components/cards/ConfigCard.vue
+++ b/src/components/cards/ConfigCard.vue
@@ -2,10 +2,11 @@
 	<a class='card is-shadowless card--is-clickable' @click='$emit("click")'>
 		<header class='card-header is-shadowless' :id='id'>
 			<span class='card-header-title'>{{title}}</span>
-			<a class='card-header-icon' @click='$emit("delete")'>
+			<a class='card-header-icon button is-danger' @click='$emit("delete")'>
 				<span class='icon'>
 					<i class='fas fa-trash' aria-hidden='true'></i>
 				</span>
+				<span class='card-header-icon-label requires-card-hover'>Delete</span>
 			</a>
 		</header>
 	</a>

--- a/src/components/cards/ConfigCard.vue
+++ b/src/components/cards/ConfigCard.vue
@@ -2,11 +2,11 @@
 	<a class='card is-shadowless card--is-clickable' @click='$emit("click")'>
 		<header class='card-header is-shadowless' :id='id'>
 			<span class='card-header-title'>{{title}}</span>
-			<a class='card-header-icon button is-danger' @click='$emit("delete")'>
+			<a class='card-header-icon button is-danger is-colored-button-only requires-card-hover' @click='$emit("delete")'>
 				<span class='icon'>
 					<i class='fas fa-trash' aria-hidden='true'></i>
 				</span>
-				<span class='card-header-icon-label requires-card-hover'>Delete</span>
+				<span class='card-header-icon-label'>Delete</span>
 			</a>
 		</header>
 	</a>

--- a/src/components/cards/ConfigCard.vue
+++ b/src/components/cards/ConfigCard.vue
@@ -2,13 +2,15 @@
 	<a class='card is-shadowless card--is-clickable' @click='$emit("click")'>
 		<header class='card-header is-shadowless' :id='id'>
 			<span class='card-header-title'>{{title}}</span>
+		</header>
+		<div class='card-header-icons'>
 			<a class='card-header-icon button is-danger is-colored-button-only requires-card-hover' @click='$emit("delete")'>
 				<span class='icon'>
 					<i class='fas fa-trash' aria-hidden='true'></i>
 				</span>
 				<span class='card-header-icon-label'>Delete</span>
 			</a>
-		</header>
+		</div>
 	</a>
 </template>
 

--- a/src/components/cards/LocalModCard.vue
+++ b/src/components/cards/LocalModCard.vue
@@ -45,6 +45,12 @@
 				</span>
 				<span class='card-header-icon-label requires-card-hover'>Update</span>
 			</a>
+			<a class='card-header-icon button is-info requires-card-hover' @click='$emit("view-associated-mods")'>
+				<span class='icon'>
+					<i class='fas fa-project-diagram' aria-hidden='true'></i>
+				</span>
+				<span class='card-header-icon-label'>Associated mods</span>
+			</a>
 			<a class='card-header-icon button is-danger is-colored-button-only requires-card-hover' @click='$emit("uninstall-mod")'>
 				<span class='icon'>
 					<i class='fas fa-trash' aria-hidden='true'></i>

--- a/src/components/cards/LocalModCard.vue
+++ b/src/components/cards/LocalModCard.vue
@@ -15,30 +15,24 @@
 							   @click.prevent="toggle">
 						<label :for="`toggle${id}`"></label>
 				</div>
-				<span class='card-title card-title--is-large'>
-					{{manifest.getDisplayName()}}
-					<span v-if='manifest.getAuthorName()' class='card-byline'>by {{manifest.getAuthorName()}}</span>
-					&nbsp;<span class="is-secondary">·</span>&nbsp;
-					<ExternalLink :url="`${manifest.getWebsiteUrl()}${manifest.getVersionNumber().toString()}`"
-								  :target="'external'"
-								  class="card-version text-smaller">
-									<i class='fas fa-code-branch'></i>
-									{{manifest.getVersionNumber().toString()}}
-					</ExternalLink>
-				</span>
+				<span class='card-title card-title--is-large'>{{manifest.getDisplayName()}}</span>
 				<span v-if="manifest.isDeprecated()" class="tag is-danger has-tooltip-top"
 					  data-tooltip='This mod has been marked as deprecated, suggesting that an alternative be used instead.'>
 						Deprecated
 				</span>
 			</span>
-			<a v-if="missingDependencies.length > 0"
-				  class='card-header-icon button is-warning has-tooltip-top'
-				  :data-tooltip="`Missing ${missingDependencies.length} dependencies`">
-					<span class='icon'>
-						<i class='fas fa-exclamation-circle'></i>
-					</span>
-					<span class='card-header-icon-label requires-card-hover'>Install Missing Dependency</span>
-			</a>
+		</header>
+		<div class='card-header-icons'>
+			<div>
+				<a v-if="missingDependencies.length > 0"
+					class='card-header-icon button is-warning has-tooltip-top'
+					:data-tooltip="`Missing ${missingDependencies.length} dependencies`">
+						<span class='icon'>
+							<i class='fas fa-exclamation-circle'></i>
+						</span>
+						<span class='card-header-icon-label requires-card-hover'>Install missing dependency</span>
+				</a>
+			</div>
 			<a v-if="!isLatest()" class='card-header-icon button is-info' @click='$emit("update-mod")'>
 				<span class='icon'>
 					<i class='fas fa-cloud-download-alt' aria-hidden='true'></i>
@@ -57,7 +51,23 @@
 				</span>
 				<span class='card-header-icon-label'>Uninstall</span>
 			</a>
-		</header>
+		</div>
+		<footer class='card-footer card-footer-borderless'>
+			<span class='card-footer-item non-selectable'>
+				<external-link v-if='manifest.getAuthorName()' target="link" 
+							   :url="`https://thunderstore.io/package/${manifest.getAuthorName()}`">
+							   	{{manifest.getAuthorName()}}
+				</external-link>
+			</span>
+			<span class='card-footer-item non-selectable'>
+				<external-link :url="`${manifest.getWebsiteUrl()}${manifest.getVersionNumber().toString()}`"
+							   :target="'external'"
+							   class="card-version">
+								<i class='fas fa-code-branch'></i>
+								{{manifest.getVersionNumber().toString()}}
+				</external-link>
+			</span>
+		</footer>
 		<div class='card-content card-content--is-compressed'>
 			<div class='content'>
 				<template v-if="manifest.description !== ''">

--- a/src/components/cards/LocalModCard.vue
+++ b/src/components/cards/LocalModCard.vue
@@ -1,0 +1,116 @@
+<template>
+	<div class='card is-shadowless card--is-clickable card--is-cozy cursor-pointer' 
+	   :class="{'card--is-disabled': !manifest.isEnabled(), 'card--is-deprecated': manifest.isDeprecated()}">
+		<figure class='card-image image is-72x72 image-parent mod-logo' v-if="manifest.icon !== ''">
+			<img :src='manifest.icon' alt='Mod Logo' class='image-overlap'/>
+			<img v-if="funkyMode" src='../../assets/funky_mode.png' alt='Mod Logo' class='image-overlap'/>
+		</figure>
+		<header class='card-header is-shadowless' :id='id'>
+			<span class='card-header-title'>
+				<div class="field card-toggle has-tooltip-top"
+					 :data-tooltip='`This mod is ${manifest.isEnabled() ? "enabled" : "disabled"}.`'>
+						<input :id="`toggle${id}`" type="checkbox" class="switch is-info is-rounded"
+							   ref="switch"
+							   :checked='manifest.isEnabled()' 
+							   @click.prevent="toggle">
+						<label :for="`toggle${id}`"></label>
+				</div>
+				<span class='card-title card-title--is-large'>
+					{{manifest.getDisplayName()}}
+					<span v-if='manifest.getAuthorName()' class='card-byline'>by {{manifest.getAuthorName()}}</span>
+					&nbsp;<span class="is-secondary">·</span>&nbsp;
+					<ExternalLink :url="`${manifest.getWebsiteUrl()}${manifest.getVersionNumber().toString()}`"
+								  :target="'external'"
+								  class="card-version text-smaller">
+									<i class='fas fa-code-branch'></i>
+									{{manifest.getVersionNumber().toString()}}
+					</ExternalLink>
+				</span>
+				<span v-if="manifest.isDeprecated()" class="tag is-danger has-tooltip-top"
+					  data-tooltip='This mod has been marked as deprecated, suggesting that an alternative be used instead.'>
+						Deprecated
+				</span>
+			</span>
+			<a v-if="missingDependencies.length > 0"
+				  class='card-header-icon button is-warning has-tooltip-top'
+				  :data-tooltip="`Missing ${missingDependencies.length} dependencies`">
+					<span class='icon'>
+						<i class='fas fa-exclamation-circle'></i>
+					</span>
+					<span class='card-header-icon-label requires-card-hover'>Install Missing Dependency</span>
+			</a>
+			<a v-if="!isLatest()" class='card-header-icon button is-info' @click='$emit("update-mod")'>
+				<span class='icon'>
+					<i class='fas fa-cloud-download-alt' aria-hidden='true'></i>
+				</span>
+				<span class='card-header-icon-label requires-card-hover'>Update</span>
+			</a>
+			<a class='card-header-icon button is-danger is-colored-button-only requires-card-hover' @click='$emit("uninstall-mod")'>
+				<span class='icon'>
+					<i class='fas fa-trash' aria-hidden='true'></i>
+				</span>
+				<span class='card-header-icon-label'>Uninstall</span>
+			</a>
+		</header>
+		<div class='card-content card-content--is-compressed'>
+			<div class='content'>
+				<template v-if="manifest.description !== ''">
+					<p class="card-description">
+						{{manifest.description}}
+					</p>
+					<slot name='description'></slot>
+				</template>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script lang='ts'>
+import ManifestV2 from 'src/model/ManifestV2';
+import ThunderstoreMod from 'src/model/ThunderstoreMod';
+import ModBridge from 'src/r2mm/mods/ModBridge';
+import Vue from 'vue';
+import { Component, Prop, Watch } from 'vue-property-decorator'
+import ExternalLink from '../ExternalLink.vue';
+
+@Component({
+	components: {
+		ExternalLink,
+	}
+})
+export default class LocalModCard extends Vue {
+
+    @Prop()
+    id: string | undefined;
+	
+	@Prop()
+	manifest: ManifestV2 | undefined;
+	
+	@Prop({default: () => []})
+	missingDependencies: string[] | undefined;
+
+    @Prop({default: false})
+	funkyMode: boolean | undefined;
+	
+	toggle() {
+		setTimeout(() => {
+			// for some reason this only works if it's delayed until after the event is over
+			this.$emit("update:enabled", !(this.$refs.switch as HTMLInputElement).checked);
+		}, 1);
+	}
+	
+	// when the manifest changes, re-render this component
+	@Watch("manifest", {deep: true})
+	onManifestChange() {
+		this.$forceUpdate();
+	}
+	
+    emitMove(direction: string) {
+        this.$emit("move" + direction);
+	}
+	
+	isLatest() {
+		return ModBridge.isLatestVersion(this.manifest);
+	}
+}
+</script>

--- a/src/components/cards/OnlineModCard.vue
+++ b/src/components/cards/OnlineModCard.vue
@@ -12,7 +12,6 @@
 				</span>
 				<span class='card-title card-title--is-large'>
 					{{mod.getName()}}
-					<span v-if='mod.getOwner()' class='card-byline'>by {{mod.getOwner()}}</span>
 				</span>
 				<span v-if="mod.isPinned()" class="tag is-info has-tooltip-top"
 					  data-tooltip='This mod is pinned on Thunderstore.'>Pinned</span>&nbsp;
@@ -21,6 +20,8 @@
 						Deprecated
 				</span>
 			</span>
+		</header>
+		<div class='card-header-icons'>
 			<ExternalLink :url="mod.getPackageUrl()" :target="'external'" class='card-header-icon button is-info requires-card-hover'>
 				<span class='icon'>
 					<i class='fas fa-eye' aria-hidden='true'></i>
@@ -39,15 +40,14 @@
 				</span>
 				<span class='card-header-icon-label'>Uninstall</span>
 			</a>
-		</header>
-		<div class='card-content card-content--is-compressed'>
-			<div class='content'>
-				<p v-if="description !== ''" class="card-description">
-					{{description}}
-				</p>
-			</div>
 		</div>
 		<footer class='card-footer card-footer-borderless'>
+			<span class='card-footer-item non-selectable'>
+				<external-link v-if='mod.getOwner()' target="link" 
+							   :url="`https://thunderstore.io/package/${mod.getOwner()}`">
+								{{mod.getOwner()}}
+				</external-link>
+			</span>
 			<span class='card-footer-item non-selectable'>
 				<label class='card-footer-item-label'>Last updated:</label>
 				<span class='card-footer-item-value'>{{getReadableDate(mod.getDateUpdated())}}</span>
@@ -59,6 +59,13 @@
 				<span class='has-tooltip-top' data-tooltip='Likes'><i class='fas fa-thumbs-up'/> {{mod.getRating()}}</span>
 			</span>
 		</footer>
+		<div class='card-content card-content--is-compressed'>
+			<div class='content'>
+				<p v-if="description !== ''" class="card-description">
+					{{description}}
+				</p>
+			</div>
+		</div>
 	</div>
 </template>
 

--- a/src/components/cards/OnlineModCard.vue
+++ b/src/components/cards/OnlineModCard.vue
@@ -1,0 +1,115 @@
+<template>
+	<div class='card is-shadowless card--is-clickable card--is-cozy cursor-pointer' 
+	   :class="{'card--is-disabled': isInstalled(), 'card--is-deprecated': mod.isDeprecated()}">
+		<figure class='card-image image is-72x72 image-parent mod-logo' v-if="icon !== ''">
+			<img :src='icon' alt='Mod Logo' class='image-overlap'/>
+			<img v-if="funkyMode" src='../../assets/funky_mode.png' alt='Mod Logo' class='image-overlap'/>
+		</figure>
+		<header class='card-header is-shadowless' :id='id'>
+			<span class='card-header-title'>
+				<span v-if='isInstalled()' class='icon is-success' data-tooltip='This mod is installed.'>
+					<i class='fas fa-check' aria-hidden='true'></i>
+				</span>
+				<span class='card-title card-title--is-large'>
+					{{mod.getName()}}
+					<span v-if='mod.getOwner()' class='card-byline'>by {{mod.getOwner()}}</span>
+				</span>
+				<span v-if="mod.isPinned()" class="tag is-info has-tooltip-top"
+					  data-tooltip='This mod is pinned on Thunderstore.'>Pinned</span>&nbsp;
+				<span v-if="mod.isDeprecated()" class="tag is-danger has-tooltip-top"
+					  data-tooltip='This mod has been marked as deprecated, suggesting that an alternative be used instead.'>
+						Deprecated
+				</span>
+			</span>
+			<ExternalLink :url="mod.getPackageUrl()" :target="'external'" class='card-header-icon button is-info requires-card-hover'>
+				<span class='icon'>
+					<i class='fas fa-eye' aria-hidden='true'></i>
+				</span>
+				<span class='card-header-icon-label'>View on Thunderstore</span>
+			</ExternalLink>
+			<a v-if='!isInstalled()' class='card-header-icon button is-success requires-card-hover' @click='$emit("install-mod")'>
+				<span class='icon'>
+					<i class='fas fa-download' aria-hidden='true'></i>
+				</span>
+				<span class='card-header-icon-label'>Install</span>
+			</a>
+			<a v-else class='card-header-icon button is-danger is-colored-button-only requires-card-hover' @click='$emit("uninstall-mod")'>
+				<span class='icon'>
+					<i class='fas fa-trash' aria-hidden='true'></i>
+				</span>
+				<span class='card-header-icon-label'>Uninstall</span>
+			</a>
+		</header>
+		<div class='card-content card-content--is-compressed'>
+			<div class='content'>
+				<p v-if="description !== ''" class="card-description">
+					{{description}}
+				</p>
+			</div>
+		</div>
+		<footer class='card-footer card-footer-borderless'>
+			<span class='card-footer-item non-selectable'>
+				<label class='card-footer-item-label'>Last updated:</label>
+				<span class='card-footer-item-value'>{{getReadableDate(mod.getDateUpdated())}}</span>
+			</span>
+			<span class='card-footer-item non-selectable'>
+				<span class='has-tooltip-top' data-tooltip='Downloads'><i class='fas fa-download'/> {{mod.getTotalDownloads()}}</span>
+			</span>
+			<span class='card-footer-item non-selectable'>
+				<span class='has-tooltip-top' data-tooltip='Likes'><i class='fas fa-thumbs-up'/> {{mod.getRating()}}</span>
+			</span>
+		</footer>
+	</div>
+</template>
+
+<script lang='ts'>
+import ManifestV2 from 'src/model/ManifestV2';
+import ThunderstoreMod from 'src/model/ThunderstoreMod';
+import ModBridge from 'src/r2mm/mods/ModBridge';
+import Vue from 'vue';
+import { Component, Prop, Watch } from 'vue-property-decorator'
+import ExternalLink from '../ExternalLink.vue';
+
+@Component({
+	components: {
+		ExternalLink,
+	}
+})
+export default class OnlineModCard extends Vue {
+
+    @Prop()
+    id: string | undefined;
+	
+	@Prop()
+	mod: ThunderstoreMod | undefined;
+
+    @Prop({default: false})
+	funkyMode: boolean | undefined;
+	
+	get latestVersion() {
+		return this.mod?.getVersions()?.[0];
+	}
+	
+	get icon() {
+		return this.latestVersion?.getIcon();
+	}
+	
+	get description() {
+		return this.latestVersion?.getDescription();
+	}
+
+	get localModList(): ManifestV2[] {
+		return this.$store.state.localModList;
+	}
+
+	isInstalled() {
+		const matchedMod = (this.mod && this.localModList.find((local: ManifestV2) => local.getName() === this.mod!.getFullName()));
+		return matchedMod != undefined;
+	}
+
+	getReadableDate(date: Date): string {
+		const dateObject: Date = new Date(date);
+		return `${dateObject.toDateString()}, ${dateObject.toLocaleTimeString()}`
+	}
+}
+</script>

--- a/src/components/cards/all.ts
+++ b/src/components/cards/all.ts
@@ -1,6 +1,10 @@
 import ConfigCard from './ConfigCard.vue';
+import LocalModCard from './LocalModCard.vue';
+import OnlineModCard from './OnlineModCard.vue';
 
 export {
 	ConfigCard,
+	LocalModCard,
+	OnlineModCard,
 };
 

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -1,26 +1,26 @@
 <template>
     <div>
-        <div class='sticky-top sticky-top--search border-at-bottom'>
-            <div class='card is-shadowless is-square'>
-                <div class='card-header-title'>
-                    <span class="non-selectable">Search:&nbsp;&nbsp;</span>
-                    <input v-model='search' class="input" type="text" placeholder="Search for a setting"/>
-                </div>
-            </div>
-        </div>
         <Hero title='Settings'
               :subtitle='"Advanced options for r2modman: " + managerVersionNumber.toString()'
               heroType='is-info'/>
-        <div class="margin-right">
-            <div class="tabs">
-                <ul>
-                    <li v-for="(key, index) in tabs" :key="`tab-${key}`"
-                        :class="[{'is-active': activeTab === key}]"
-                        @click="changeTab(key)">
-                        <a>{{key}}</a>
-                    </li>
-                </ul>
+        <div class='sticky-top sticky-top--search'>
+            <div class='card is-shadowless is-square card--is-compressed'>
+                <div class='card-header-title input-group input-group--is-small'>
+                    <label class="non-selectable" for="settings-search">Search&nbsp;&nbsp;</label>
+                    <input v-model='search' id="settings-search" class="input" type="text" placeholder="Search for a setting"/>
+                </div>
+                <div class="tabs">
+                    <ul>
+                        <li v-for="(key, index) in tabs" :key="`tab-${key}`"
+                            :class="[{'is-active': activeTab === key}]"
+                            @click="changeTab(key)">
+                            <a>{{key}}</a>
+                        </li>
+                    </ul>
+                </div>
             </div>
+        </div>
+        <div class="margin-right">
             <template v-if="activeTab === 'All'">
                 <SettingsItem v-for="(key, index) in searchableSettings" :key="`setting-${key.action}`"
                               :action="key.action"

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -272,11 +272,11 @@
             ),
             new SettingsRow(
                 'Other',
-                'Switch card display type',
-                'Switch between expanded or collapsed cards.',
+                'Toggle icon display mode',
+                'Switch between all icons (notifications and actions) and reduced icons (notifications only).',
                 () => {
                     const settings = ManagerSettings.getSingleton();
-                    return settings.expandedCards ? 'Current: expanded' : 'Current: collapsed (default)';
+                    return settings.allIconDisplayMode ? 'Current: all (default)' : 'Current: reduced';
                 },
                 'fa-exchange-alt',
                 () => this.emitInvoke('SwitchCard')

--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -126,8 +126,8 @@
                                     :funkyMode="settings.funkyModeEnabled"
                                     @update:enabled="toggleMod(key, $event)"
                                     @update-mod="updateMod(key)"
-                                    @uninstall-mod="uninstallModRequireConfirmation(key)">
-                                        <a class='card-footer-item' @click="viewDependencyList(key)">View associated</a>
+                                    @uninstall-mod="uninstallModRequireConfirmation(key)"
+                                    @view-associated-mods="viewDependencyList(key)">
                     </local-mod-card>
         </draggable>
     </div>

--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -116,9 +116,10 @@
             </template>
         </Modal>
 
-        <draggable v-model='sortableModList' group="mods" 
-                   @start="drag=canSort(); $emit('sort-start')" 
-                   @end="drag=false; $emit('sort-end')">
+        <draggable ref="draggable" v-model='sortableModList' group="mods"
+                   animation="200"
+                   @start="startSort()" 
+                   @end="endSort()">
                     <local-mod-card v-for='(key, index) in sortableModList' :key="'local-' + key.getName()"
                                     :id="index"
                                     :manifest="key"
@@ -463,6 +464,20 @@
 
         getSortDirectionOptions() {
             return Object.values(SortDirection);
+        }
+        
+        startSort() {
+            if (!this.canSort()) {
+                return false;
+            }
+            
+            (this.$refs.draggable as Vue).$el.classList.add('sorting');
+            this.$emit('sort-start');
+        }
+        
+        endSort() {
+            (this.$refs.draggable as Vue).$el.classList.remove('sorting');
+            this.$emit('sort-end')
         }
 
         canSort() {

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -7,13 +7,15 @@
             @closed-modal="modToDownload = null;"
             @error="emitError($event)"
         />
-        <online-mod-card v-for='(key, index) in pagedModList' :key="'online-' + key.getFullName()"
-                         :id="index"
-                         :mod="key"
-                         :funkyMode="settings.funkyModeEnabled"
-                         @install-mod="showDownloadModal(key)"
-                         @uninstall-mod="$emit('uninstall-mod', key)">
-        </online-mod-card>
+        <div>
+            <online-mod-card v-for='(key, index) in pagedModList' :key="'online-' + key.getFullName()"
+                             :id="index"
+                             :mod="key"
+                             :funkyMode="settings.funkyModeEnabled"
+                             @install-mod="showDownloadModal(key)"
+                             @uninstall-mod="$emit('uninstall-mod', key)">
+            </online-mod-card>
+        </div>
     </div>
 </template>
 

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -12,5 +12,6 @@
 @import "bulma-steps";
 @import "bulma-divider";
 @import "bulma-tooltip";
+@import "bulma-switch";
 
 @import "custom";

--- a/src/css/components/Card.scss
+++ b/src/css/components/Card.scss
@@ -17,7 +17,7 @@
         border-radius: 4px;
     }
 
-    &:hover, &:active, &:focus {
+    &:hover, &:active, &:focus, &:focus-within {
         color: #ffffff;
         &::before {
 			@if $is-border {
@@ -28,6 +28,7 @@
 				border: 0;
 			}
 		}
+		@content;
     }
 }
 
@@ -41,7 +42,34 @@
 	&--is-clickable {
 		display: block;
 		padding: 8px;
-		@include button-hover-effect($margin: 4px, $is-border: true);
+		
+		.requires-card-hover {
+			display: none;
+		}
+		
+		--hovered: 0;
+		
+		@include button-hover-effect($margin: 4px, $is-border: true) {
+			--link: #{$scheme-link-hover};
+			--hovered: 1;
+		
+			.requires-card-hover {
+				display: block;
+			}
+		}
+	}
+}
+	
+.button.card-header-icon {
+	background: none;
+	border: none;
+	height: auto;
+	padding: 0 calc(0.5rem + 0.2rem * var(--hovered)) 0 calc(0.5rem + 0.5rem * var(--hovered));
+	margin: calc(0.5rem * var(--hovered));
+	
+	color: $scheme-link;
+	&:hover, &:focus, &:active {
+		color: $scheme-link-hover;
 	}
 }
 

--- a/src/css/components/Card.scss
+++ b/src/css/components/Card.scss
@@ -82,19 +82,23 @@
 		}
 		
 		--card-is-hovered: 0;
-		
-		@include button-hover-effect($margin: 4px, $is-border: true) {
-			--card-is-hovered: 1;
-			--display: unset;
-			--label-display: unset;
-			z-index: 2;
-		
-			.card-header-title {
-				color: #{$scheme-text-strong};
-			}
+	}
+}
+
+:not(.sorting) > .card--is-clickable {
+	@include button-hover-effect($margin: 4px, $is-border: true) {
+		--card-is-hovered: 1;
+		--display: unset;
+		--label-display: unset;
+		z-index: 2;
+	
+		.card-header-title {
+			color: #{$scheme-text-strong};
 		}
 	}
-	
+}
+
+.card {
 	--card-is-cozy: 0;
 	--card-is-not-cozy: 1;
 	&--is-cozy {
@@ -131,6 +135,13 @@
 	
 	&--is-deprecated .card-title {
 		text-decoration: line-through;
+	}
+	
+	&.sortable-ghost {
+		--card-background-color: #{$scheme-background-dark};
+		> * {
+			opacity: 0.2;
+		}
 	}
 }
 

--- a/src/css/components/Card.scss
+++ b/src/css/components/Card.scss
@@ -1,4 +1,4 @@
-@mixin button-hover-effect ($margin: 10px, $is-border: false) {
+@mixin button-hover-effect ($margin: 1rem, $is-border: false) {
     // these two lines allow the hover effect's pseudo-element to position itself behind the element's text, with a bit of a margin
     position: relative;
 	z-index: 1;
@@ -12,16 +12,28 @@
         width: calc(100% - #{$margin * 2});
         height: calc(100% - #{$margin * 2});
         z-index: -1;
-        background-color: transparent;
-        border: 1px solid $scheme-border-secondary;
-        border-radius: 4px;
-    }
+		background-color: transparent;
+		@if $is-border {
+        	top: 0;
+			left: $margin * 8;
+			width: calc(100% - #{$margin * 16});
+			border-top: 1px solid $scheme-border-secondary;
+		}
+	}
+	
+	&:first-child::before {
+		border-top: none;
+	}
 
     &:hover, &:active, &:focus, &:focus-within {
-        color: #ffffff;
         &::before {
+			border-radius: 4px;
+			
 			@if $is-border {
-				border-color: $scheme-border-hover;
+				top: $margin;
+				left: $margin;
+				width: calc(100% - #{$margin * 2});
+				border: 1px solid $scheme-border-hover;
 				
 			} @else {
 				background-color: $scheme-primary;
@@ -29,48 +41,159 @@
 			}
 		}
 		@content;
-    }
+	}
+	
+	&:hover + &, &:active + &, &:focus + &, &:focus-within + & {
+		&::before {
+			border: none;
+		}
+	}
 }
 
 .card {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	> * {
+		grid-column: 2;
+	}
+	
 	&--is-disabled {
-		.mod-logo, .card-title, .card-content {
+		.mod-logo, .card-title, .card-content, .card-footer, .card-toggle:not(:hover):not(:focus):not(:active) {
 			opacity: 0.6;
+		}
+		
+		.mod-logo {
+			filter: grayscale(80%) opacity(80%);
 		}
 	}
 	
 	&--is-clickable {
-		display: block;
-		padding: 8px;
-		
+		--display: none;
+		--label-display: none;
 		.requires-card-hover {
-			display: none;
+			display: var(--display);
 		}
 		
-		--hovered: 0;
+		.manager.show-all-icons & {
+			--display: unset;
+			.card-header-icon > .card-header-icon-label {
+				display: var(--label-display);
+			}
+		}
+		
+		--card-is-hovered: 0;
 		
 		@include button-hover-effect($margin: 4px, $is-border: true) {
-			--link: #{$scheme-link-hover};
-			--hovered: 1;
+			--card-is-hovered: 1;
+			--display: unset;
+			--label-display: unset;
 		
-			.requires-card-hover {
-				display: block;
+			.card-header-title {
+				color: #{$scheme-text-strong};
 			}
 		}
 	}
+	
+	--card-is-cozy: 0;
+	--card-is-not-cozy: 1;
+	&--is-cozy {
+		--card-is-cozy: 1;
+		--card-is-not-cozy: 0;
+		
+		.card-footer {
+			color: $scheme-text-secondary;
+			display: block;
+		}
+		
+		.card-footer-item {
+			display: inline;
+			// align-items: unset;
+			justify-content: unset;
+			padding: 0 0 0 1.5rem;
+			position: relative;
+			
+			&:not(:last-child)::before {
+				content: "·";
+				position: absolute;
+				left: calc(100% + 0.5rem);
+				opacity: 0.6;
+			}
+		}
+	}
+	
+	--card-is-compressed: 0;
+	--card-is-not-compressed: 1;
+	&--is-compressed {
+		--card-is-compressed: 1;
+		--card-is-not-compressed: 0;
+	}
+	
+	&--is-deprecated .card-title {
+		text-decoration: line-through;
+	}
+}
+
+.card {
+	padding: calc(1rem - 0.5rem * var(--card-is-not-cozy) - 0.5rem * var(--card-is-compressed));
+}
+
+.card-header-title {
+	padding: calc(0.25rem + 0.5rem * var(--card-is-not-cozy)) 1rem;
+	
+	> .icon {
+		font-size: 1.7rem;
+		margin: 0 0.8rem 0 0.2rem;
+	}
+}
+
+.card-title--is-large {
+	font-size: 21px;
+	font-weight: normal;
+	letter-spacing: 0.2px;
+}
+
+.card-image {
+	grid-column: 1;
+	grid-row: 1/5;
+}
+
+.card-content--is-compressed {
+	padding: 0.25rem 1.5rem;
 }
 	
 .button.card-header-icon {
 	background: none;
 	border: none;
 	height: auto;
-	padding: 0 calc(0.5rem + 0.2rem * var(--hovered)) 0 calc(0.5rem + 0.5rem * var(--hovered));
-	margin: calc(0.5rem * var(--hovered));
-	
+	padding: 
+		0.2rem
+		calc(0.5rem + 0.2rem * var(--card-is-hovered)) 
+		0.3rem
+		calc(0.5rem + 0.5rem * var(--card-is-hovered));
+	margin: 
+		calc(0.25rem + 0.25rem * var(--card-is-not-cozy))
+		calc(0.5rem * var(--card-is-hovered)) 
+		auto;
 	color: $scheme-link;
-	&:hover, &:focus, &:active {
-		color: $scheme-link-hover;
+	
+	$link-colors: map-merge($colors, $scheme-text-colors);
+	
+	// --link: #{nth(map-get($colors, "warning"), 1)};
+	@each $name, $pair in $link-colors {
+		$color: nth($pair, 1);
+		&.is-#{$name} {
+			--link: #{$color};
+		}
 	}
+	
+	&.is-colored-button-only {
+		--link: #{nth(map-get($link-colors, "info"), 1)};
+	}
+}
+
+.card-header .tag {
+	margin-left: 1.1rem;
+	top: 1px;
 }
 
 .card-footer-borderless, .card-footer-borderless .card-footer-item {
@@ -87,4 +210,28 @@
 
 .card-timestamp strong {
     color: inherit;
+}
+
+.field.card-toggle {
+	margin-bottom: 0;
+	margin-right: 0.6rem;
+	> label {
+		vertical-align: sub;
+	}
+}
+
+.mod-logo {
+	border-radius: 4px;
+	overflow: hidden;
+}
+
+.text-smaller {
+	font-size: 0.7em;
+	position: relative;
+	top: -1px;
+}
+
+.card-footer-item-label {
+	margin-right: 0.5rem;
+	opacity: 0.7;
 }

--- a/src/css/components/Card.scss
+++ b/src/css/components/Card.scss
@@ -1,4 +1,40 @@
-@mixin button-hover-effect ($margin: 1rem, $is-border: false) {
+@function str-replace($string, $search, $replace: '') {
+	$index: str-index($string, $search);
+
+	@if $index {
+		@return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+	}
+
+	@return $string;
+}
+
+@mixin button-hover-effect ($margin, $is-border) {
+	&:hover, &:active, &:focus, &:focus-within {
+		&::before {
+			border-radius: 4px;
+			
+			@if $is-border {
+				top: $margin;
+				left: $margin;
+				width: calc(100% - #{$margin * 2});
+				border: 1px solid $scheme-border-hover;
+				
+			} @else {
+				background-color: $scheme-primary;
+				border: 0;
+			}
+		}
+		@content;
+	}
+	
+	&:hover + *, &:active + *, &:focus + *, &:focus-within + * {
+		&::before {
+			border: none;
+		}
+	}
+}
+
+@mixin button-hover-effect-host ($margin: 1rem, $is-border: false, $hover-selector: null) {
     // these two lines allow the hover effect's pseudo-element to position itself behind the element's text, with a bit of a margin
     position: relative;
 	z-index: 1;
@@ -25,28 +61,13 @@
 		border-top: none;
 	}
 
-    &:hover, &:active, &:focus, &:focus-within {
-        &::before {
-			border-radius: 4px;
-			
-			@if $is-border {
-				top: $margin;
-				left: $margin;
-				width: calc(100% - #{$margin * 2});
-				border: 1px solid $scheme-border-hover;
-				
-			} @else {
-				background-color: $scheme-primary;
-				border: 0;
-			}
+	@if $hover-selector != null {
+		// a more correct version of this would only use @at-root when the & character is detected
+		@at-root #{str-replace($hover-selector, "&", &)} {
+			@include button-hover-effect ($margin, $is-border) { @content; };
 		}
-		@content;
-	}
-	
-	&:hover + &, &:active + &, &:focus + &, &:focus-within + & {
-		&::before {
-			border: none;
-		}
+	} @else {
+		@include button-hover-effect ($margin, $is-border) { @content; };
 	}
 }
 
@@ -82,23 +103,23 @@
 		}
 		
 		--card-is-hovered: 0;
-	}
-}
-
-:not(.sorting) > .card--is-clickable {
-	@include button-hover-effect($margin: 4px, $is-border: true) {
-		--card-is-hovered: 1;
-		--display: unset;
-		--label-display: unset;
-		z-index: 2;
-	
-		.card-header-title {
-			color: #{$scheme-text-strong};
+		
+		@include button-hover-effect-host(
+			$margin: 4px, 
+			$is-border: true, 
+			$hover-selector: ":not(.sorting) > &" // adds :not(.sorting) > & to the start of the hover selector
+		) {
+			--card-is-hovered: 1;
+			--display: unset;
+			--label-display: unset;
+			z-index: 2;
+		
+			.card-header-title {
+				color: #{$scheme-text-strong};
+			}
 		}
 	}
-}
-
-.card {
+	
 	--card-is-cozy: 0;
 	--card-is-not-cozy: 1;
 	&--is-cozy {
@@ -139,6 +160,11 @@
 	
 	&.sortable-ghost {
 		--card-background-color: #{$scheme-background-dark};
+		
+		&::before {
+			border-top: none;
+		}
+		
 		> * {
 			opacity: 0.2;
 		}
@@ -281,7 +307,7 @@
 }
 
 .card-footer-item:not(.non-selectable) {
-	@include button-hover-effect;
+	@include button-hover-effect-host;
 }
 
 .card-byline, .card-timestamp {

--- a/src/css/components/Card.scss
+++ b/src/css/components/Card.scss
@@ -71,7 +71,7 @@
 		--display: none;
 		--label-display: none;
 		.requires-card-hover {
-			display: var(--display);
+			display: var(--display, var(--default-display));
 		}
 		
 		.manager.show-all-icons & {
@@ -87,6 +87,7 @@
 			--card-is-hovered: 1;
 			--display: unset;
 			--label-display: unset;
+			z-index: 2;
 		
 			.card-header-title {
 				color: #{$scheme-text-strong};
@@ -152,16 +153,17 @@
 	letter-spacing: 0.2px;
 }
 
-.card-image {
-	grid-column: 1;
-	grid-row: 1/5;
+.card-header-icons {
+	display: flex;
+	justify-content: flex-end;
 }
 
-.card-content--is-compressed {
-	padding: 0.25rem 1.5rem;
+.card-header, .card-header-icons {
+	grid-row: 1;
 }
 	
 .button.card-header-icon {
+	--default-display: flex;
 	background: none;
 	border: none;
 	height: auto;
@@ -194,6 +196,73 @@
 .card-header .tag {
 	margin-left: 1.1rem;
 	top: 1px;
+}
+
+.card-image {
+	grid-column: 1;
+	grid-row: 1/5;
+}
+
+@media (max-width: 1919px) {
+	.card--is-cozy {
+		&:hover, &:active, &:focus, &:focus-within {
+			.card-header-icons {
+				position: absolute;
+				top: 2rem;
+				right: 1.25rem;
+				display: flex;
+				flex-direction: column;
+				z-index: 1;
+				padding: 0.25rem;
+				min-width: 120px;
+				
+				&::before, &::after {
+					position: absolute;
+					bottom: calc(100% - 3px);
+					right: 0;
+					text-align: right;
+					padding: 4px 12px;
+				}
+				&::after { content: "Options"; }
+				&::before { 
+					content: "☰ \00a0 \00a0 \00a0 \00a0 \00a0 \00a0 \00a0 \00a0 \00a0 \00a0 \00a0 \00a0"; 
+					font-size: 1.1em;
+					margin-bottom: -1px;
+					border-radius: 4px;
+				}
+				
+				&:hover, &:focus-within {
+					background: $scheme-popup-background;
+					border-radius: 4px;
+					&::before {
+						background: $scheme-popup-background;
+					}
+				}
+				
+				&:not(:hover):not(:focus-within) {
+					.button.card-header-icon {
+						display: none;
+					}
+					
+					&::before, &::after {
+						color: $scheme-link;
+					}
+				}
+			}
+			
+			.button.card-header-icon {
+				margin-top: 0;
+			}
+		}
+		
+		& ~ &:last-child {
+			margin-bottom: 5rem;
+		}
+	}
+}
+
+.card-content--is-compressed {
+	padding: 0.25rem 1.5rem;
 }
 
 .card-footer-borderless, .card-footer-borderless .card-footer-item {

--- a/src/css/components/Card.scss
+++ b/src/css/components/Card.scss
@@ -315,3 +315,7 @@
 	margin-right: 0.5rem;
 	opacity: 0.7;
 }
+	
+.modal .card {
+	padding: 0;
+}

--- a/src/css/components/Icon.scss
+++ b/src/css/components/Icon.scss
@@ -1,0 +1,11 @@
+.icon {
+	$link-colors: map-merge($colors, $scheme-text-colors);
+	
+	// --link: #{nth(map-get($colors, "warning"), 1)};
+	@each $name, $pair in $link-colors {
+		$color: nth($pair, 1);
+		&.is-#{$name} {
+			color: $color;
+		}
+	}
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -202,6 +202,7 @@ select {
 }
 
 .input-group {
+    font-weight: normal;
 
     &--flex {
         flex: 1;
@@ -210,11 +211,20 @@ select {
     display: block;
     white-space: nowrap;
 
-    & label {
+    label {
         display: block;
-        font-size: 0.9em;
         opacity: 0.8;
-        margin-bottom: 0.2em;
+        padding-bottom: 0.2em;
+        color: $menu-label-color;
+        font-size: 0.7em;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+    }
+    
+    &--is-small {
+        &.card-header-title {
+            padding: 0.5rem;
+        }
     }
 }
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -91,12 +91,17 @@ select {
 }
 
 @import "components/Card";
+@import "components/Icon";
 
 .is-text {
     color: inherit;
     &--bold {
         font-weight: 500;
     }
+}
+
+.is-secondary {
+    color: $scheme-text-secondary;
 }
 
 .scrollable {
@@ -242,4 +247,9 @@ select[disabled] {
     padding: 0 .5em;
     margin-right: .5em;
     color: $scheme-text;
+}
+
+.image.is-72x72 {
+    width: 72px;
+    height: 72px;
 }

--- a/src/css/scheme/dark.scss
+++ b/src/css/scheme/dark.scss
@@ -1,5 +1,6 @@
 :root.html--dark {
     // dark theme palette
+    $night-0: #16212c;
     $night-1: #1f2d3b;
     $night-2: #283850;
     $night-3: #3a4958;
@@ -29,6 +30,7 @@
     --border-secondary: #{$night-2};
     --border-hover: #{$night-5};
     --border-active: #{$night-9};
+    --popup: #{$night-0};
 
     --text-color-warning: #ffdd57;
     

--- a/src/css/scheme/dark.scss
+++ b/src/css/scheme/dark.scss
@@ -10,6 +10,7 @@
     $night-c: #cedef1;
     $night-d: #d9e3ee;
     $night-e: #e6eff8;
+    $night-f: #ffffff;
     $primary-1: #3273dc;
     $primary-2: #5596ff;
     
@@ -17,17 +18,19 @@
     
     --background: #{$night-1};
     --text: #{$night-c};
+    --text-strong: #{$night-e};
     --text-secondary: #{$night-9};
     --scheme-primary: #{$primary-1};
     --link: #{$primary-2};
     --link-hover: #{$night-e};
+    --link-strong-hover: #{$night-f};
     --shadow: #00000080;
     --border: #{$night-3};
     --border-secondary: #{$night-2};
     --border-hover: #{$night-5};
     --border-active: #{$night-9};
 
-    --text-strong: #{$night-e};
+    --text-color-warning: #ffdd57;
     
     --hr-background-color: #{$night-2};
     

--- a/src/css/scheme/dark.scss
+++ b/src/css/scheme/dark.scss
@@ -18,6 +18,7 @@
     // overriding variables with dark theme colors
     
     --background: #{$night-1};
+    --background-dark: #{$night-0};
     --text: #{$night-c};
     --text-strong: #{$night-e};
     --text-secondary: #{$night-9};
@@ -30,7 +31,6 @@
     --border-secondary: #{$night-2};
     --border-hover: #{$night-5};
     --border-active: #{$night-9};
-    --popup: #{$night-0};
 
     --text-color-warning: #ffdd57;
     

--- a/src/css/scheme/dark.scss
+++ b/src/css/scheme/dark.scss
@@ -1,6 +1,6 @@
 :root.html--dark {
     // dark theme palette
-    $night-0: #16212c;
+    $night-0: #1a2633;
     $night-1: #1f2d3b;
     $night-2: #283850;
     $night-3: #3a4958;

--- a/src/css/scheme/light.scss
+++ b/src/css/scheme/light.scss
@@ -1,5 +1,6 @@
 // custom vars
 $scheme-background: var(--background, #ffffff);
+$scheme-background-dark: var(--background-dark, #f5f5f5);
 $scheme-text: var(--text, #4a4a4a);
 $scheme-text-secondary: var(--text-secondary, #6b6464);
 $scheme-text-strong: var(--text-strong, #363636);
@@ -13,7 +14,7 @@ $scheme-border: var(--border, #dbdbdb);
 $scheme-border-secondary: var(--border-secondary, #efefef);
 $scheme-border-hover: var(--border-hover, #b5b5b5);
 $scheme-border-active: var(--border-active, #4a4a4a);
-$scheme-popup-background: var(--popup, #f5f5f5);
+$scheme-popup-background: var(--popup, $scheme-background-dark);
 
 // custom text colors (these will be merged with bulma's defaults and used specifically for text)
 $scheme-text-colors: ();
@@ -48,11 +49,11 @@ $button-disabled-color: var(--button-disabled-color, $button-color);
 $button-disabled-background-color: var(--button-disabled-background-color, $button-background-color);
 $button-disabled-border-color: var(--button-disabled-border-color, $button-border-color);
 
-$code-background: var(--code-background, #f5f5f5);
+$code-background: var(--code-background, $scheme-background-dark);
 
 $content-heading-color: var(--content-heading-color, $title-color);
 
-$notification-background-color: var(--notification-background-color, #f5f5f5);
+$notification-background-color: var(--notification-background-color, $scheme-background-dark);
 
 $card-background-color: var(--card-background-color, $scheme-background);
 $card-header-color: var(--card-header-color, $scheme-text-strong);
@@ -60,7 +61,7 @@ $card-color: var(--card-color, $scheme-text);
 $card-footer-border-top: 1px solid var(--card-footer-border-top, $scheme-border);
 
 $menu-item-color: var(--menu-item-color, $scheme-text);
-$menu-item-hover-background-color: var(--menu-item-hover-background-color, #f5f5f5);
+$menu-item-hover-background-color: var(--menu-item-hover-background-color, $scheme-background-dark);
 $menu-item-hover-color: var(--menu-item-hover-color, $scheme-text-strong);
 $menu-label-color: var(--menu-label-color, #9e9e9e);
 $menu-list-border-left: 1px solid var(--menu-list-border-left, $scheme-border);
@@ -79,7 +80,7 @@ $input-border-color: var(--input-border-color, $scheme-border);
 $input-hover-border-color: var(--input-hover-border-color, $scheme-border-hover);
 $input-focus-border-color: var(--input-focus-border-color, #3273dc);
 $input-disabled-color: var(--input-disabled-color, #7a7a7a);
-$input-disabled-background-color: var(--input-disabled-background-color, #f5f5f5);
+$input-disabled-background-color: var(--input-disabled-background-color, $scheme-background-dark);
 $input-disabled-border-color: var(--input-disabled-border-color, $scheme-border-secondary);
 $input-disabled-placeholder-color: var(--input-disabled-placeholder-color, #7a7a7a4a);
 
@@ -92,7 +93,7 @@ $pagination-focus-border-color: var(--pagination-focus-border-color, $scheme-bor
 
 $panel-block-color: var(--panel-block-color, $scheme-text-strong);
 $panel-item-border: 1px solid var(--panel-item-border, $scheme-border);
-$panel-block-hover-background-color: var(--panel-block-hover-background-color, #f5f5f5);
+$panel-block-hover-background-color: var(--panel-block-hover-background-color, $scheme-background-dark);
 
 $list-item-color: var(--list-item-color, $scheme-text);
 $list-background-color: var(--list-background-color, $scheme-background);

--- a/src/css/scheme/light.scss
+++ b/src/css/scheme/light.scss
@@ -4,13 +4,26 @@ $scheme-text: var(--text, #4a4a4a);
 $scheme-text-secondary: var(--text-secondary, #6b6464);
 $scheme-text-strong: var(--text-strong, #363636);
 $scheme-primary: var(--scheme-primary, #3273dc);
+$scheme-primary-light: var(--scheme-primary-light, #5596ff);
 $scheme-link: var(--link, $scheme-primary);
 $scheme-link-hover: var(--link-hover, $scheme-text-strong);
+$scheme-link-strong-hover: var(--link-strong-hover, $scheme-text-strong);
 $scheme-shadow: var(--shadow, #0000003b);
 $scheme-border: var(--border, #dbdbdb);
 $scheme-border-secondary: var(--border-secondary, #efefef);
 $scheme-border-hover: var(--border-hover, #b5b5b5);
 $scheme-border-active: var(--border-active, #4a4a4a);
+
+// custom text colors (these will be merged with bulma's defaults and used specifically for text)
+$scheme-text-colors: ();
+
+@mixin defineColor($name, $color) {
+	$scheme-text-colors: map-merge($scheme-text-colors, ($name: (var(--text-color-#{$name}, $color)))) !global;
+}
+
+@include defineColor("danger", #f84d4d);
+@include defineColor("info", $scheme-primary-light);
+@include defineColor("warning", #eca100);
 
 
 // overriding bulma variables with CSS vars that can be replaced with other values when on a different scheme

--- a/src/css/scheme/light.scss
+++ b/src/css/scheme/light.scss
@@ -13,6 +13,7 @@ $scheme-border: var(--border, #dbdbdb);
 $scheme-border-secondary: var(--border-secondary, #efefef);
 $scheme-border-hover: var(--border-hover, #b5b5b5);
 $scheme-border-active: var(--border-active, #4a4a4a);
+$scheme-popup-background: var(--popup, #f5f5f5);
 
 // custom text colors (these will be merged with bulma's defaults and used specifically for text)
 $scheme-text-colors: ();

--- a/src/pages/ConfigEditor.vue
+++ b/src/pages/ConfigEditor.vue
@@ -42,13 +42,15 @@
 
                                     </div>
                                 </div>
-								<config-card v-for='(file, index) in sortedConfigFiles' 
-									:key="`config-file-${file.name}`"
-									:id="index"
-									:title="file.name"
-									@click="editFile(file)"
-									@delete="deleteConfig(file.getPath())">
-								</config-card>
+								<div>
+									<config-card v-for='(file, index) in sortedConfigFiles' 
+										:key="`config-file-${file.name}`"
+										:id="index"
+										:title="file.name"
+										@click="editFile(file)"
+										@delete="deleteConfig(file.getPath())">
+									</config-card>
+								</div>
 							</div>
 							<div class='container' v-else-if="editing && loadedFile.getPath().toLowerCase().endsWith('.cfg')">
 								<div>

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -315,6 +315,8 @@
 							<LocalModList
 								ref="localModList"
                                 @error="showError($event)"
+								@sort-start="sorting=true"
+								@sort-end="sorting=false"
                             />
 						</template>
 					</template>
@@ -562,7 +564,8 @@
 		dragAndDropText: string = 'Drag and drop file here to install mod';
 		showDragAndDropModal: boolean = false;
 		showUpdateAllModal: boolean = false;
-        showDependencyStrings: boolean = false;
+		showDependencyStrings: boolean = false;
+		sorting: boolean = false;
 
 		@Watch('pageNumber')
 		changePage() {
@@ -1170,12 +1173,20 @@
             const defaultDragText = 'Drag and drop file here to install mod';
 
             document.ondragover = (ev) => {
+				if (this.sorting) {
+					return;
+				}
+				
                 this.dragAndDropText = defaultDragText;
                 this.showDragAndDropModal = true;
                 ev.preventDefault();
             }
 
             document.ondragleave = (ev) => {
+				if (this.sorting) {
+					return;
+				}
+				
                 if (ev.relatedTarget === null) {
                     this.showDragAndDropModal = false;
                 }
@@ -1183,6 +1194,10 @@
             }
 
             document.body.ondrop = (ev) => {
+				if (this.sorting) {
+					return;
+				}
+				
                 if (FileDragDrop.areMultipleFilesDragged(ev)) {
                     this.dragAndDropText = 'Only a single mod can be installed at a time';
                     return;

--- a/src/pages/Splash.vue
+++ b/src/pages/Splash.vue
@@ -131,7 +131,7 @@
 <script lang='ts'>
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { Hero, Progress, Link } from '../components/all';
+import { Hero, Progress, ExternalLink } from '../components/all';
 
 import RequestItem from '../model/requests/RequestItem';
 import axios from 'axios';
@@ -153,7 +153,7 @@ import FolderMigration from '../migrations/FolderMigration';
     components: {
         'hero': Hero,
         'progress-bar': Progress,
-        'link-component': Link,
+        'link-component': ExternalLink,
     }
 })
 export default class Splash extends Vue {

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -45,7 +45,7 @@ export default class ManagerSettings {
                 this.linkedFiles = parsedYaml.linkedFiles || [];
                 this.lastSelectedProfile = parsedYaml.lastSelectedProfile;
                 this.steamDirectory = parsedYaml.steamDirectory;
-                this.expandedCards = parsedYaml.expandedCards || false;
+                this.allIconDisplayMode = parsedYaml.expandedCards || false;
                 this.legacyInstallMode = parsedYaml.legacyInstallMode;
                 this.darkTheme = parsedYaml.darkTheme;
                 this.launchParameters = parsedYaml.launchParameters || '';

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -26,7 +26,7 @@ export default class ManagerSettings {
     public steamDirectory: string | null = null;
     public lastSelectedProfile: string = 'Default';
     public funkyModeEnabled: boolean = false;
-    public allIconDisplayMode: boolean = true;
+    public allIconDisplayMode: boolean = false;
     public legacyInstallMode: boolean = false;
     public linkedFiles: string[] = [];
     public darkTheme: boolean = false;

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -26,7 +26,7 @@ export default class ManagerSettings {
     public steamDirectory: string | null = null;
     public lastSelectedProfile: string = 'Default';
     public funkyModeEnabled: boolean = false;
-    public expandedCards: boolean = false;
+    public allIconDisplayMode: boolean = true;
     public legacyInstallMode: boolean = false;
     public linkedFiles: string[] = [];
     public darkTheme: boolean = false;
@@ -112,13 +112,13 @@ export default class ManagerSettings {
         return this.save();
     }
 
-    public expandCards(): R2Error | void {
-        this.expandedCards = true;
+    public setIconDisplayModeAll (): R2Error | void {
+        this.allIconDisplayMode = true;
         return this.save();
     }
 
-    public collapseCards(): R2Error | void {
-        this.expandedCards = false;
+    public setIconDisplayModeReduced (): R2Error | void {
+        this.allIconDisplayMode = false;
         return this.save();
     }
 

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -45,7 +45,7 @@ export default class ManagerSettings {
                 this.linkedFiles = parsedYaml.linkedFiles || [];
                 this.lastSelectedProfile = parsedYaml.lastSelectedProfile;
                 this.steamDirectory = parsedYaml.steamDirectory;
-                this.allIconDisplayMode = parsedYaml.expandedCards || false;
+                this.allIconDisplayMode = parsedYaml.allIconDisplayMode || false;
                 this.legacyInstallMode = parsedYaml.legacyInstallMode;
                 this.darkTheme = parsedYaml.darkTheme;
                 this.launchParameters = parsedYaml.launchParameters || '';

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -48,7 +48,7 @@ export default class ProfileModList {
         }
     }
 
-    private static saveModList(profile: Profile, modList: ManifestV2[]): R2Error | null {
+    public static saveModList(profile: Profile, modList: ManifestV2[]): R2Error | null {
         try {
             const yamlModList: string = yaml.stringify(modList);
             try {

--- a/tests/unit/manager/ManagerSettings.test.ts
+++ b/tests/unit/manager/ManagerSettings.test.ts
@@ -24,11 +24,11 @@ describe('ManagerSettings', () => {
     });
 
     context('Ensure values saved', () => {
-        it('Expand/collapse cards', () => {
+        it('Icon display mode', () => {
             booleanSettingTestHelper(
-                'expandedCards',
-                () => ManagerSettings.getSingleton().expandCards(),
-                () => ManagerSettings.getSingleton().collapseCards()
+                'allIconDisplayMode',
+                () => ManagerSettings.getSingleton().setIconDisplayModeAll(),
+                () => ManagerSettings.getSingleton().setIconDisplayModeReduced()
             );
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,6 +2345,11 @@ bulma-steps@^2.2.1:
   resolved "https://registry.yarnpkg.com/bulma-steps/-/bulma-steps-2.2.1.tgz#39cc353ae049701c60aa7c74a27bf56b8463cb1a"
   integrity sha512-fD50xz49zPVAfsRNcwBR7rd1lgNdKrcsIXAfVMwMH9A6iDhauOTkiEJOxXj4xZuW/CI6JpV+fCgj5uIuN1lP3Q==
 
+bulma-switch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bulma-switch/-/bulma-switch-2.0.0.tgz#7a187cd1bb8073e9a542478d936b89315f1ffcd8"
+  integrity sha512-myD38zeUfjmdduq+pXabhJEe3x2hQP48l/OI+Y0fO3HdDynZUY/VJygucvEAJKRjr4HxD5DnEm4yx+oDOBXpAA==
+
 bulma-tooltip@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/bulma-tooltip/-/bulma-tooltip-3.0.2.tgz#2cf0abab1de2eba07f9d84eb7f07a8a88819ea92"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9278,6 +9278,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.10.1:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.2.tgz#6e40364d913f98b85a14f6678f92b5c1221f5290"
+  integrity sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -10479,6 +10484,13 @@ vue@2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+
+vuedraggable@^2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-2.24.1.tgz#304abd7644dde05c1f199a227bf9e9107f56197a"
+  integrity sha512-G1fxO1oshx+WLdieSGl6jSJdlHOQFga1FpjuUpgXldbpKNzxpjsGn4xYNnRHVrOAqm8aG5FfpdQlh5LHesxCeA==
+  dependencies:
+    sortablejs "^1.10.1"
 
 vuex@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
**Note: Depends on #309**

- Use padding for labels instead of margin so there's no deadzone
- Style labels based on menu section labels
- Use font size normal instead of bold
- Reorganise settings header stuff so that tabs and search are sticky together and both below the "hero"

## Light theme settings
![image](https://user-images.githubusercontent.com/6081834/94407513-ddb16c00-01b6-11eb-83ff-da5ff34146da.png)
![image](https://user-images.githubusercontent.com/6081834/94407575-f588f000-01b6-11eb-920a-7a5ff3f4a1ac.png)

## Dark theme settings
![image](https://user-images.githubusercontent.com/6081834/94407532-e5711080-01b6-11eb-8266-70632b579fb1.png)
![image](https://user-images.githubusercontent.com/6081834/94407549-ebff8800-01b6-11eb-9b48-17bbeb68896b.png)

## Light theme local mods
![image](https://user-images.githubusercontent.com/6081834/94407671-105b6480-01b7-11eb-85f5-a7be184e8dcf.png)

## Dark theme local mods
![image](https://user-images.githubusercontent.com/6081834/94407697-1c472680-01b7-11eb-98e4-a70da55b8855.png)

## Light theme online mods
![image](https://user-images.githubusercontent.com/6081834/94407840-57495a00-01b7-11eb-8fb1-4b9e8f9d68fe.png)

## Dark theme online mods
![image](https://user-images.githubusercontent.com/6081834/94407818-4d275b80-01b7-11eb-91db-079e37e4c092.png)
