### PR TITLE
Linux: improve default Steam dir autoconfiguration

### DIFF
--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -22,8 +22,12 @@ export default class GameDirectoryResolverImpl extends GameDirectoryResolverProv
             const dirs = [
                 path.resolve(homedir(), '.local', 'share', 'Steam'),
                 path.resolve(homedir(), '.steam', 'steam'),
+                path.resolve(homedir(), '.steam', 'root'),
+                path.resolve(homedir(), '.steam'),
                 path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
-                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam', 'steam')
+                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam', 'steam'),
+                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam', 'root'),
+                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam')
             ];
             for (let dir of dirs) {
                 if (await FsProvider.instance.exists(dir))

--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -6,7 +6,7 @@ import * as vdf from '@node-steam/vdf';
 import * as path from 'path';
 import { homedir } from 'os';
 import ManagerSettings from '../ManagerSettings';
-import FsProvider from "../../../providers/generic/file/FsProvider";
+import FsProvider from '../../../providers/generic/file/FsProvider';
 import GameDirectoryResolverProvider from '../../../providers/ror2/game/GameDirectoryResolverProvider';
 
 const appManifest = 'appmanifest_632360.acf';
@@ -21,11 +21,13 @@ export default class GameDirectoryResolverImpl extends GameDirectoryResolverProv
         try {
             const dirs = [
                 path.resolve(homedir(), '.local', 'share', 'Steam'),
-                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam')
+                path.resolve(homedir(), '.steam', 'steam'),
+                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
+                path.resolve(homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam', 'steam')
             ];
             for (let dir of dirs) {
                 if (await FsProvider.instance.exists(dir))
-                    return dir;
+                    return await FsProvider.instance.realpath(dir);
             }
             throw new Error('Steam is not installed');
         } catch(e) {


### PR DESCRIPTION
Use the Steam catch-all just in case, BUT resolve links to their real path

This specifically fixes the issue of the guy over at Discord, though it is SUPER weird they got that bug in the first place. Maybe Ubuntu is doing stuff the non standard way again.

(guess you'll have to pick this on the dsp branch also}