### PR TITLE
Add mention of Scoop package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ You can choose to update, enable/disable or even uninstall mods with a simple cl
 ## Installing
 
 ### First time installing
+#### Packages
+If you use the [Scoop](https://scoop.sh/) package manager, you can install by running:
+1. `scoop bucket add games`
+2. `scoop install r2modman`
+
 #### Windows
 1. Click "Manual Download" on Thunderstore.
 2. Inside the downloaded **.zip** file. Run the "r2modman Setup X.X.X.exe" (where X.X.X is the current version).


### PR DESCRIPTION
A Scoop [package](https://github.com/Calinou/scoop-games/commit/14f791b24d0d83f8a1975511554c53158cb215f8) for `r2modman` is available in the unofficial games bucket.
I can't guarantee I'll be able to maintain this forever, but it is fairly easy. The JSON manifest can automatically update using the `checkver.ps1` tool shipped with Scoop.