### PR TITLE
Search by key instead of whole string

### DIFF
--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -230,6 +230,7 @@ import Game from '../../model/game/Game';
 import ConflictManagementProvider from '../../providers/generic/installing/ConflictManagementProvider';
 import Draggable from 'vuedraggable';
 import DonateButton from '../../components/buttons/DonateButton.vue';
+import SearchUtils from '../../utils/SearchUtils';
 
 @Component({
         components: {
@@ -317,9 +318,9 @@ import DonateButton from '../../components/buttons/DonateButton.vue';
             if (this.searchQuery.trim() === '') {
                 this.searchableModList = [...(this.modifiableModList || [])];
             }
+            const searchKeys = SearchUtils.makeKeys(this.searchQuery);
             this.searchableModList = this.modifiableModList.filter((x: ManifestV2) => {
-                return x.getName().toLowerCase().indexOf(this.searchQuery.toLowerCase()) >= 0
-                    || x.getDescription().toLowerCase().indexOf(this.searchQuery.toLowerCase()) >= 0;
+                return SearchUtils.isSearched(searchKeys, x.getName(), x.getDescription());
             });
         }
 

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -83,6 +83,7 @@ import ThunderstoreMod from '../../model/ThunderstoreMod';
 import OnlineModListProvider from '../../providers/components/loaders/OnlineModListProvider';
 import ArrayUtils from '../../utils/ArrayUtils';
 import debounce from 'lodash.debounce';
+import SearchUtils from '../../utils/SearchUtils';
 
 @Component({
     components: {
@@ -146,12 +147,11 @@ export default class OnlineModView extends Vue {
         const filterCategories = this.$store.state.modFilters.selectedCategories;
         const showDeprecatedPackages = this.$store.state.modFilters.showDeprecatedPackages;
 
-        const lowercaseSearchFilter = this.thunderstoreSearchFilter.toLowerCase();
         this.searchableThunderstoreModList = this.sortedThunderstoreModList;
-        if (lowercaseSearchFilter.trim().length > 0) {
+        const searchKeys = SearchUtils.makeKeys(this.thunderstoreSearchFilter);
+        if (searchKeys.length > 0) {
             this.searchableThunderstoreModList = this.sortedThunderstoreModList.filter((x: ThunderstoreMod) => {
-                return x.getFullName().toLowerCase().indexOf(lowercaseSearchFilter) >= 0
-                    || x.getVersions()[0].getDescription().toLowerCase().indexOf(lowercaseSearchFilter) >= 0;
+                return SearchUtils.isSearched(searchKeys, x.getFullName(), x.getVersions()[0].getDescription())
             });
         }
         if (!allowNsfw) {

--- a/src/utils/SearchUtils.ts
+++ b/src/utils/SearchUtils.ts
@@ -1,0 +1,11 @@
+export default class SearchUtils {
+    public static makeKeys(search: string) {
+        return search.trim().toLowerCase().split(' ');
+    }
+
+    public static isSearched(keys: string[], name: string, description: string) {
+        name = name.toLowerCase();
+        description = description.toLowerCase();
+        return keys.every(i => name.indexOf(i) >= 0 || description.indexOf(i) >= 0);
+    }
+}


### PR DESCRIPTION
The search is sometimes annoying as it has to be typed exactly like it is named, without making an error with spaces. I changed it to split the search between spaces and then every key must be present. It feels more natural to use.

May also related to #714 as underscores are not really typed by a user