### PR TITLE
Remove deprecated ::v-deep selector

### DIFF
--- a/src/components/navigation/NavigationMenu.vue
+++ b/src/components/navigation/NavigationMenu.vue
@@ -131,7 +131,7 @@ export default class NavigationMenu extends Vue {
 
 <style lang="scss" scoped>
 
-.menu-list::v-deep a a {
+.menu-list a a {
     padding: 0;
 }
 


### PR DESCRIPTION
::v-deep is deprecated in favor of :deep(). Using ::v-deep litters the build process output with a deprecated warning.

When I altered the NavigationMenu, it seemed to me that using the selector was required for things to work as expected. Now it seems that everything works fine without it too.