### PR TITLE
Improve pagination support for large page counts

### DIFF
--- a/src/components/navigation/PaginationButtons.vue
+++ b/src/components/navigation/PaginationButtons.vue
@@ -1,0 +1,58 @@
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { truncatePagination } from "../../utils/Pagination";
+
+@Component({})
+export default class PaginationButtons extends Vue {
+    @Prop({ required: true })
+    private currentPage!: number;
+
+    @Prop({ required: true })
+    private pageCount!: number;
+
+    @Prop({ required: true })
+    private contextSize!: number;
+
+    @Prop({ required: true })
+    private onClick!: (pageIndex: number) => void;
+
+    @Watch("currentPage")
+    @Watch("pageCount")
+    @Watch("contextSize")
+    visibleButtons() {
+        return truncatePagination({
+            currentPage: this.currentPage,
+            pageCount: this.pageCount,
+            contextSize: this.contextSize,
+        });
+    }
+}
+</script>
+
+<template>
+<nav class="pagination">
+    <ul class="pagination-list">
+        <li
+            v-for="button in visibleButtons()"
+            :key="`pagination-${button.index}`"
+        >
+            <a
+                :class="[
+                    'pagination-link',
+                    'flex-centered',
+                    {'is-current': button.index === currentPage}
+                ]"
+                @click="onClick(button.index)"
+            >{{button.title}}</a>
+        </li>
+    </ul>
+</nav>
+</template>
+
+<style scoped lang="scss">
+.flex-centered {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -60,16 +60,21 @@
         </div>
         <br/>
         <div class="pagination">
-            <div class="smaller-font">
-                <a
+            <ul class="pagination-list">
+                <li
                     v-for="button in getPaginationButtons()"
                     :key="`pagination-${button.index}`"
-                    :class="['pagination-link', {'is-current': button.index === pageNumber}]"
-                    @click="updatePageNumber(button.index)"
                 >
-                    {{ button.title }}
-                </a>
-            </div>
+                    <a
+                        :class="[
+                            'pagination-link',
+                            'flex-centered',
+                            {'is-current': button.index === pageNumber}
+                        ]"
+                        @click="updatePageNumber(button.index)"
+                    >{{button.title}}</a>
+                </li>
+            </ul>
         </div>
     </div>
 </template>
@@ -239,3 +244,11 @@ export default class OnlineModView extends Vue {
     }
 };
 </script>
+
+<style lang="scss" scoped>
+.flex-centered {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -61,10 +61,13 @@
         <br/>
         <div class="pagination">
             <div class="smaller-font">
-                <a v-for="index in getPaginationSize()" :key="`pagination-${index}`"
-                    :class="['pagination-link', {'is-current': index === pageNumber}]"
-                    @click="updatePageNumber(index)">
-                    {{index}}
+                <a
+                    v-for="button in getPaginationButtons()"
+                    :key="`pagination-${button.index}`"
+                    :class="['pagination-link', {'is-current': button.index === pageNumber}]"
+                    @click="updatePageNumber(button.index)"
+                >
+                    {{ button.title }}
                 </a>
             </div>
         </div>
@@ -84,6 +87,7 @@ import OnlineModListProvider from '../../providers/components/loaders/OnlineModL
 import ArrayUtils from '../../utils/ArrayUtils';
 import debounce from 'lodash.debounce';
 import SearchUtils from '../../utils/SearchUtils';
+import { PaginationButton, truncatePagination } from "../../utils/Pagination";
 
 @Component({
     components: {
@@ -111,6 +115,18 @@ export default class OnlineModView extends Vue {
 
     getPaginationSize() {
         return Math.ceil(this.searchableThunderstoreModList.length / this.pageSize);
+    }
+
+    @Watch("pageNumber")
+    @Watch("getPaginationSize")
+    getPaginationButtons(): PaginationButton[] {
+        const result = truncatePagination({
+            currentPage: this.pageNumber,
+            pageCount: this.getPaginationSize(),
+            contextSize: 3,
+        });
+        console.log(result);
+        return result;
     }
 
     getSortDirections() {

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -101,7 +101,7 @@ import { PaginationButton, truncatePagination } from "../../utils/Pagination";
 })
 
 export default class OnlineModView extends Vue {
-    readonly pageSize = 140;
+    readonly pageSize = 40;
     pagedThunderstoreModList: ThunderstoreMod[] = [];
     pageNumber = 1;
     searchableThunderstoreModList: ThunderstoreMod[] = [];

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -59,23 +59,12 @@
             </p>
         </div>
         <br/>
-        <div class="pagination">
-            <ul class="pagination-list">
-                <li
-                    v-for="button in getPaginationButtons()"
-                    :key="`pagination-${button.index}`"
-                >
-                    <a
-                        :class="[
-                            'pagination-link',
-                            'flex-centered',
-                            {'is-current': button.index === pageNumber}
-                        ]"
-                        @click="updatePageNumber(button.index)"
-                    >{{button.title}}</a>
-                </li>
-            </ul>
-        </div>
+        <PaginationButtons
+            :current-page="pageNumber"
+            :page-count="getPaginationSize()"
+            :context-size="3"
+            :on-click="updatePageNumber"
+        />
     </div>
 </template>
 
@@ -92,11 +81,12 @@ import OnlineModListProvider from '../../providers/components/loaders/OnlineModL
 import ArrayUtils from '../../utils/ArrayUtils';
 import debounce from 'lodash.debounce';
 import SearchUtils from '../../utils/SearchUtils';
-import { PaginationButton, truncatePagination } from "../../utils/Pagination";
+import PaginationButtons from "../navigation/PaginationButtons.vue";
 
 @Component({
     components: {
         OnlineModList: OnlineModListProvider.provider,
+        PaginationButtons,
     }
 })
 
@@ -120,18 +110,6 @@ export default class OnlineModView extends Vue {
 
     getPaginationSize() {
         return Math.ceil(this.searchableThunderstoreModList.length / this.pageSize);
-    }
-
-    @Watch("pageNumber")
-    @Watch("getPaginationSize")
-    getPaginationButtons(): PaginationButton[] {
-        const result = truncatePagination({
-            currentPage: this.pageNumber,
-            pageCount: this.getPaginationSize(),
-            contextSize: 3,
-        });
-        console.log(result);
-        return result;
     }
 
     getSortDirections() {
@@ -244,11 +222,3 @@ export default class OnlineModView extends Vue {
     }
 };
 </script>
-
-<style lang="scss" scoped>
-.flex-centered {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-</style>

--- a/src/utils/Pagination.ts
+++ b/src/utils/Pagination.ts
@@ -1,0 +1,54 @@
+
+export type PaginationButton = {
+    index: number;
+    title: string;
+}
+
+export function truncatePagination(props: {
+    currentPage: number,
+    pageCount: number,
+    contextSize: number,
+}): PaginationButton[] {
+    const result = [];
+
+    if (props.currentPage - props.contextSize > 1) {
+        result.push({
+            index: 1,
+            title: "1"
+        });
+    }
+    if (props.currentPage - props.contextSize - 1 > 1) {
+        result.push({
+            index: props.currentPage - props.contextSize - 1,
+            title: "...",
+        });
+    }
+
+    for (
+        let i = props.currentPage - props.contextSize;
+        i <= props.currentPage + props.contextSize;
+        i++
+    ) {
+        if (i > 0 && i <= props.pageCount) {
+            result.push({
+                index: i,
+                title: i.toString(),
+            });
+        }
+    }
+
+    if (props.currentPage + props.contextSize + 1 < props.pageCount) {
+        result.push({
+            index: props.currentPage + props.contextSize + 1,
+            title: "...",
+        });
+    }
+    if (props.currentPage + props.contextSize < props.pageCount) {
+        result.push({
+            index: props.pageCount,
+            title: props.pageCount.toString(),
+        });
+    }
+
+    return result;
+}


### PR DESCRIPTION
Change the online mod list pagination to only render page buttons for pages in the near vicinity of the current page as well as the first and last page. This significantly improves the experience for games with a lot of mods available.

| Before | After |
|---|---|
| ![image](https://github.com/ebkr/r2modmanPlus/assets/8225825/2bd669ca-1732-40b5-8ef1-9a8db59cc4d7) | ![image](https://github.com/ebkr/r2modmanPlus/assets/8225825/5211bb79-74bd-4e95-a7a7-335ac8aa57af) |