### PR TITLE
Pin MacOS to v11 for CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             os: windows-latest
             platform: win
           - kind: mac
-            os: macos-latest
+            os: macos-11
             platform: osx
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
MacOS 12 drops support for Python 2 which is required by the current version of electron-builder.