### PR TITLE
Create dedicated components for mod modals

### DIFF
--- a/src/components/views/LocalModList/AssociatedModsModal.vue
+++ b/src/components/views/LocalModList/AssociatedModsModal.vue
@@ -1,0 +1,62 @@
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Modal } from '../../all';
+import ManifestV2 from '../../../model/ManifestV2';
+
+@Component({
+    components: {Modal}
+})
+export default class AssociatedModsModal extends Vue {
+
+    @Prop({required: true})
+    readonly mod!: ManifestV2;
+
+    @Prop({required: true})
+    readonly dependencyList!: Set<ManifestV2>;
+
+    @Prop({required: true})
+    readonly dependantsList!: Set<ManifestV2>;
+
+    @Prop({required: true, type: Function})
+    readonly onClose!: () => void;
+}
+</script>
+<template>
+    <Modal :open="true" @close-modal="onClose">
+        <template v-slot:title>
+            <p class='card-header-title'>
+                Mods associated with {{mod.getName()}}
+            </p>
+        </template>
+        <template v-slot:body>
+            <div v-if="!!dependencyList.size">
+                <h3 class="subtitle is-5">Dependencies</h3>
+                <ul class="list">
+                    <li class="list-item" v-for='(key, index) in dependencyList'
+                        :key='`dependency-${index}`'>
+                        {{key.getName()}}
+                    </li>
+                </ul>
+            </div>
+            <br v-if="!!dependencyList.size"/>
+            <div v-if="!!dependantsList.size">
+                <h3 class="subtitle is-5">Dependants</h3>
+                <ul class="list">
+                    <li class="list-item" v-for='(key, index) in dependantsList'
+                        :key='`dependant-${index}`'>
+                        {{key.getName()}}
+                    </li>
+                </ul>
+            </div>
+        </template>
+        <template v-slot:footer>
+            <button class="button is-info" @click="onClose">
+                Done
+            </button>
+        </template>
+    </Modal>
+</template>
+
+<style scoped lang="scss">
+
+</style>

--- a/src/components/views/LocalModList/DisableModModal.vue
+++ b/src/components/views/LocalModList/DisableModModal.vue
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Modal } from '../../all';
+import ManifestV2 from '../../../model/ManifestV2';
+
+@Component({
+    components: {Modal}
+})
+export default class DisableModModal extends Vue {
+
+    @Prop({required: true})
+    readonly mod!: ManifestV2;
+
+    @Prop({required: true})
+    readonly dependencyList!: Set<ManifestV2>;
+
+    @Prop({required: true})
+    readonly dependantsList!: Set<ManifestV2>;
+
+    @Prop({required: true})
+    readonly modBeingDisabled!: string | null;
+
+    @Prop({required: true, type: Function})
+    readonly onClose!: () => void;
+
+    @Prop({required: true, type: Function})
+    readonly onDisableIncludeDependents!: (mod: ManifestV2) => void;
+
+    @Prop({required: true, type: Function})
+    readonly onDisableExcludeDependents!: (mod: ManifestV2) => void;
+}
+</script>
+<template>
+    <Modal :open="true" @close-modal="onClose">
+        <template v-slot:title>
+            <p class='card-header-title'>Disabling
+                {{mod.getName()}}
+            </p>
+        </template>
+        <template v-slot:body>
+            <div class='notification is-warning'>
+                <p>
+                    Other mods depend on this mod. Select <strong>Disable all</strong>
+                    to disable dependent mods, otherwise they may cause errors.
+                </p>
+            </div>
+            <p>Mods to be disabled:</p>
+            <br/>
+            <div>
+                <ul class="list">
+                    <li class="list-item">{{mod.getName()}}</li>
+                    <li class="list-item" v-for='(key, index) in dependantsList'
+                        :key='`dependant-${index}`'>
+                        {{key.getName()}}
+                    </li>
+                </ul>
+            </div>
+        </template>
+        <template v-slot:footer>
+            <button class="button is-info"
+                    @click="onDisableIncludeDependents(mod)">
+                Disable all (recommended)
+            </button>
+            <button class="button"
+                    @click="onDisableExcludeDependents(mod)">
+                Disable {{mod.getName()}} only
+            </button>
+            <span v-if="modBeingDisabled" class="tag is-warning margin-top--1rem margin-left">
+                Disabling {{ modBeingDisabled }}
+            </span>
+        </template>
+    </Modal>
+</template>
+
+<style scoped lang="scss">
+
+</style>

--- a/src/components/views/LocalModList/UninstallModModal.vue
+++ b/src/components/views/LocalModList/UninstallModModal.vue
@@ -1,0 +1,79 @@
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Modal } from '../../all';
+import ManifestV2 from '../../../model/ManifestV2';
+
+@Component({
+    components: {Modal}
+})
+export default class UninstallModModal extends Vue {
+
+    @Prop({required: true})
+    readonly mod!: ManifestV2;
+
+    @Prop({required: true})
+    readonly dependencyList!: Set<ManifestV2>;
+
+    @Prop({required: true})
+    readonly dependantsList!: Set<ManifestV2>;
+
+    @Prop({required: true})
+    readonly modBeingUninstalled!: string | null;
+
+    @Prop({required: true, type: Function})
+    readonly onClose!: () => void;
+
+    @Prop({required: true, type: Function})
+    readonly onUninstallIncludeDependents!: (mod: ManifestV2) => void;
+
+    @Prop({required: true, type: Function})
+    readonly onUninstallExcludeDependents!: (mod: ManifestV2) => void;
+}
+</script>
+<template>
+    <Modal :open="true" @close-modal="onClose">
+        <template v-slot:title>
+            <p class='card-header-title'>
+                Uninstalling {{mod.getName()}}
+            </p>
+        </template>
+        <template v-slot:body>
+            <div class='notification is-warning'>
+                <p>
+                    Other mods depend on this mod. Select <strong>Uninstall all</strong>
+                    to uninstall dependent mods, otherwise they may cause errors.
+                </p>
+            </div>
+            <p>Mods to be uninstalled:</p>
+            <br/>
+            <div>
+                <ul class="list">
+                    <li class="list-item">{{mod.getName()}}</li>
+                    <li class="list-item" v-for='(key, index) in dependantsList'
+                        :key='`dependant-${index}`'>
+                        {{key.getName()}}
+                    </li>
+                </ul>
+            </div>
+        </template>
+        <template v-slot:footer>
+            <button class="button is-info"
+                    :disabled="modBeingUninstalled !== null"
+                    @click="onUninstallIncludeDependents(mod)">
+                Uninstall all (recommended)
+            </button>
+            <button class="button"
+                    :disabled="modBeingUninstalled !== null"
+                    @click="onUninstallExcludeDependents(mod)">
+                Uninstall {{mod.getName()}} only
+            </button>
+            <span v-if="modBeingUninstalled" class="tag is-warning margin-top--1rem margin-left">
+                Uninstalling {{ modBeingUninstalled }}
+            </span>
+        </template>
+    </Modal>
+</template>
+
+<style scoped lang="scss">
+
+</style>


### PR DESCRIPTION
Create dedicated components for mod management modals (uninstall, disable, view assocaited). This commit does not move the state management anywhere yet, but ideally it too would be separated from the LocalModList.vue component.

While this commit does increase the amount of boilerplate in the interim, it makes it easier to understand the state flow of the modals (especially inside the modal component itself) and leaves room for future changes that don't directly impact all of the modals.