### PR TITLE
feat: flatpak support #729

### DIFF
--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
@@ -1,6 +1,7 @@
 import FsProvider from '../../../../providers/generic/file/FsProvider';
 import LinuxGameDirectoryResolver from '../../../manager/linux/GameDirectoryResolver';
 import path from 'path';
+import fs from 'fs';
 import GameRunnerProvider from '../../../../providers/generic/game/GameRunnerProvider';
 import Game from '../../../../model/game/Game';
 import R2Error from '../../../../model/errors/R2Error';
@@ -11,6 +12,7 @@ import LoggerProvider, { LogSeverity } from '../../../../providers/ror2/logging/
 import { exec } from 'child_process';
 import GameInstructions from '../../instructions/GameInstructions';
 import GameInstructionParser from '../../instructions/GameInstructionParser';
+import { homedir } from 'os';
 
 export default class SteamGameRunner_Linux extends GameRunnerProvider {
 
@@ -68,8 +70,11 @@ export default class SteamGameRunner_Linux extends GameRunnerProvider {
 
         LoggerProvider.instance.Log(LogSeverity.INFO, `Steam directory is: ${steamDir}`);
 
+        const flatpakSpawnPrefix = fs.existsSync('/.flatpak-info') ? "flatpak-spawn --host" : "";
+        const steamCmd = steamDir.indexOf(path.join(homedir(), '.var', 'app', 'com.valvesoftware.Steam')) == 0 ? "flatpak run --filesystem=home/.config/r2modmanPlus-local com.valvesoftware.Steam" : `"${steamDir}/steam.sh"`;
+
         try {
-            const cmd = `"${steamDir}/steam.sh" -applaunch ${game.activePlatform.storeIdentifier} ${args} ${settings.getContext().gameSpecific.launchParameters}`;
+            const cmd = `${flatpakSpawnPrefix} ${steamCmd} -applaunch ${game.activePlatform.storeIdentifier} ${args} ${settings.getContext().gameSpecific.launchParameters}`;
             LoggerProvider.instance.Log(LogSeverity.INFO, `Running command: ${cmd}`);
             await exec(cmd);
         } catch(err) {


### PR DESCRIPTION
This PR adds support for steam as a flatpak, and also for r2modmanplus to be packaged as a flatpak but detecting if it is a flatpak and launching steam using flatpak-spawn. 

I tested that user installation of flatpak steam as a user works, both user + system installation of r2modmanplus as a user works, and that they work together. I also tested that other use cases didn't break to an extent. I did not test system installations of steam as a flatpak though which might need to be tested.

If users have a more custom setup, they may need to make adjustments to flatpak permissions with flatseal.

On an unrelated note, is there a way to launch r2modman such that auto-updates are disabled? I think that might also be a good idea for the flatpak, which manages updates.