### PR TITLE
fix-for-issue-759

### DIFF
--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -10,6 +10,7 @@ import FsProvider from '../../../providers/generic/file/FsProvider';
 import GameDirectoryResolverProvider from '../../../providers/ror2/game/GameDirectoryResolverProvider';
 import Game from '../../../model/game/Game';
 import GameManager from '../../../model/game/GameManager';
+import { getPropertyFromPath } from '../../../utils/Common';
 
 export default class GameDirectoryResolverImpl extends GameDirectoryResolverProvider {
 
@@ -200,7 +201,16 @@ export default class GameDirectoryResolverImpl extends GameDirectoryResolverProv
         const userAccountID = (BigInt(userSteamID64) & BigInt(0xFFFFFFFF)).toString();
 
         const localConfig = vdf.parse((await FsProvider.instance.readFile(path.join(steamBaseDir, 'userdata', userAccountID, 'config', 'localconfig.vdf'))).toString());
-        const apps = localConfig.UserLocalConfigStore.Software.Valve.Steam.Apps || localConfig.UserLocalConfigStore.Software.Valve.Steam.apps;
+
+        //find apps in one of possible locations.
+        const apps = getPropertyFromPath(localConfig, [
+            'UserLocalConfigStore.Software.Valve.Steam.Apps',
+            'UserLocalConfigStore.Software.Valve.Steam.apps',
+            'UserLocalConfigStore.Software.Valve.steam.apps'
+        ]);
+        if (!apps) {
+            console.warn('Steam.Apps not found !');
+        }
 
         return apps[game.activePlatform.storeIdentifier!].LaunchOptions || '';
     }

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -1,0 +1,27 @@
+type Mappable = {
+  [key: string]: any;
+};
+
+export const getPropertyFromPath = (object: Mappable, path: string | string[]): any => {
+    if (!object) {
+    	return undefined;
+    }
+    if (typeof path === 'string') {
+  	    const parts = path.split('.');
+        for (let i = 0; i < parts.length; i++) {
+            if (!object) {
+                return undefined;
+            }
+            const key = parts[i];
+            object = object[key];
+        }
+        return object;
+    }
+    for (let i = 0; i < path.length; i++) {
+        const res = getPropertyFromPath(object, path[i]);
+        if (res) {
+            return res;
+        }
+    }
+    return undefined;
+};


### PR DESCRIPTION
Looks like that json structure for steam apps has changed again (at least for Linux). This patch extends previous solution to check for all known path variants. Possibly we could even get away with doing case-insensitive string comparison - since swapping upper and lower case is their thing :upside_down_face: 

In case nothing is found  `Steam.Apps not found !` warning will be outputted to the console - so hopefully it will be easier to find/report/fix in the future.

Since project is not using lodash or something similar I have added simple util function for finding object property by path.

https://github.com/ebkr/r2modmanPlus/issues/759