### PR TITLE
Fix version number links leading to GitHub website

### DIFF
--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -179,7 +179,7 @@
                     <a class='card-footer-item' @click="enableMod(key)" v-else>Enable</a>
                 </template>
                 <a class='card-footer-item' @click="viewDependencyList(key)">Associated</a>
-                <Link :url="`${key.getWebsiteUrl()}${key.getVersionNumber().toString()}`"
+                <Link :url="`${key.getWebsiteUrl().replace(/(https:\/\/github.com\/[\w\d-]+\/[\w\d-]+)[^\s]*/, "$1/releases/tag/")}${key.getVersionNumber().toString()}`"
                       :target="'external'"
                       class="card-footer-item">
                         <i class='fas fa-code-branch margin-right margin-right--half-width'></i>


### PR DESCRIPTION
The default `{url}{version}` generates broken links with GitHub urls, which may be used when a mod is imported locally (and has a GitHub website set in its manifest).

This is a quick fix to adjust any GitHub urls to point to `{url}/releases/tag/{version}` while preserving the default behaviour for non-GitHub urls.

URL | Before | After
--- | --- | ---
https://github.com/risk-of-thunder/R2API | https://github.com/risk-of-thunder/R2API4.4.0 | https://github.com/risk-of-thunder/R2API/releases/tag/4.4.0
https://thunderstore.io/package/tristanmcpherson/R2API/ | https://thunderstore.io/package/tristanmcpherson/R2API/5.0.5 | https://thunderstore.io/package/tristanmcpherson/R2API/5.0.5