### PR TITLE
Improve performance of Manager.setAllModsEnabled

### DIFF
--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -499,30 +499,46 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 		}
 
         async setAllModsEnabled(enabled: boolean) {
-            for (const mod of this.localModList) {
-                let profileErr: R2Error | void;
-                if (enabled) {
-                    profileErr = await ProfileInstallerProvider.instance.enableMod(mod, this.contextProfile!);
-                } else {
-                    profileErr = await ProfileInstallerProvider.instance.disableMod(mod, this.contextProfile!);
-                }
-                if (profileErr instanceof R2Error) {
-                    this.showError(profileErr);
-                    continue;
-                }
-                const update: ManifestV2[] | R2Error = await ProfileModList.updateMod(mod, this.contextProfile!, async (updatingMod: ManifestV2) => {
-                    if (enabled) {
-                        updatingMod.enable();
-                    } else {
-                        updatingMod.disable();
+            let lastSuccessfulUpdate: ManifestV2[] = [];
+
+            try {
+                for (const mod of this.localModList) {
+                    if (mod.isEnabled() === enabled) {
+                        continue;
                     }
-                });
-                if (update instanceof R2Error) {
-                    this.showError(update);
-                    continue;
+
+                    let profileErr: R2Error | void;
+                    if (enabled) {
+                        profileErr = await ProfileInstallerProvider.instance.enableMod(mod, this.contextProfile!);
+                    } else {
+                        profileErr = await ProfileInstallerProvider.instance.disableMod(mod, this.contextProfile!);
+                    }
+                    if (profileErr instanceof R2Error) {
+                        this.showError(profileErr);
+                        continue;
+                    }
+                    const update: ManifestV2[] | R2Error = await ProfileModList.updateMod(mod, this.contextProfile!, async (updatingMod: ManifestV2) => {
+                        if (enabled) {
+                            updatingMod.enable();
+                        } else {
+                            updatingMod.disable();
+                        }
+                    });
+                    if (update instanceof R2Error) {
+                        this.showError(update);
+                    } else {
+                        lastSuccessfulUpdate = update;
+                    }
                 }
-                await this.$store.dispatch("updateModList", update);
+            } catch (e) {
+                const name = `Error ${enabled ? "enabling" : "disabling"} mods`;
+                this.showError(R2Error.fromThrownValue(e, name));
+            } finally {
+                if (lastSuccessfulUpdate.length) {
+                    await this.$store.dispatch("updateModList", lastSuccessfulUpdate);
+                }
             }
+
             await this.$router.push({name: "manager.installed"});
         }
 


### PR DESCRIPTION
- Skip processing the mods that already are in the desired state
- Update VueX store only once at the end, not after each mod, since this will trigger a costly rerendering (which will be addressed separately