### PR TITLE
Mount dependency string modal only when it's opened

### DIFF
--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -58,7 +58,7 @@
 				</button>
 			</template>
 		</modal>
-        <modal v-show="showDependencyStrings" :open="showDependencyStrings" @close-modal="showDependencyStrings = false;">
+        <modal v-if="showDependencyStrings" :open="showDependencyStrings" @close-modal="showDependencyStrings = false;">
             <template v-slot:title>
                 <p class='card-header-title'>Dependency string list</p>
             </template>


### PR DESCRIPTION
The modal rerenders when ever the local mod list updates. This is unnecessary since the list can be changed from e.g. LocalModList, while the modal can be opened only from the settings view.

Normally this wouldn't be much of a problem, but currently the method that's used to get the list of local mods does some extra stuff and is slow.