### PR TITLE
Change the way dumpedConfigVariables is cloned

### DIFF
--- a/src/components/config-components/ConfigEditLayout.vue
+++ b/src/components/config-components/ConfigEditLayout.vue
@@ -155,7 +155,7 @@ import BepInExConfigUtils from '../../utils/BepInExConfigUtils';
             const newLine = new ConfigLine(oldLine.value, oldLine.comments, oldLine.allowedValues);
             newLine.commentsExpanded = !oldLine.commentsExpanded;
             this.dumpedConfigVariables[key][variable] = newLine;
-            this.dumpedConfigVariables = JSON.parse(JSON.stringify(this.dumpedConfigVariables));
+            this.dumpedConfigVariables = { ...this.dumpedConfigVariables };
         }
 
         setConfigLineValue(line: ConfigLine, value: number) {


### PR DESCRIPTION
using `JSON.parse(JSON.stringify(this.dumpedConfigVariables))` doesn't clone class methods. switched to spread operator