### PR TITLE
Flush local mod list before moving to profile

### DIFF
--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -429,9 +429,10 @@ export default class Profiles extends Vue {
         return sanitize(nameToSanitize);
     }
 
-    setProfileAndContinue() {
-        settings.setProfile(Profile.getActiveProfile().getProfileName());
-        this.$router.push({name: 'manager.installed'});
+    async setProfileAndContinue() {
+        await this.$store.dispatch('updateModList', []);
+        await settings.setProfile(Profile.getActiveProfile().getProfileName());
+        await this.$router.push({name: 'manager.installed'});
     }
 
     downloadImportedProfileMods(modList: ExportMod[], callback?: () => void) {


### PR DESCRIPTION
LocalModList is rendered before transition to the view actually takes place. If user has previously viewed a large profile, it's still stored in VueX and this unnecessary step can take several seconds. Resetting the stored mod list prevents this unnecessary wait.

Ideally this would be done when the mod list component unmounts, but that would mess with the NavigationBar which shows the number of installed mods.