### PR TITLE
Added config slider

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bulma": "^0.8.0",
     "bulma-checkradio": "^1.1.1",
     "bulma-divider": "^0.2.0",
+    "bulma-slider": "^2.0.4",
     "bulma-steps": "^2.2.1",
     "bulma-switch": "^2.0.0",
     "bulma-tooltip": "^3.0.2",

--- a/src/components/config-components/ConfigEditLayout.vue
+++ b/src/components/config-components/ConfigEditLayout.vue
@@ -38,14 +38,24 @@
                             <span class="pre" v-else>{{getCommentDisplay(line.comments)}}</span>
                         </p>
                         <br/>
-                        <template v-if="line.allowedValues.length > 0">
-                            <select class="select select--full" v-model="line.value">
-                                <option v-for="(opt, index) in line.allowedValues" :key="`opt-${key}-${configFile.getName()}-${variable}-${index}`">
-                                    {{opt}}
-                                </option>
-                            </select>
-                        </template>
-                        <input class="input" v-model="line.value" v-else/>
+                        <div class='settings-input-container'>
+                            <template v-if='line.hasRange()'>
+                                <q-slider
+                                    v-on:input="x => setConfigLineValue(line, x)"
+                                    :value="parseFloat(line.value)"
+                                    :min="line.getMinRange()"
+                                    :max="line.getMaxRange()">
+                                </q-slider>
+                            </template>
+                            <template v-if="line.allowedValues.length > 0">
+                                <select class="select select--full" v-model="line.value">
+                                    <option v-for="(opt, index) in line.allowedValues" :key="`opt-${key}-${configFile.getName()}-${variable}-${index}`">
+                                        {{opt}}
+                                    </option>
+                                </select>
+                            </template>
+                            <input class="input" v-model="line.value" v-else/>
+                        </div>
                     </div>
                 </div>
                 <br/>
@@ -148,6 +158,9 @@
             this.dumpedConfigVariables = JSON.parse(JSON.stringify(this.dumpedConfigVariables));
         }
 
+        setConfigLineValue(line: ConfigLine, value: number) {
+            line.value = value.toString();
+        }
 
     }
 

--- a/src/components/config-components/ConfigEditLayout.vue
+++ b/src/components/config-components/ConfigEditLayout.vue
@@ -40,12 +40,13 @@
                         <br/>
                         <div class='settings-input-container'>
                             <template v-if='line.hasRange()'>
-                                <q-slider
-                                    v-on:input="x => setConfigLineValue(line, x)"
+                                <input
+                                    type="range"
+                                    class="slider is-fullwidth is-circle is-small"
+                                    v-on:input="e => setConfigLineValue(line, e.target.value)"
                                     :value="parseFloat(line.value)"
                                     :min="line.getMinRange()"
-                                    :max="line.getMaxRange()">
-                                </q-slider>
+                                    :max="line.getMaxRange()" />
                             </template>
                             <template v-if="line.allowedValues.length > 0">
                                 <select class="select select--full" v-model="line.value">

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -14,5 +14,6 @@
 @import "~bulma-steps";
 @import "~bulma-divider";
 @import "~bulma-tooltip";
+@import "~bulma-slider";
 
 @import "custom";

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -447,3 +447,13 @@ code {
 .inherit-background-colour {
     background-color: $scheme-background;
 }
+
+// need to override slider thumb because it is off center otherwise
+.q-slider__thumb-container {
+    top: 20px;
+}
+
+.settings-input-container {
+    display: flex;
+    gap: 16px;
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -448,12 +448,9 @@ code {
     background-color: $scheme-background;
 }
 
-// need to override slider thumb because it is off center otherwise
-.q-slider__thumb-container {
-    top: 20px;
-}
-
 .settings-input-container {
     display: flex;
     gap: 16px;
+    height: 40px;
+    align-items: center;
 }

--- a/src/model/file/ConfigLine.ts
+++ b/src/model/file/ConfigLine.ts
@@ -7,10 +7,36 @@ export default class ConfigLine {
     public comments: string[];
     public allowedValues: string[];
     public commentsExpanded: boolean = false;
+    private readonly range: number[];
 
     public constructor(value: string, comments: string[], allowedValues?: string[]) {
         this.value = value;
         this.comments = comments;
         this.allowedValues = allowedValues || [];
+        this.range = this.parseRange();
+    }
+
+    public hasRange() {
+        return this.range.length === 2;
+    }
+
+    public getMinRange() {
+        return this.hasRange() ? this.range[0] : 0;
+    }
+
+    public getMaxRange() {
+        return this.hasRange() ? this.range[1] : 0;
+    }
+
+    private parseRange(): number[] {
+        for (let comment of this.comments) {
+            if (comment.startsWith('# Acceptable value range')) {
+                // regex to get all numbers inside a string
+                const range: string[] = comment.match(/\d+/g) || [];
+                return range.map(x => Number(x));
+            }
+        }
+
+        return [];
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,6 +3367,11 @@ bulma-divider@^0.2.0:
   resolved "https://registry.yarnpkg.com/bulma-divider/-/bulma-divider-0.2.0.tgz#a9b4d9fe8b270c7cb7573023c575062bc62616f3"
   integrity sha512-REe3k56GECRfDaqFjC8cwLhV4RxXmV0RubuzDJqwior9wlJcdHlN0qfW0tvUX+qphikaTQegIeRuhjRIAqkjkw==
 
+bulma-slider@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/bulma-slider/-/bulma-slider-2.0.4.tgz#c10359dc9e26c357b6718ca827083b611177e453"
+  integrity sha512-JKuU/vp2si5I2rWiHBKaaYWBRECNY1Ow7yNFjxlHdUnPLowNee02K6QYd/ORGEesFPAHXOt+mKPZTEYFhKmviQ==
+
 bulma-steps@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/bulma-steps/-/bulma-steps-2.2.1.tgz#39cc353ae049701c60aa7c74a27bf56b8463cb1a"


### PR DESCRIPTION
This adds a slider inside the config settings for values that have a `# Acceptable value range: From [a] to [b]` setting.
It is only applying integer values even when the field is set to another type.

![grafik](https://user-images.githubusercontent.com/39767545/147790085-c105c604-1af7-41e8-94dd-f59847928b9a.png)
