### PR TITLE
Trim the code when importing a profile

### DIFF
--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -479,7 +479,7 @@ export default class Profiles extends Vue {
 
     async importProfileUsingCode() {
         try {
-            const filepath = await ProfileImportExport.downloadProfileCode(this.profileImportCode);
+            const filepath = await ProfileImportExport.downloadProfileCode(this.profileImportCode.trim());
             await this.importProfileHandler([filepath]);
         } catch (e: any) {
             this.showError(R2Error.fromThrownValue(e, "Failed to import profile"));


### PR DESCRIPTION
When sharing a profile code with friends sometimes extra spaces are copied alongside the id. If that's the case a 404 error will be generated. This commit adds a trim() to the code to remove any whitespaces.