### PR TITLE
Exclude BepInEx_Server from mod linker

### DIFF
--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -103,7 +103,7 @@ export default class ModLinker {
                         }
                     } else {
                         if ((await fs.lstat(path.join(profile.getPathOfProfile(), file))).isDirectory()) {
-                            if (!["bepinex", "mods", "melonloader", "plugins", "userdata", "_state", "userlibs", "qmods"].includes(file.toLowerCase())) {
+                            if (!["bepinex", "bepinex_server", "mods", "melonloader", "plugins", "userdata", "_state", "userlibs", "qmods"].includes(file.toLowerCase())) {
                                 const fileProfileFolderPath = path.join(profile.getPathOfProfile(), file);
                                 const fileTree = await FileTree.buildFromLocation(fileProfileFolderPath);
                                 if (fileTree instanceof R2Error) {


### PR DESCRIPTION
Exclude the BepInEx_Server directory from being copied into the game
directory from the profile directory.

This directory is used by the Mythic-ServerLaunchFix mod for V Rising to
automatically replicate clientside mod installs to the built-in server
of the game. Unfortunately the manager attempting to implicitly copy the
BepInEx_Server directory from the profile to the game directory will
fail and prevent launching of the game.

Even though this fix is implementation specific, it can be considered
fine for now, as there is no better system in place. Perhaps in the
future it would be better to explicitly declare what to copy instead of
what NOT to copy.