### PR TITLE
Remove version number from links leading to Thunderstore website

### DIFF
--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -138,12 +138,15 @@
                             Disabled
                         </span>
                         <span class="card-title selectable">
-                            <template v-if="key.isEnabled()">
-                                {{key.getDisplayName()}} <span class="card-byline selectable">by {{key.getAuthorName()}}</span>
-                            </template>
-                            <template v-else>
-                                <strike class='selectable'>{{key.getDisplayName()}} <span class="card-byline">by {{key.getAuthorName()}}</span></strike>
-                            </template>
+                            <component :is="key.isEnabled() ? 'span' : 'strike'" class="selectable">
+                                {{key.getDisplayName()}}
+                                <span class="selectable card-byline">
+                                    v{{key.getVersionNumber()}}
+                                </span>
+                                <span :class="`card-byline ${key.isEnabled() && 'selectable'}`">
+                                    by {{key.getAuthorName()}}
+                                </span>
+                            </component>
                         </span>
                     </span>
                 </template>
@@ -179,11 +182,11 @@
                     <a class='card-footer-item' @click="enableMod(key)" v-else>Enable</a>
                 </template>
                 <a class='card-footer-item' @click="viewDependencyList(key)">Associated</a>
-                <Link :url="`${key.getWebsiteUrl()}${key.getVersionNumber().toString()}`"
+                <Link :url="key.getWebsiteUrl()"
                       :target="'external'"
                       class="card-footer-item">
-                        <i class='fas fa-code-branch margin-right margin-right--half-width'></i>
-                        {{key.getVersionNumber().toString()}}
+                        Website
+                        <i class="fas fa-external-link-alt margin-left margin-left--half-width"></i>
                 </Link>
                 <a class='card-footer-item' v-if="!isLatest(key)" @click="updateMod(key)">Update</a>
                 <a class='card-footer-item' v-if="getMissingDependencies(key).length > 0"


### PR DESCRIPTION
Newer communities have a different URL structure for showing a specific version of a package than the older communities that use subdomains. Installed mods tried to link to a specific version, but the links were broken for the new communities, which confused users.

Always link to the non version specific page as a quick fix. A proper fix would require backend changes and/or an actual spec. One could sniff the base URL to determine how to link to a specific version, but this would be prone to break if the URL structure change again (e.g. once the new Thunderstore website is launched).

Since the button doesn't lead to the actual installed version anymore, use "website" as the label instead of the version number. This is in line with how the non-installed mods currently link to the website.

Since the version number needs to be shown somewhere, show it on the package title row instead.