### PR TITLE
Remove unnecessary layout spacing

### DIFF
--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -189,7 +189,7 @@
                        v-if="key.enabled">Disable</a>
                     <a class='card-footer-item' @click="enableMod(key)" v-else>Enable</a>
                 </template>
-                <a class='card-footer-item' @click="viewDependencyList(key)">View associated</a>
+                <a class='card-footer-item' @click="viewDependencyList(key)">Associated</a>
                 <Link :url="`${key.getWebsiteUrl()}${key.getVersionNumber().toString()}`"
                       :target="'external'"
                       class="card-footer-item">

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -51,7 +51,7 @@
             </template>
             <a class='card-footer-item' @click='showDownloadModal(key)'>Download</a>
             <Link :url="key.getPackageUrl()" :target="'external'" class='card-footer-item'>
-                View on Website
+                Website <i class="fas fa-external-link-alt margin-left margin-left--half-width"></i>
             </Link>
             <template v-if="key.getDonationLink() !== undefined">
                 <DonateButton :mod="key"/>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -51,7 +51,7 @@ select {
 // custom
 .menu {
     display: block;
-    padding: 1em;
+    padding: 1em 0 1em 1em;
     position: sticky;
     top: 0;
 
@@ -127,9 +127,9 @@ select {
 
 .row-card {
     background-color: rgba(255, 255, 255, 0);
-    margin: 0 1em 4px 0;
     transition: background-color 0.2s, box-shadow 0.2s linear;
     border-bottom: 1px solid $scheme-border;
+    margin: 0 0 4px;
 
     &--expanded {
         border-bottom-width: 0;
@@ -357,6 +357,14 @@ code {
 
     &--half-width {
         margin-right: 0.5rem;
+    }
+}
+
+.margin-left {
+    margin-left: 1em;
+
+    &--half-width {
+        margin-left: 0.5rem;
     }
 }
 

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -32,60 +32,38 @@
         </div>
         <div class="columns">
             <div class="column is-full">
-                <br/>
-
                 <div class="sticky-top is-shadowless background-bg z-top">
-                    <div class="container" v-if="viewMode === 'Card'">
-                        <nav class="level">
+                    <div class="container">
+                        <nav class="level mb-2" v-if="viewMode === 'Card'">
                             <div class="level-item">
                                 <div class="card-header-title">
                                     <div class="input-group input-group--flex margin-right">
-                                        <label for="local-search" class="non-selectable">Search</label>
                                         <input id="local-search" v-model='filterText' class="input margin-right" type="text" placeholder="Search for a game"/>
                                     </div>
                                 </div>
                             </div>
                             <div>
-                                <br/>
                                 <i class="button fas fa-list" @click="toggleViewMode"></i>
                             </div>
                         </nav>
-                        <div class="level">
-                            <div class="level-item">
-                                <div class="tabs">
-                                    <ul class="text-center">
-                                        <li v-for="(key, index) in gameInstanceTypes" :key="`tab-${key}`"
-                                            :class="[{'is-active': activeTab === key}]">
-                                            <a @click="changeTab(key)">{{key}}</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="container" v-else-if="viewMode === 'List'">
-                        <nav class="level">
+                        <nav class="level mb-2" v-else-if="viewMode === 'List'">
                             <div class="level-item">
                                 <div class="card-header-title">
                                     <div class="input-group input-group--flex margin-right">
-                                        <label for="local-search" class="non-selectable">Search</label>
                                         <input id="local-search" v-model='filterText' class="input margin-right" type="text" placeholder="Search for a game"/>
                                     </div>
                                 </div>
                             </div>
                             <div class="margin-right">
-                                <br/>
                                 <a class="button is-info"
                                    :disabled="selectedGame === null && !this.runningMigration" @click="selectGame(selectedGame)">Select
                                     game</a>
                             </div>
                             <div class="margin-right">
-                                <br/>
                                 <a class="button"
                                    :disabled="selectedGame === null && !this.runningMigration" @click="selectDefaultGame(selectedGame)">Set as default</a>
                             </div>
                             <div>
-                                <br/>
                                 <i class="button fas fa-th-large" @click="toggleViewMode"></i>
                             </div>
                         </nav>
@@ -107,8 +85,7 @@
                     <article class="media">
                         <div class="media-content">
                             <div class="content pad--sides" v-if="viewMode === 'Card'">
-                                <h1 class="title is-4">{{ activeTab }}s</h1>
-                                <div>
+                                <div class="game-cards-container">
                                     <div v-for="(game, index) of filteredGameList" :key="`${index}-${game.displayName}-${selectedGame === game}-${isFavourited(game)}`" class="inline-block margin-right margin-bottom">
 
                                         <div class="inline">
@@ -165,7 +142,6 @@
                                         </div>
                                     </a>
                                 </div>
-                                <br/>
                             </div>
                         </div>
                     </article>
@@ -459,3 +435,16 @@ export default class GameSelectionScreen extends Vue {
 
 }
 </script>
+
+
+<style lang="scss" scoped>
+.game-cards-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.mb-2 {
+    margin-bottom: 0.5rem !important;
+}
+</style>


### PR DESCRIPTION
Remove unnecessary layout spacing in order to enable more compact layout
to render nicely e.g. on smaller resolutions.

Most of the changes apply to the game select view, which can be compared here:

Old: https://streamable.com/5eezo5
New: https://streamable.com/6cacf0

Or the most notable section, being the very top of the list:
![image](https://user-images.githubusercontent.com/8225825/195143111-0589235a-4904-45ee-86a3-bc1c70ef24b0.png)
![image](https://user-images.githubusercontent.com/8225825/195143156-77ca125e-f1c2-41f1-90bf-17149bec06a6.png)

Note that the hero vertical padding change shown above hasn't been applied to this PR, but otherwise the results are the same