### PR TITLE
Better support for linux native games

### DIFF
--- a/src/model/game/Game.ts
+++ b/src/model/game/Game.ts
@@ -8,10 +8,11 @@ export default class Game {
     private readonly _dataFolderName: string;
     private readonly _thunderstoreUrl: string;
     private readonly _exclusionsUrl: string;
+    private readonly _linuxNative: boolean;
 
     constructor(displayName: string, appid: number, internalFolderName: string,
                 steamFolderName: string, exeName: string, dataFolderName: string,
-                tsUrl: string, exclusionsUrl: string) {
+                tsUrl: string, exclusionsUrl: string, linuxNative: boolean) {
 
         this._displayName = displayName;
         this._appId = appid;
@@ -21,6 +22,7 @@ export default class Game {
         this._dataFolderName = dataFolderName;
         this._thunderstoreUrl = tsUrl;
         this._exclusionsUrl = exclusionsUrl;
+        this._linuxNative = linuxNative;
     }
 
     get displayName(): string {
@@ -53,5 +55,9 @@ export default class Game {
 
     get exclusionsUrl(): string {
         return this._exclusionsUrl;
+    }
+
+    get linuxNative(): boolean {
+        return this._linuxNative;
     }
 }

--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -7,15 +7,15 @@ export default class GameManager {
     private static _gameList = [
         new Game('Risk of Rain 2', 632360, 'RiskOfRain2',
             'Risk of Rain 2', 'Risk of Rain 2.exe', 'Risk of Rain 2_Data',
-            'https://thunderstore.io/api/v1/package', 'https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md'),
+            'https://thunderstore.io/api/v1/package', 'https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md', false),
 
         new Game('Dyson Sphere Program', 1366540, 'DysonSphereProgram',
             'Dyson Sphere Program', 'DSPGAME.exe', 'DSPGAME_Data',
-            'https://dsp.thunderstore.io/api/v1/package', 'https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md'),
+            'https://dsp.thunderstore.io/api/v1/package', 'https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md', false),
 
         new Game('Valheim', 892970, 'Valheim',
             'Valheim', 'valheim.exe', 'valheim_Data',
-            'https://valheim.thunderstore.io/api/v1/package', 'https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md')
+            'https://valheim.thunderstore.io/api/v1/package', 'https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md', true)
     ];
 
     static get activeGame(): Game {

--- a/src/providers/generic/game/linux/GameRunnerProviderImpl.ts
+++ b/src/providers/generic/game/linux/GameRunnerProviderImpl.ts
@@ -17,8 +17,12 @@ export default class GameRunnerProviderImpl extends GameRunnerProvider {
 
     public async startModded(game: Game): Promise<void | R2Error> {
         LoggerProvider.instance.Log(LogSeverity.INFO, 'Launching modded');
-        await this.ensureWineWillLoadBepInEx(game);
-        return this.start(game, `--doorstop-enable true --doorstop-target "Z:${await FsProvider.instance.realpath(path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll"))}"`);
+        var doorstopTarget = `${await FsProvider.instance.realpath(path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "core", "BepInEx.Preloader.dll"))}`;
+        if (!game.linuxNative) {
+            await this.ensureWineWillLoadBepInEx(game);
+            doorstopTarget = `Z:${doorstopTarget}`
+        }
+        return this.start(game, `--doorstop-enable true --doorstop-target "${doorstopTarget}"`);
     }
 
     public startVanilla(game: Game): Promise<void | R2Error> {


### PR DESCRIPTION
Pretty much everything else "just works" aside from the `Z:` prefix on the preloader path and unnecessary wine things.

Remaining problems:
* Users will need to set the launch options in steam to `./start_game_bepinex.sh %command%`. Not sure if there's any way around this apart from skipping `steam.sh` altogether and calling `start_game_bepinex.sh` directly in the game runner.
* Should probably add an override in the profile settings in the event that users want to force it to run through proton. Steam has a checkbox for it, so r2mm might as well too.