### PR TITLE
Add standalone GameRunningModal

### DIFF
--- a/src/components/modals/GameRunningModal.vue
+++ b/src/components/modals/GameRunningModal.vue
@@ -1,0 +1,40 @@
+<template>
+    <div id="gameRunningModal" :class="['modal', {'is-active': isOpen}]">
+        <div class="modal-background" @click="close"></div>
+        <div class="modal-content">
+            <div class='notification is-info'>
+                <h3 class="title" v-if="isSteamGame">{{ activeGame.displayName }} is launching via Steam</h3>
+                <h3 class="title" v-else>{{ activeGame.displayName }} is starting</h3>
+                <h5 class="title is-5">Close this message to continue modding.</h5>
+                <div v-if="isSteamGame">
+                    <p>If this is taking a while, it's likely due to Steam starting.</p>
+                    <p>Please be patient, and have fun!</p>
+                </div>
+            </div>
+        </div>
+        <button class="modal-close is-large" aria-label="close" @click="close"></button>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+import Game from "../../model/game/Game";
+import { StorePlatform } from "../../model/game/StorePlatform";
+
+@Component
+export default class GameRunningModal extends Vue {
+    @Prop({required: true})
+    readonly activeGame!: Game;
+
+    isSteamGame = this.activeGame.activePlatform.storePlatform === StorePlatform.STEAM;
+
+    close() {
+        this.$store.commit('closeGameRunningModal');
+    }
+
+    get isOpen(): boolean {
+        return this.$store.state.modals.isGameRunningModalOpen;
+    }
+}
+</script>

--- a/src/components/navigation/NavigationMenu.vue
+++ b/src/components/navigation/NavigationMenu.vue
@@ -1,20 +1,5 @@
 <template>
     <div class="full-height">
-        <div id='gameRunningModal' :class="['modal', {'is-active':(gameRunning !== false)}]">
-            <div class="modal-background" @click="closeGameRunningModal()"></div>
-            <div class='modal-content'>
-                <div class='notification is-info' v-if="activeGame !== undefined">
-                    <h3 class='title' v-if="activeGame.activePlatform.storePlatform === 'Steam'">{{ activeGame.displayName }} is launching via Steam</h3>
-                    <h3 class='title' v-else>{{ activeGame.displayName }} is starting</h3>
-                    <h5 class="title is-5">Close this message to continue modding.</h5>
-                    <div v-if="activeGame.activePlatform.storePlatform === 'Steam'">
-                        <p>If this is taking a while, it's likely due to Steam starting.</p>
-                        <p>Please be patient, and have fun!</p>
-                    </div>
-                </div>
-            </div>
-            <button class="modal-close is-large" aria-label="close" @click="closeGameRunningModal()"></button>
-        </div>
         <div class="sticky-top sticky-top--no-shadow sticky-top--no-padding">
             <aside class="menu">
                 <p class="menu-label">{{ activeGame.displayName }}</p>
@@ -104,8 +89,6 @@ import {
         @Prop({default: ""})
         private view!: string;
 
-        private gameRunning: boolean = false;
-
         get settings() {
             return ManagerSettings.getSingleton(this.activeGame);
         }
@@ -139,21 +122,17 @@ import {
                     await linkProfileFiles(this.activeGame, this.contextProfile!);
                 }
 
-                this.gameRunning = true;
+                this.$store.commit("openGameRunningModal");
                 await launch(this.activeGame, this.contextProfile!, mode);
             } catch (error) {
                 if (error instanceof R2Error) {
-                    this.gameRunning = false;
+                    this.$store.commit("closeGameRunningModal");
                     this.$emit("error", error);
                 } else {
                     throw error;
                 }
             }
 
-        }
-
-        closeGameRunningModal() {
-            this.gameRunning = false;
         }
 
         created() {

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -197,6 +197,8 @@
             @error="showError($event)"
         />
 
+		<GameRunningModal :activeGame="activeGame" />
+
 		<div class='columns' id='content'>
 			<div class="column non-selectable" :class="navbarClass">
                 <NavigationMenu :view="view"
@@ -356,6 +358,7 @@ import GameRunnerProvider from '../providers/generic/game/GameRunnerProvider';
 import LocalFileImportModal from '../components/importing/LocalFileImportModal.vue';
 import { PackageLoader } from '../model/installing/PackageLoader';
 import GameInstructions from '../r2mm/launching/instructions/GameInstructions';
+import GameRunningModal from '../components/modals/GameRunningModal.vue';
 
 @Component({
 		components: {
@@ -365,6 +368,7 @@ import GameInstructions from '../r2mm/launching/instructions/GameInstructions';
             NavigationMenu: NavigationMenuProvider.provider,
             SettingsView,
             DownloadModModal,
+            GameRunningModal,
 			'hero': Hero,
 			'progress-bar': Progress,
 			'ExpandableCard': ExpandableCard,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+
+import ModalsModule from './modules/ModalsModule';
 import { FolderMigration } from '../migrations/FolderMigration';
 
 // import example from './module-example'
@@ -65,7 +67,7 @@ export default function(/* { ssrContext } */) {
             }
         },
         modules: {
-            // example
+            modals: ModalsModule,
         },
 
         // enable strict mode (adds overhead!)

--- a/src/store/modules/ModalsModule.ts
+++ b/src/store/modules/ModalsModule.ts
@@ -1,0 +1,19 @@
+interface State {
+    isGameRunningModalOpen: boolean;
+}
+
+export default {
+    state: (): State => ({
+        isGameRunningModalOpen: false,
+    }),
+
+    mutations: {
+        closeGameRunningModal: function(state: State): void {
+            state.isGameRunningModalOpen = false;
+        },
+
+        openGameRunningModal: function(state: State): void {
+            state.isGameRunningModalOpen = true;
+        }
+    }
+}


### PR DESCRIPTION
The modal was originally built in the navigation menu since that's where the games are launched from, but decoupling these two will hopefully make it easier to customize the NavigationMenu in different views and mod manager variants.

Since the modal and the NavigationMenu are no longer a direct parent- child relation, the status of modal visibity is stored in Vuex store. A separate store module was created for this purpose - the idea is that in the future it could be used to manage more modals than just the one it currently does.