### PR TITLE
Skip '.git' directory in ModLinker processing.

### DIFF
--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -84,6 +84,10 @@ export default class ModLinker {
             const profileFiles = await fs.readdir(profile.getPathOfProfile());
             try {
                 for (const file of profileFiles) {
+                    if (file.toLowerCase() === '.git') {
+                        continue;
+                    }
+
                     if ((await fs.lstat(path.join(profile.getPathOfProfile(), file))).isFile()) {
                         if (file.toLowerCase() !== 'mods.yml') {
                             try {


### PR DESCRIPTION
Added a check in the ModLinker class to exclude '.git' directories when looping over profile files. This is important to prevent the '.git' directory from being treated as a mod, when the mod profile is hosted on a github repository.