### PR TITLE
Fix elements peaking out above sticky-top

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -77,7 +77,7 @@ select {
 
 .sticky-top {
     position: sticky;
-    top: 0;
+    top: -0.1px;
     z-index: 100;
     padding: 1em;
     box-shadow: 1px 1px 3px 0 $scheme-shadow;


### PR DESCRIPTION
<img width="1283" alt="Screenshot 2022-07-26 192348" src="https://user-images.githubusercontent.com/19309705/181072797-55ef76c9-8bb1-4bdc-9503-7db2fb996f1c.png">

Not sure why this happens, it's kinda weird because using dev tools it appears that the sticky-top is really at the top but for some reason, the games below still peak through. I suspect Windows upscaling is messing something up weirdly because it doesn't happen on my 1080p monitor which doesn't have upscaling.

Also, not sure if there's a better fix but this works and shouldn't make a perceptible difference (probably not even any difference at all on 1080p monitors, at least I didn't notice one when toggling ig back and forth via dev tools).