### PR TITLE
Improve Splash screen download indicators

### DIFF
--- a/src/components/mixins/SplashMixin.vue
+++ b/src/components/mixins/SplashMixin.vue
@@ -44,6 +44,7 @@ export default class SplashMixin extends Vue {
         };
 
         ThunderstorePackages.EXCLUSIONS = await ConnectionProvider.instance.getExclusions(showProgress);
+        this.getRequestItem('ExclusionsList').setProgress(100);
     }
 
     // Get the list of Thunderstore mods from API.
@@ -62,6 +63,8 @@ export default class SplashMixin extends Vue {
             this.isOffline = true;
             this.heroTitle = 'Failed to get mods from Thunderstore';
             this.loadingText = 'You may be offline or Thunderstore is unavailabe. Checking cache.';
+        } finally {
+            this.getRequestItem('ThunderstoreDownload').setProgress(100);
         }
 
         if (response) {

--- a/src/pages/Splash.vue
+++ b/src/pages/Splash.vue
@@ -194,6 +194,9 @@ export default class Splash extends mixins(SplashMixin) {
     }
 
     retryConnection() {
+        this.getRequestItem('UpdateCheck').setProgress(0);
+        this.getRequestItem('ExclusionsList').setProgress(0);
+        this.getRequestItem('ThunderstoreDownload').setProgress(0);
         this.isOffline = false;
         this.checkForUpdates();
     }

--- a/src/utils/HttpUtils.ts
+++ b/src/utils/HttpUtils.ts
@@ -31,11 +31,7 @@ export const getAxiosWithTimeouts = (responseTimeout = 5000, totalTimeout = 1000
 };
 
 interface LongRunningRequestOptions {
-    /**
-     * Custom function to be called when progress is made. Doesn't work
-     * properly currently, since the progress percentage can't be
-     * calculated because the total length of the content isn't known.
-     */
+    /** Custom function to be called when progress is made. */
     downloadProgressed?: DownloadProgressed;
     /**
      * Time (in ms) the request has to trigger the first download
@@ -84,10 +80,9 @@ export const makeLongRunningGetRequest = async (
         rollingTimeout = setTimeout(abort, transmissionTimeout);
 
         if (typeof downloadProgressed === "function") {
-            // TODO: Progress percentage can't be calculated since the
-            // content length is unknown. Looks like this hasn't worked
-            // in a while.
-            downloadProgressed(0);
+            // Backend might not provided total content length.
+            const percent = progress.total ? (progress.loaded / progress.total) * 100 : 0;
+            downloadProgressed(percent);
         }
     }
 


### PR DESCRIPTION
- Calculate package list download progress percentage if possible. This requires that the response headers contain the total length of the content, which is not guaranteed.
- Set exclusion list download progress to 100 when done. Previously this would be left to 0 if the response headers didn't contain the content length.
- Set package list download progress to 100 when done, even if the download fails. Strictly speaking this wouldn't be necessary since the progress bar is hidden after this step, but it might prevent issues in the future if the UI is changed.
- Reset all progress to 0 if user attempts to reconnect after some part of the process has failed.