### PR TITLE
Fixed issues with MelonLoader not generating relevant assemblies

### DIFF
--- a/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
@@ -3,13 +3,20 @@ import { GameInstruction } from '../../GameInstructions';
 import Game from '../../../../../model/game/Game';
 import Profile from '../../../../../model/Profile';
 import { DynamicGameInstruction } from '../../DynamicGameInstruction';
+import FsProvider from '../../../../../providers/generic/file/FsProvider';
+import * as path from 'path';
 
 export default class MelonLoaderGameInstructions extends GameInstructionGenerator {
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
-        return {
-            moddedParameters: `--melonloader.basedir "${DynamicGameInstruction.PROFILE_DIRECTORY}"`,
-            vanillaParameters: `--no-mods`
+        let moddedParameters = `--melonloader.basedir "${DynamicGameInstruction.PROFILE_DIRECTORY}"`;
+        if (!await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), 'MelonLoader', 'Managed', 'Assembly-CSharp.dll'))) {
+            console.log("Regenerating AGF")
+           moddedParameters += " --melonloader.agfregenerate"
         }
+        return {
+            moddedParameters: moddedParameters,
+            vanillaParameters: `--no-mods`
+        };
     }
 }


### PR DESCRIPTION
Quick fix to force MelonLoader to generate the relevant "agf" assemblies

Not sure why MelonLoader stopped working with it, although this at least fixes the issue and should make it usable for BONEWORKS/LABS again.