### PR TITLE
Handle returned R2Errors

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -411,9 +411,12 @@ let assignId = 0;
                     }
                     if (olderInstallOfMod !== undefined) {
                         if (!olderInstallOfMod.isEnabled()) {
-                            await ProfileModList.updateMod(manifestMod, profile, async mod => {
+                            const updateError = await ProfileModList.updateMod(manifestMod, profile, async mod => {
                                 mod.disable();
                             });
+                            if (updateError instanceof R2Error) {
+                                return reject(updateError);
+                            }
                             await ProfileInstallerProvider.instance.disableMod(manifestMod, profile);
                         }
                     }

--- a/src/r2mm/installing/LocalModInstaller.ts
+++ b/src/r2mm/installing/LocalModInstaller.ts
@@ -60,7 +60,11 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
                         }
                     }
                     await FsProvider.instance.writeFile(path.join(cacheDirectory, manifest.getName(), manifest.getVersionNumber().toString(), "mm_v2_manifest.json"), JSON.stringify(manifest));
-                    await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
+                    const uninstallResult = await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
+                    if (uninstallResult instanceof R2Error) {
+                        callback(false, uninstallResult);
+                        return Promise.resolve();
+                    }
                     const profileInstallResult = await ProfileInstallerProvider.instance.installMod(manifest, profile);
                     if (profileInstallResult instanceof R2Error) {
                         callback(false, profileInstallResult);
@@ -86,7 +90,11 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
             const fileSafe = file.split("\\").join("/");
             await FsProvider.instance.copyFile(fileSafe, path.join(modCacheDirectory, path.basename(fileSafe)));
             await FsProvider.instance.writeFile(path.join(modCacheDirectory, "mm_v2_manifest.json"), JSON.stringify(manifest));
-            await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
+            const uninstallResult = await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
+            if (uninstallResult instanceof R2Error) {
+                callback(false, uninstallResult);
+                return Promise.resolve();
+            }
             const profileInstallResult = await ProfileInstallerProvider.instance.installMod(manifest, profile);
             if (profileInstallResult instanceof R2Error) {
                 callback(false, profileInstallResult);

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -440,7 +440,11 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
             files: Array.from(existing.entries())
         }
         await FsProvider.instance.writeFile(path.join(profile.getPathOfProfile(), "_state", `${mod.getName()}-state.yml`), yaml.stringify(mft));
-        await ConflictManagementProvider.instance.overrideInstalledState(mod, profile);
+        const err = await ConflictManagementProvider.instance.overrideInstalledState(mod, profile);
+
+        if (err instanceof R2Error) {
+            throw err;
+        }
     }
 
 }


### PR DESCRIPTION
I'm putting this up here to discuss whether changes like these make sense. Generally speaking the code base contains places where R2Errors are returned, and the caller:

* Intentionally ignores the error and it makes sense to me given the context
* Intentionally ignores the error and I'm not sure if it's wise
* Just ignores the error and I can't tell whether it's intentional or not

Any thoughts what should be done in these cases?

---

Another issue: there's multiple places where settings are loaded, but then it's not checked if `.load()` returned R2Error or not. Given the recent addition of SettingsLoader, is this okay, or should we always check the return value?

---

Marking as a draft for discussion and because this haven't been tested thoroughly manually yet.