### PR TITLE
Include GameRunningModal in all pages supporting game launching

### DIFF
--- a/src/components/navigation/NavigationLayout.vue
+++ b/src/components/navigation/NavigationLayout.vue
@@ -6,6 +6,7 @@
         <div class="column">
             <router-view @error="$emit('error', $event)" />
         </div>
+        <GameRunningModal :activeGame="activeGame" />
     </div>
 </template>
 
@@ -14,10 +15,18 @@
 import { Component, Vue } from 'vue-property-decorator';
 
 import NavigationMenu from './NavigationMenu.vue';
+import GameRunningModal from '../modals/GameRunningModal.vue';
+import GameManager from '../../model/game/GameManager';
 
 @Component({
-    components: {NavigationMenu}
+    components: {GameRunningModal, NavigationMenu}
 })
-export default class NavigationLayout extends Vue {}
+export default class NavigationLayout extends Vue {
+    activeGame = GameManager.unsetGame();
+
+    created() {
+        this.activeGame = GameManager.activeGame;
+    }
+}
 
 </script>

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -130,7 +130,6 @@
         <CategoryFilterModal />
         <LocalFileImportModal :visible="importingLocalMod" @close-modal="importingLocalMod = false" @error="showError($event)"/>
         <DownloadModModal @error="showError($event)" />
-        <GameRunningModal :activeGame="activeGame" />
 
         <router-view name="subview"
                      @error="showError"
@@ -176,14 +175,12 @@ import LocalFileImportModal from '../components/importing/LocalFileImportModal.v
 import { PackageLoader } from '../model/installing/PackageLoader';
 import GameInstructions from '../r2mm/launching/instructions/GameInstructions';
 import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
-import GameRunningModal from '../components/modals/GameRunningModal.vue';
 
 @Component({
 		components: {
             LocalFileImportModal,
             CategoryFilterModal,
             DownloadModModal,
-            GameRunningModal,
 			'hero': Hero,
 			'progress-bar': Progress,
 			'ExpandableCard': ExpandableCard,


### PR DESCRIPTION
Game can be launched from all pages containing the NavigationMenu, but downloads, config editor, and help page didn't actually contain the modal that's supposed to be shown when a game is launched.