### PR TITLE
Refactor profile code download

### DIFF
--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -260,7 +260,6 @@ import StatusEnum from '../model/enums/StatusEnum';
 import ManagerSettings from '../r2mm/manager/ManagerSettings';
 import ProfileModList from '../r2mm/mods/ProfileModList';
 import ProfileInstallerProvider from '../providers/ror2/installing/ProfileInstallerProvider';
-import PathResolver from '../r2mm/manager/PathResolver';
 import ThunderstoreDownloaderProvider from '../providers/ror2/downloading/ThunderstoreDownloaderProvider';
 
 import * as  yaml from 'yaml';
@@ -273,7 +272,7 @@ import ManagerInformation from '../_managerinf/ManagerInformation';
 import GameDirectoryResolverProvider from '../providers/ror2/game/GameDirectoryResolverProvider';
 import GameManager from '../model/game/GameManager';
 import Game from '../model/game/Game';
-import { ProfileApiClient } from '../r2mm/profiles/ProfilesClient';
+import { ProfileImportExport } from '../r2mm/mods/ProfileImportExport';
 
 let settings: ManagerSettings;
 let fs: FsProvider;
@@ -478,23 +477,12 @@ export default class Profiles extends Vue {
         });
     }
 
-    async parseProfileResponse(profileData: string) {
-        if (profileData.startsWith("#r2modman")) {
-            const buf = Buffer.from(profileData.substring(9).trim(), 'base64');
-            await FileUtils.ensureDirectory(path.join(PathResolver.ROOT, '_import_cache'));
-            await fs.writeFile(path.join(PathResolver.ROOT, '_import_cache', 'import.r2z'), buf);
-            await this.importProfileHandler([path.join(PathResolver.ROOT, '_import_cache', 'import.r2z')]);
-        } else {
-            throw new Error('Code invalid, no profile is associated with this code');
-        }
-    }
-
     async importProfileUsingCode() {
         try {
-            const resp = await ProfileApiClient.getProfile(this.profileImportCode);
-            await this.parseProfileResponse(resp.data);
+            const filepath = await ProfileImportExport.downloadProfileCode(this.profileImportCode);
+            await this.importProfileHandler([filepath]);
         } catch (e: any) {
-            this.showError(R2Error.fromThrownValue(e, "Failed to find profile"));
+            this.showError(R2Error.fromThrownValue(e, "Failed to import profile"));
         }
     }
 

--- a/src/r2mm/manager/PathResolver.ts
+++ b/src/r2mm/manager/PathResolver.ts
@@ -1,7 +1,3 @@
-import * as path from 'path';
-import ManagerSettings from './ManagerSettings';
-import FileUtils from '../../utils/FileUtils';
-
 export default class PathResolver {
 
     private static _APPDATA_DIR: string = '';
@@ -19,7 +15,6 @@ export default class PathResolver {
     static get ROOT(): string {
         return PathResolver._ROOT;
     }
-
 
     static set ROOT(value: string) {
         this._ROOT = value;

--- a/src/r2mm/mods/ProfileImportExport.ts
+++ b/src/r2mm/mods/ProfileImportExport.ts
@@ -1,0 +1,59 @@
+import FileUtils from '../../utils/FileUtils';
+import path from 'path';
+import PathResolver from '../../r2mm/manager/PathResolver';
+import FsProvider from '../../providers/generic/file/FsProvider';
+import { ProfileApiClient } from '../../r2mm/profiles/ProfilesClient';
+
+let fs: FsProvider
+
+const IMPORT_CACHE_DIRNAME = "_import_cache";
+const PROFILE_DATA_PREFIX = "#r2modman";
+
+const getImportCacheDir = async (): Promise<string> => {
+    const dir = path.join(PathResolver.ROOT, IMPORT_CACHE_DIRNAME);
+    await FileUtils.ensureDirectory(dir);
+    return dir;
+}
+
+const getDownloadDestination = async (): Promise<string> => {
+    const cacheDir = await getImportCacheDir();
+    // TODO: This really should always generate an unique filename in order to
+    //       ensure there are no conflicts for if for some reason multiple
+    //       imports are happening at the same time. Achieving uniqueness
+    //       is simple enough, but it shouldn't be done without a cleanup
+    //       strategy to avoid bloating the user's system. A cleanup strategy
+    //       on the other hand turns out to be non-trivial, and as such
+    //       a fixed filename is currently used.
+    return path.join(cacheDir, "import.r2z");
+}
+
+const isProfileDataValid = (profileData: string): boolean => {
+    return profileData.startsWith(PROFILE_DATA_PREFIX)
+}
+
+async function saveDownloadedProfile(profileData: string): Promise<string> {
+    if (!isProfileDataValid(profileData)) {
+        throw new Error("Invalid profile data");
+    }
+
+    const b64 = profileData.substring(PROFILE_DATA_PREFIX.length).trim();
+    const decoded = Buffer.from(b64, "base64");
+    const destination = await getDownloadDestination();
+    await fs.writeFile(destination, decoded);
+    return destination;
+}
+
+/**
+ * Downloads a mod profile to the local import cache and returns the path of the
+ * created file.
+ * @param profileCode - The profile code
+ * @returns string The path to the created file
+ */
+async function downloadProfileCode(profileCode: string): Promise<string> {
+    const response = await ProfileApiClient.getProfile(profileCode);
+    return saveDownloadedProfile(response.data);
+}
+
+export const ProfileImportExport = {
+    downloadProfileCode,
+}


### PR DESCRIPTION
Create a module dedicated for profile import and export related logic
and move parts of the profile code download logic there away from the
Vue component.

Related discussion: https://github.com/ebkr/r2modmanPlus/pull/869#discussion_r1029625254