### PR TITLE
Ensure long config names wrap when necessary

### DIFF
--- a/src/components/ExpandableCard.vue
+++ b/src/components/ExpandableCard.vue
@@ -88,3 +88,10 @@
         }
     }
 </script>
+
+
+<style lang="scss" scoped>
+.card-header-title {
+    word-break: break-all;
+}
+</style>


### PR DESCRIPTION
Long config names were overflowing in the config editor; make them word break & wrap instead.

Old:
![image](https://user-images.githubusercontent.com/8225825/209309703-fd0aed7b-223b-421a-b9e5-b2486fd39d4b.png)

New:
![image](https://user-images.githubusercontent.com/8225825/209309732-85820048-7945-4540-92ea-eb8f6d33370b.png)
