### PR TITLE
Watch showDeprecatedPackages filter for state change to update mod list

### DIFF
--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -136,6 +136,7 @@ export default class OnlineModView extends Vue {
     @Watch("$store.state.modFilters.allowNsfw")
     @Watch("$store.state.modFilters.categoryFilterMode")
     @Watch("$store.state.modFilters.selectedCategories")
+    @Watch("$store.state.modFilters.showDeprecatedPackages")
     filterThunderstoreModList() {
         const allowNsfw = this.$store.state.modFilters.allowNsfw;
         const categoryFilterMode = this.$store.state.modFilters.categoryFilterMode;


### PR DESCRIPTION
Changes to recently added new filter weren't watched, so the mod list wasn't updated unless some other filter was updated at the same time.