### PR TITLE
Fixing search to elevate exact matches

### DIFF
--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -154,6 +154,15 @@ export default class OnlineModView extends Vue {
                 return SearchUtils.isSearched(searchKeys, x.getFullName(), x.getVersions()[0].getDescription())
             });
         }
+        exactMatches = this.sortedThunderstoreModList.filter((x: ThunderstoreMod) => {
+            return searchKeys.indexOf(x.getFullName().toLowerCase()) > -1;
+        });
+        unexactMatches = this.sortedThunderstoreModList.filter((x: ThunderstoreMod) => {
+            return searchKeys.indexOf(x.getFullName().toLowerCase()) == -1;
+        });
+        if (exactMatches.length > 0) {
+            this.searchableThunderstoreModList = exactMatches.concat(unexactMatches);
+        }
         if (!allowNsfw) {
             this.searchableThunderstoreModList = this.searchableThunderstoreModList.filter(mod => !mod.getNsfwFlag());
         }


### PR DESCRIPTION
This always super annoys me when I'm searching for a specific mod with a name I already know. This reorders the exact matches to the top of the list. 