### PR TITLE
Ensure settings can be loaded before mounting the app

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -10,6 +10,11 @@ const { configure } = require('quasar/wrappers');
 
 module.exports = configure(function(/* ctx */) {
     return {
+        // https://v1.quasar.dev/quasar-cli/quasar-conf-js#property-sourcefiles
+        sourceFiles: {
+            rootComponent: 'src/AppWrapper.vue'
+        },
+
         // https://quasar.dev/quasar-cli/supporting-ts
         supportTS: true,
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="q-app">
+    <div>
 
         <router-view @error="showError" v-if="visible"/>
 
@@ -90,23 +90,19 @@ export default class App extends mixins(UtilityMixin) {
     }
 
     async created() {
-
         // Use as default game for settings load.
-        const riskOfRain2Game = GameManager.gameList.find(value => value.displayName === "Risk of Rain 2")!;
-        GameManager.activeGame = riskOfRain2Game;
+        GameManager.activeGame = GameManager.unsetGame();
 
         this.hookThunderstoreModListRefresh();
         this.hookProfileModListRefresh();
 
-        const settings = await ManagerSettings.getSingleton(riskOfRain2Game);
+        const settings = await ManagerSettings.getSingleton(GameManager.activeGame);
         this.settings = settings;
 
         InstallationRuleApplicator.apply();
         InstallationRules.validate();
 
         ipcRenderer.once('receive-appData-directory', async (_sender: any, appData: string) => {
-
-            await settings.load();
             PathResolver.APPDATA_DIR = path.join(appData, 'r2modmanPlus-local');
             // Legacy path. Needed for migration.
             PathResolver.CONFIG_DIR = path.join(PathResolver.APPDATA_DIR, "config");
@@ -130,7 +126,6 @@ export default class App extends mixins(UtilityMixin) {
             ipcRenderer.once('receive-is-portable', async (_sender: any, isPortable: boolean) => {
                 ManagerInformation.IS_PORTABLE = isPortable;
                 LoggerProvider.instance.Log(LogSeverity.INFO, `Starting manager on version ${ManagerInformation.VERSION.toString()}`);
-                await settings.load();
                 this.visible = true;
             });
             ipcRenderer.send('get-is-portable');

--- a/src/AppWrapper.vue
+++ b/src/AppWrapper.vue
@@ -1,0 +1,25 @@
+<template>
+    <div id="q-app">
+        <SettingsLoader :logError="logError">
+            <App />
+        </SettingsLoader>
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+import App from "./App.vue";
+import SettingsLoader from "./components/SettingsLoader.vue";
+import R2Error from "./model/errors/R2Error";
+
+@Component({
+    components: {App, SettingsLoader}
+})
+export default class AppWrapper extends Vue {
+    logError(error: R2Error) {
+        console.error(error.name, error.message, error.stack);
+    }
+}
+</script>

--- a/src/components/SettingsLoader.vue
+++ b/src/components/SettingsLoader.vue
@@ -1,0 +1,92 @@
+<template>
+    <div id="settings-loader">
+        <slot v-if="isLoaded" />
+
+        <div v-else :class="['modal', 'z-top', {'is-active': error}]">
+            <div class="modal-content">
+                <div class="notification is-danger">
+                    <h3 class="title">Error</h3>
+                    <h5 class="title is-5">{{error && error.name}}</h5>
+                    <p>{{error && error.message}}</p>
+                    <div v-if="error && error.solution">
+                        <br/>
+                        <h5 class="title is-5">Suggestion</h5>
+                        <p>{{error && error.solution}}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+import R2Error from "../model/errors/R2Error";
+import GameManager from "../model/game/GameManager";
+import ManagerSettings from "../r2mm/manager/ManagerSettings";
+
+const url = "https://github.com/ebkr/r2modmanPlus/wiki/Error:-White-or-blank-game-select-screen-on-startup";
+const solution = `Resetting settings might help. For more information, see ${url}`;
+
+@Component
+export default class SettingsLoader extends Vue {
+    @Prop({required: true})
+    private logError!: (error: R2Error) => void;
+
+    error: R2Error|null = null;
+    isLoaded = false;
+
+    handleError(name: string, message: string, solution: string|null = null) {
+        this.error = new R2Error(name, message, solution);
+        this.logError(this.error);
+    }
+
+    async created() {
+        let defaultGame;
+        let settings;
+        let error;
+        
+        try {
+            defaultGame = getDefaultGame();
+        } catch (e) {
+            this.handleError("Failed to read default game", `${e}`);
+            return;
+        }
+
+        try {
+            settings = await ManagerSettings.getSingleton(defaultGame);
+        } catch (e) {
+            this.handleError("Failed to read ManagerSettings", `${e}`, solution);
+            return;
+        }
+
+        try {
+            error = await settings.load();
+        } catch (e) {
+            this.handleError("Failed to load ManagerSettings", `${e}`, solution);
+            return;
+        }
+
+        if (error) {
+            this.handleError(error.name, error.message, solution);
+            return;
+        }
+
+        this.isLoaded = true;
+    }
+}
+
+const getDefaultGame = () => {
+    const defaultGame = GameManager.unsetGame();
+
+    // Don't trust the non-null asserted typing of .unsetGame().
+    if (defaultGame === undefined) {
+        throw new Error("GameManager.unsetGame() returned undefined");
+    }
+
+    return defaultGame;
+};
+
+</script>


### PR DESCRIPTION
For example a corrupted IndexedDB storage may cause loading the settings to fail, which would result in the users seeing an emptyish screen. To prevent that, try to load the settings as the first thing when the app is launched. If that fails, log the error for debug purposes and display an error modal to the user.

Refs TS-1357