### PR TITLE
Add Linux support

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -199,7 +199,7 @@ module.exports = function(ctx) {
                     include: 'build/installer.nsh'
                 },
                 linux: {
-                    target: ['AppImage', 'snap'],
+                    target: ['AppImage', 'tar.gz'],
                     icon: 'src/assets/icon.png',
                     maintainer: 'ebkr'
                 }

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -201,7 +201,8 @@ module.exports = function(ctx) {
                 linux: {
                     target: ['AppImage', 'tar.gz'],
                     icon: 'src/assets/icon.png',
-                    maintainer: 'ebkr'
+                    maintainer: 'ebkr',
+                    category: 'Game'
                 }
             }
         }

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -171,7 +171,7 @@
                 'Debugging',
                 'Set launch parameters',
                 'Provide custom arguments used to start the game.',
-                () => 'These commands are used against the Steam.exe on game startup',
+                () => 'These commands are used against the Steam executable on game startup',
                 'fa-wrench',
                 () => this.emitInvoke('SetLaunchParameters')
             ),

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -489,6 +489,7 @@
     import CacheUtil from '../r2mm/mods/CacheUtil';
     import CategoryFilterMode from '../model/enums/CategoryFilterMode';
     import ArrayUtils from '../utils/ArrayUtils';
+    import ExecUtils from '../utils/ExecUtils';
     import NavigationMenu from '../components/navigation/NavigationMenu.vue';
     import 'bulma-checkradio/dist/css/bulma-checkradio.min.css';
 
@@ -793,11 +794,11 @@
 		}
 
 		browseDataFolder() {
-			spawn('powershell.exe', ['explorer', `${PathResolver.ROOT}`]);
+			ExecUtils.openPathInFileManager(PathResolver.ROOT);
 		}
 
         browseProfileFolder() {
-			spawn('powershell.exe', ['explorer', `${Profile.getActiveProfile().getPathOfProfile()}`]);
+			ExecUtils.openPathInFileManager(Profile.getActiveProfile().getPathOfProfile());
 		}
 
 		toggleCardExpanded(expanded: boolean) {

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -490,7 +490,7 @@
     import CacheUtil from '../r2mm/mods/CacheUtil';
     import CategoryFilterMode from '../model/enums/CategoryFilterMode';
     import ArrayUtils from '../utils/ArrayUtils';
-    import ExecUtils from '../utils/ExecUtils';
+    import OpenUtils from '../utils/OpenUtils';
     import NavigationMenu from '../components/navigation/NavigationMenu.vue';
     import 'bulma-checkradio/dist/css/bulma-checkradio.min.css';
 
@@ -828,11 +828,11 @@
 		}
 
 		browseDataFolder() {
-			ExecUtils.openPathInFileManager(PathResolver.ROOT);
+			OpenUtils.openPathInFileManager(PathResolver.ROOT);
 		}
 
         browseProfileFolder() {
-			ExecUtils.openPathInFileManager(Profile.getActiveProfile().getPathOfProfile());
+			OpenUtils.openPathInFileManager(Profile.getActiveProfile().getPathOfProfile());
 		}
 
 		toggleCardExpanded(expanded: boolean) {

--- a/src/r2mm/manager/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/GameDirectoryResolver.ts
@@ -45,10 +45,15 @@ export default class GameDirectoryResolver {
                 case 'win32':
                     return this.win32_getSteamDirectory();
                 case 'linux':
-                    // TODO: Make it so it also detects Snap/Flatpak Steam installs
-                    const dir = path.resolve(homedir(), '.local', 'share', 'Steam');
-                    if(!fs.existsSync(dir)) throw new Error('Steam is not installed');
-                    return dir;
+                    const dirs = [
+                        path.resolve(homedir(), '.local', 'share', 'Steam'),
+                        path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam')
+                    ];
+                    dirs.forEach(dir => {
+                        if(fs.existsSync(dir))
+                            return dir;
+                    });
+                    throw new Error('Steam is not installed');
                 default:
                     throw new Error('Unsupported platform');
             }

--- a/src/r2mm/manager/GameRunner.ts
+++ b/src/r2mm/manager/GameRunner.ts
@@ -30,8 +30,8 @@ export default class GameRunner {
             return;
         }
         Logger.Log(LogSeverity.INFO, `Steam directory is: ${steamDir}`);
-        Logger.Log(LogSeverity.INFO, `Running command: ${steamDir}.exe -applaunch 632360 --doorstop-enable true --doorstop-target r2modman\\BepInEx\\core\\BepInEx.Preloader.dll`);
-        exec(`"${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable true --doorstop-target ${path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll")} ${settings.launchParameters}`, (err => {
+        Logger.Log(LogSeverity.INFO, `Running command: "${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable true --doorstop-target ${process.platform !== 'win32' ? 'Z:' : ''}${path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll")} ${settings.launchParameters}`);
+        exec(`"${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable true --doorstop-target ${process.platform !== 'win32' ? 'Z:' : ''}${path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll")} ${settings.launchParameters}`, (err => {
             if (err !== null) {
                 Logger.Log(LogSeverity.ACTION_STOPPED, 'Error was thrown whilst starting modded');
                 Logger.Log(LogSeverity.ERROR, err.message);
@@ -49,7 +49,7 @@ export default class GameRunner {
             return;
         }
         Logger.Log(LogSeverity.INFO, `Steam directory is: ${steamDir}`);
-        Logger.Log(LogSeverity.INFO, `Running command: ${steamDir}.exe -applaunch 632360 --doorstop-enable false`);
+        Logger.Log(LogSeverity.INFO, `Running command: "${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable false`);
         exec(`"${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable false ${settings.launchParameters}`, (err => {
             if (err !== null) {
                 Logger.Log(LogSeverity.ACTION_STOPPED, 'Error was thrown whilst starting modded');

--- a/src/r2mm/manager/GameRunner.ts
+++ b/src/r2mm/manager/GameRunner.ts
@@ -10,6 +10,17 @@ import Profile from '../../model/Profile';
 
 export default class GameRunner {
 
+    public static chooseExecutable(): string {
+        switch(process.platform){
+            case 'win32':
+                return 'Steam.exe';
+            case 'linux':
+                return 'steam.sh';
+            default:
+                return 'steam';
+        }
+    }
+
     public static playModded(ror2Directory: string, onComplete: (err: R2Error | null) => void) {
         Logger.Log(LogSeverity.INFO, 'Launching modded');
         const settings = ManagerSettings.getSingleton();
@@ -20,7 +31,7 @@ export default class GameRunner {
         }
         Logger.Log(LogSeverity.INFO, `Steam directory is: ${steamDir}`);
         Logger.Log(LogSeverity.INFO, `Running command: ${steamDir}.exe -applaunch 632360 --doorstop-enable true --doorstop-target r2modman\\BepInEx\\core\\BepInEx.Preloader.dll`);
-        exec(`"${steamDir}/Steam.exe" -applaunch 632360 --doorstop-enable true --doorstop-target ${path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll")} ${settings.launchParameters}`, (err => {
+        exec(`"${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable true --doorstop-target ${path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll")} ${settings.launchParameters}`, (err => {
             if (err !== null) {
                 Logger.Log(LogSeverity.ACTION_STOPPED, 'Error was thrown whilst starting modded');
                 Logger.Log(LogSeverity.ERROR, err.message);
@@ -39,7 +50,7 @@ export default class GameRunner {
         }
         Logger.Log(LogSeverity.INFO, `Steam directory is: ${steamDir}`);
         Logger.Log(LogSeverity.INFO, `Running command: ${steamDir}.exe -applaunch 632360 --doorstop-enable false`);
-        exec(`"${steamDir}/Steam.exe" -applaunch 632360 --doorstop-enable false ${settings.launchParameters}`, (err => {
+        exec(`"${steamDir}/${GameRunner.chooseExecutable()}" -applaunch 632360 --doorstop-enable false ${settings.launchParameters}`, (err => {
             if (err !== null) {
                 Logger.Log(LogSeverity.ACTION_STOPPED, 'Error was thrown whilst starting modded');
                 Logger.Log(LogSeverity.ERROR, err.message);

--- a/src/r2mm/manager/PreloaderFixer.ts
+++ b/src/r2mm/manager/PreloaderFixer.ts
@@ -1,6 +1,6 @@
 import GameDirectoryResolver from './GameDirectoryResolver';
 import R2Error from 'src/model/errors/R2Error';
-import ExecUtils from 'src/utils/ExecUtils';
+import OpenUtils from 'src/utils/OpenUtils';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 
@@ -22,7 +22,7 @@ export default class PreloaderFixer {
             return new R2Error('Failed to remove Managed directory', err.message, 'Try launching r2modman as an administrator');
         }
         try {
-            ExecUtils.openURI('steam://validate/632360');
+            OpenUtils.openURI('steam://validate/632360');
         } catch(e) {
             const err: Error = e;
             return new R2Error('Failed to start steam://validate', err.message, null);

--- a/src/r2mm/manager/PreloaderFixer.ts
+++ b/src/r2mm/manager/PreloaderFixer.ts
@@ -1,8 +1,8 @@
 import GameDirectoryResolver from './GameDirectoryResolver';
 import R2Error from 'src/model/errors/R2Error';
+import ExecUtils from 'src/utils/ExecUtils';
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { spawnSync } from 'child_process';
 
 export default class PreloaderFixer {
 
@@ -22,7 +22,7 @@ export default class PreloaderFixer {
             return new R2Error('Failed to remove Managed directory', err.message, 'Try launching r2modman as an administrator');
         }
         try {
-            spawnSync(`powershell`, ['start', 'steam://validate/632360']);
+            ExecUtils.openURI('steam://validate/632360');
         } catch(e) {
             const err: Error = e;
             return new R2Error('Failed to start steam://validate', err.message, null);

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -11,7 +11,7 @@ import FileWriteError from 'src/model/errors/FileWriteError';
 import ManifestV2 from 'src/model/ManifestV2';
 import ExportFormat from 'src/model/exports/ExportFormat';
 import ExportMod from 'src/model/exports/ExportMod';
-import { spawn } from 'child_process';
+import ExecUtils from 'src/utils/ExecUtils';
 import PathResolver from '../manager/PathResolver';
 import AdmZip from 'adm-zip';
 import Axios from 'axios';
@@ -157,7 +157,7 @@ export default class ProfileModList {
         if (exportResult instanceof R2Error) {
             return exportResult;
         } else {
-            spawn('powershell.exe', ['explorer', `/select,${exportResult}`]);
+            ExecUtils.openFileManagerToFile(exportResult);
         }
     }
 

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -11,7 +11,7 @@ import FileWriteError from 'src/model/errors/FileWriteError';
 import ManifestV2 from 'src/model/ManifestV2';
 import ExportFormat from 'src/model/exports/ExportFormat';
 import ExportMod from 'src/model/exports/ExportMod';
-import ExecUtils from 'src/utils/ExecUtils';
+import OpenUtils from 'src/utils/OpenUtils';
 import PathResolver from '../manager/PathResolver';
 import AdmZip from 'adm-zip';
 import Axios from 'axios';
@@ -157,7 +157,7 @@ export default class ProfileModList {
         if (exportResult instanceof R2Error) {
             return exportResult;
         } else {
-            ExecUtils.openFileManagerToFile(exportResult);
+            OpenUtils.openFileManagerToFile(exportResult);
         }
     }
 

--- a/src/utils/ExecUtils.ts
+++ b/src/utils/ExecUtils.ts
@@ -1,0 +1,67 @@
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { dirname } from "path";
+
+export default class ExecUtils {
+
+	public static openURI(uri: string){
+		let args: Array<string>;
+		switch (process.platform) {
+			case "win32":
+				args = ['start', uri];
+				break;
+			case "linux":
+				args = [uri];
+			default:
+				args = [];
+				break;
+		}
+
+		return spawn(this.getExecuter(), args);
+	}
+
+	public static openPathInFileManager(path: string): ChildProcessWithoutNullStreams{
+		let args: Array<string>;
+		switch (process.platform) {
+			case "win32":
+				args = ['explorer', path];
+				break;
+			case "linux":
+				args = [path];
+			default:
+				args = [];
+				break;
+		}
+
+		return spawn(this.getExecuter(), args);
+	}
+
+	public static openFileManagerToFile(file: string): ChildProcessWithoutNullStreams{
+		let args: Array<string>;
+		switch(process.platform){
+			case "win32":
+				args = ['explorer', `/select,${file}`];
+				break;
+			case "linux":
+				// Just open the path for now, will do this properly later
+				// btw `dbus-send --session --dest=org.freedesktop.FileManager1 --type=method_call /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems array:string:"file://${file}" string:""`
+				return this.openPathInFileManager(dirname(file));
+			default:
+				args = [];
+				break;
+		}
+
+		return spawn(this.getExecuter(), args);
+	}
+
+	private static getExecuter(): string{
+		switch(process.platform){
+			case "win32":
+				return "powershell.exe";
+			case "linux":
+				return "xdg-open"; // The most common one, but Linux is hell anyway
+			default:
+				return "";
+		}
+	}
+
+}

--- a/src/utils/ExecUtils.ts
+++ b/src/utils/ExecUtils.ts
@@ -1,15 +1,14 @@
-import { ChildProcessWithoutNullStreams, spawn } from "child_process";
-import { dirname } from "path";
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 
 export default class ExecUtils {
 
 	public static openURI(uri: string){
 		let args: Array<string>;
 		switch (process.platform) {
-			case "win32":
+			case 'win32':
 				args = ['start', uri];
 				break;
-			case "linux":
+			case 'linux':
 				args = [uri];
 			default:
 				args = [];
@@ -22,11 +21,12 @@ export default class ExecUtils {
 	public static openPathInFileManager(path: string): ChildProcessWithoutNullStreams{
 		let args: Array<string>;
 		switch (process.platform) {
-			case "win32":
+			case 'win32':
 				args = ['explorer', path];
 				break;
-			case "linux":
+			case 'linux':
 				args = [path];
+				break;
 			default:
 				args = [];
 				break;
@@ -35,32 +35,34 @@ export default class ExecUtils {
 		return spawn(this.getExecuter(), args);
 	}
 
-	public static openFileManagerToFile(file: string): ChildProcessWithoutNullStreams{
-		let args: Array<string>;
+	public static openFileManagerToFile(file: string): ChildProcessWithoutNullStreams | undefined {
 		switch(process.platform){
-			case "win32":
-				args = ['explorer', `/select,${file}`];
-				break;
-			case "linux":
-				// Just open the path for now, will do this properly later
-				// btw `dbus-send --session --dest=org.freedesktop.FileManager1 --type=method_call /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems array:string:"file://${file}" string:""`
-				return this.openPathInFileManager(dirname(file));
+			case 'win32':
+				return spawn(this.getExecuter(), ['explorer', `/select,${file}`]);
+			case 'linux':
+				console.log(file,`array:string:"${file}"`);
+				return spawn('dbus-send', [
+					'--session',
+					'--dest=org.freedesktop.FileManager1',
+					'--type=method_call',
+					'/org/freedesktop/FileManager1',
+					'org.freedesktop.FileManager1.ShowItems',
+					`array:string:${file}`,
+					'string:""'
+				]);
 			default:
-				args = [];
-				break;
+				return undefined;
 		}
-
-		return spawn(this.getExecuter(), args);
 	}
 
 	private static getExecuter(): string{
 		switch(process.platform){
-			case "win32":
-				return "powershell.exe";
-			case "linux":
-				return "xdg-open"; // The most common one, but Linux is hell anyway
+			case 'win32':
+				return 'powershell.exe';
+			case 'linux':
+				return 'xdg-open'; // The most common one, but Linux is hell anyway
 			default:
-				return "";
+				return '';
 		}
 	}
 

--- a/src/utils/OpenUtils.ts
+++ b/src/utils/OpenUtils.ts
@@ -16,7 +16,6 @@ export default class OpenUtils {
 				break;
 		}
 
-		console.log(this.getExecuter(), args);
 		return spawn(this.getExecuter(), args);
 	}
 
@@ -42,7 +41,6 @@ export default class OpenUtils {
 			case 'win32':
 				return spawn(this.getExecuter(), ['explorer', `/select,${file}`]);
 			case 'linux':
-				console.log(file,`array:string:"${file}"`);
 				return spawn('dbus-send', [
 					'--session',
 					'--dest=org.freedesktop.FileManager1',

--- a/src/utils/OpenUtils.ts
+++ b/src/utils/OpenUtils.ts
@@ -1,6 +1,6 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 
-export default class ExecUtils {
+export default class OpenUtils {
 
 	public static openURI(uri: string){
 		let args: Array<string>;

--- a/src/utils/OpenUtils.ts
+++ b/src/utils/OpenUtils.ts
@@ -10,11 +10,13 @@ export default class OpenUtils {
 				break;
 			case 'linux':
 				args = [uri];
+				break;
 			default:
 				args = [];
 				break;
 		}
 
+		console.log(this.getExecuter(), args);
 		return spawn(this.getExecuter(), args);
 	}
 


### PR DESCRIPTION
closes #177

# IMPORTANT:
For the game to be able to launch modded, you need to set your launch options on Risk of Rain 2 as follows: `WINEDLLOVERRIDES="winhttp=n,b" %command%`

## Working:
- Launching the game (vanilla/modded)
- Managing mods
- Changing Steam and RoR2 directories
- Exporting profiles via codes and files
- Verifying files through Steam (preloader fix)

## Untested:
- Installing mods through the browser
- Importing profiles (but there isn't any reason for it to not work)

## Known issues:
- Electron/X11 stock icon instead of r2modmanager's one in Linux
- a config/conf.yml file is created in the current working directory (dunno if it also happens in Windows)
- (AppImage packaging issue) r2modmanager won't restart when intended
- (Only happens in Linux + development environment) Installed mods' icons won't show

## For those who cannot wait
Get an AppImage [here](https://anonfiles.com/VaQf26rap7/r2modman-3.0.36_AppImage)

## Future support
I am available to fix Linux-specific bugs. Ping me in Linux-related issues whenever possible.