### PR TITLE
Add missed dspDirectory change

### DIFF
--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -49,6 +49,7 @@ export default class ManagerSettings {
         this.installedSortBy = itf.installedSortBy || this.installedSortBy;
         this.installedSortDirection = itf.installedSortDirection || this.installedSortDirection;
         this.installedDisablePosition = itf.installedDisablePosition || this.installedDisablePosition;
+        this.dysonSphereProgramDirectory = itf.dysonSphereProgramDirectory;
     }
 
     public createDefaultSettingsObject(): ManagerSettingsInterface {


### PR DESCRIPTION
When loading the settings from IndexedDB, the saved Dyson Sphere Program directory value was ignored.