### PR TITLE
GodotML: Add boostrap CLI args

### DIFF
--- a/src/r2mm/launching/instructions/instructions/loader/GodotMLGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/GodotMLGameInstructions.ts
@@ -9,7 +9,7 @@ export class GodotMLGameInstructions extends GameInstructionGenerator {
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
         return {
-            moddedParameters: `--enable-mods --mods-path "${path.join(DynamicGameInstruction.PROFILE_DIRECTORY, "mods")}"`,
+            moddedParameters: `--script res://addons/mod_loader/mod_loader_setup.gd --enable-mods --mods-path "${path.join(DynamicGameInstruction.PROFILE_DIRECTORY, "mods")}"`,
             vanillaParameters: ''
         }
     }


### PR DESCRIPTION
Add CLI args required to install the GodotML on first launch (no-op on repeat runs)