### PR TITLE
Replaced .modpack file search with Thunderstore "Modpacks" category check

### DIFF
--- a/src/components/views/Help.vue
+++ b/src/components/views/Help.vue
@@ -113,7 +113,7 @@
             >follow this guide
             </link-component>,
             replacing <span class="code">"BepInEx\core\BepInEx.Preloader.dll" with
-            "r2modman\BepInEx\core\BepInEx.Preloader.dll"
+            "r2modman\BepInEx\core\BepInEx.Preloader.dll"</span>
         </p>
         <br/>
         <h5 class='title is-5'>Something isn't working</h5>

--- a/src/r2mm/downloading/BetterThunderstoreDownloader.ts
+++ b/src/r2mm/downloading/BetterThunderstoreDownloader.ts
@@ -154,13 +154,7 @@ export default class BetterThunderstoreDownloader extends ThunderstoreDownloader
                 // If modpack, use specified dependencies.
                 // If not, get latest version of dependencies.
                 downloadCount += 1;
-                const files = await fs.readdir(path.join(cacheDirectory, mod.getFullName(), modVersion.getVersionNumber().toString()));
-                let isModpack = false;
-                files.forEach(file => {
-                    if (file.toLowerCase().endsWith('.modpack')) {
-                        isModpack = true;
-                    }
-                });
+                let isModpack = combo.getMod().getCategories().find(value => value === "Modpacks") !== undefined;
                 if (!isModpack) {
                     // If not modpack, get latest
                     dependencies = this.buildDependencySetUsingLatest(modVersion, allMods, new Array<ThunderstoreCombo>());


### PR DESCRIPTION
Fixed Help.vue error.

The .modpack file was to support modpacks prior to Thunderstore support. As this has been implemented it is no longer needed.

closes #355 