### PR TITLE
Sort the profile list

### DIFF
--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -639,7 +639,7 @@ export default class Profiles extends Vue {
         await fs.readdir(profilesDirectory).then(dirContents => {
             dirContents.forEach(async (file: string) => {
                 if ((await fs.stat(path.join(profilesDirectory, file))).isDirectory() && file.toLowerCase() !== 'default' && file.toLowerCase() !== "_profile_update") {
-                    this.profileList.push(file);
+                    this.profileList = [...this.profileList, file].sort();
                 }
             });
         }).catch(() => { /* Do nothing */ });


### PR DESCRIPTION
Ensure the profile list is alphabetically sorted. This has been happening coincidentally in scenarios where the I/O promises resolve in order, but this might not always be guaranteed.

This isn't the most performant way to handle it (as the list is sorted after every new entry is added to it), but at the scales we're operating with, it shouldn't matter.