### PR TITLE
Exclude deprecated mods from NavigationMenu's counter

### DIFF
--- a/src/components/navigation/NavigationMenu.vue
+++ b/src/components/navigation/NavigationMenu.vue
@@ -17,7 +17,7 @@
                         <router-link :to="{name: 'manager.installed'}" class="tagged-link">
                             <i class="fas fa-folder tagged-link__icon icon--margin-right" />
                             <span class="tagged-link__content">Installed</span>
-                            <span :class="getTagLinkClasses(['manager.installed'])">{{localModList.length}}</span>
+                            <span :class="getTagLinkClasses(['manager.installed'])">{{localModCount}}</span>
                         </router-link>
                     </li>
                     <li>
@@ -29,7 +29,7 @@
                             <router-link :to="{name: 'downloads'}" class="margin-right--half-width">
                                 <i class="tag fas fa-download is-primary" />
                             </router-link>
-                            <span :class="getTagLinkClasses(['manager.online', 'downloads'])">{{thunderstoreModList.length}}</span>
+                            <span :class="getTagLinkClasses(['manager.online', 'downloads'])">{{thunderstoreModCount}}</span>
                         </router-link>
                     </li>
                 </ul>
@@ -64,10 +64,10 @@
 
 import { Component, Vue } from 'vue-property-decorator';
 import R2Error from '../../model/errors/R2Error';
-import ManifestV2 from '../../model/ManifestV2';
 import Game from '../../model/game/Game';
 import GameManager from '../../model/game/GameManager';
 import Profile from '../../model/Profile';
+import ThunderstoreMod from '../../model/ThunderstoreMod';
 import {
     LaunchMode,
     launch,
@@ -82,12 +82,16 @@ export default class NavigationMenu extends Vue {
     private contextProfile: Profile | null = null;
     private LaunchMode = LaunchMode;
 
-    get thunderstoreModList() {
-        return this.$store.state.thunderstoreModList || [];
+    get thunderstoreModCount() {
+        let mods: ThunderstoreMod[] = this.$store.state.thunderstoreModList || [];
+
+        return this.$store.state.modFilters.showDeprecatedPackages
+          ? mods.length
+          : mods.filter((m) => !m.isDeprecated()).length;
     }
 
-    get localModList(): ManifestV2[] {
-        return this.$store.state.localModList || [];
+    get localModCount(): number {
+        return (this.$store.state.localModList || []).length;
     }
 
     getTagLinkClasses(routeNames: string[]) {


### PR DESCRIPTION
Users can use a filter to show deprecated mods available online. By default deprecated mods are not shown. However, they were always counted towards the number shown on the NavigationMenu. This might confuse users when the sidebar says there's 3 mods but the list only shows 2.

While the above also applies to other filters, deprecated mods is different since it hides content by default, whereas others require user action to do so.