### PR TITLE
Update all - query performance

### DIFF
--- a/src/model/VersionNumber.ts
+++ b/src/model/VersionNumber.ts
@@ -25,12 +25,12 @@ export default class VersionNumber implements ReactiveObjectConverterInterface {
                 } else {
                     throw Error(`VersionNumber: Number found was NaN. Received: ${splitNumbers}`);
                 }
-            })
+            });
             // If successful, assign values.
             this.major = numberArray[0];
             this.minor = numberArray[1];
             this.patch = numberArray[2];
-        } catch(e) {
+        } catch (e) {
             // If an error was thrown, log reason.
             return new VersionNumber('0.0.0');
         }
@@ -67,5 +67,17 @@ export default class VersionNumber implements ReactiveObjectConverterInterface {
 
     public isEqualOrNewerThan(version: VersionNumber): boolean {
         return this.isEqualTo(version) || this.isNewerThan(version);
+    }
+
+    public compareToDescending(version: VersionNumber): number {
+        var majorCompare = version.major - this.major;
+        var minorCompare = version.minor - this.minor;
+        var patchCompare = version.patch - this.patch;
+
+        return majorCompare == 0
+            ? minorCompare == 0
+                ? patchCompare
+                : minorCompare
+            : majorCompare;
     }
 }

--- a/src/r2mm/data/ThunderstorePackages.ts
+++ b/src/r2mm/data/ThunderstorePackages.ts
@@ -3,12 +3,14 @@ import Game from '../../model/game/Game';
 import ApiResponse from '../../model/api/ApiResponse';
 import ConnectionProvider from '../../providers/generic/connection/ConnectionProvider';
 import ModBridge from '../mods/ModBridge';
+import ThunderstoreVersion from 'src/model/ThunderstoreVersion';
 
 export default class ThunderstorePackages {
 
     public static PACKAGES: ThunderstoreMod[] = [];
     public static PACKAGES_MAP: Map<String, ThunderstoreMod> = new Map();
     public static EXCLUSIONS: string[] = [];
+    public static LATEST_VERSIONS: Map<String, ThunderstoreVersion> = new Map();
 
     /**
      * Fetch latest V1 API data and apply to {PACKAGES}
@@ -36,6 +38,14 @@ export default class ThunderstorePackages {
             map.set(pkg.getFullName(), pkg);
             return map;
         }, new Map<String, ThunderstoreMod>());
+
+        ThunderstorePackages.LATEST_VERSIONS = ThunderstorePackages.PACKAGES.reduce((map, pkg) => {
+            var latestVersion = pkg.getVersions().sort((a, b) => a.getVersionNumber().compareToDescending(b.getVersionNumber()))[0];
+            if (latestVersion != undefined) {
+                map.set(pkg.getFullName(), latestVersion);
+            }
+            return map;
+        }, new Map<String, ThunderstoreVersion>());
     }
 
     public static getDeprecatedPackageMap(): Map<string, boolean> {

--- a/src/r2mm/data/ThunderstorePackages.ts
+++ b/src/r2mm/data/ThunderstorePackages.ts
@@ -3,14 +3,12 @@ import Game from '../../model/game/Game';
 import ApiResponse from '../../model/api/ApiResponse';
 import ConnectionProvider from '../../providers/generic/connection/ConnectionProvider';
 import ModBridge from '../mods/ModBridge';
-import ThunderstoreVersion from 'src/model/ThunderstoreVersion';
 
 export default class ThunderstorePackages {
 
     public static PACKAGES: ThunderstoreMod[] = [];
     public static PACKAGES_MAP: Map<String, ThunderstoreMod> = new Map();
     public static EXCLUSIONS: string[] = [];
-    public static LATEST_VERSIONS: Map<String, ThunderstoreVersion> = new Map();
 
     /**
      * Fetch latest V1 API data and apply to {PACKAGES}
@@ -38,14 +36,6 @@ export default class ThunderstorePackages {
             map.set(pkg.getFullName(), pkg);
             return map;
         }, new Map<String, ThunderstoreMod>());
-
-        ThunderstorePackages.LATEST_VERSIONS = ThunderstorePackages.PACKAGES.reduce((map, pkg) => {
-            var latestVersion = pkg.getVersions().sort((a, b) => a.getVersionNumber().compareToDescending(b.getVersionNumber()))[0];
-            if (latestVersion != undefined) {
-                map.set(pkg.getFullName(), latestVersion);
-            }
-            return map;
-        }, new Map<String, ThunderstoreVersion>());
     }
 
     public static getDeprecatedPackageMap(): Map<string, boolean> {

--- a/src/r2mm/downloading/BetterThunderstoreDownloader.ts
+++ b/src/r2mm/downloading/BetterThunderstoreDownloader.ts
@@ -107,9 +107,10 @@ export default class BetterThunderstoreDownloader extends ThunderstoreDownloader
                 const combo = new ThunderstoreCombo()
                 combo.setMod(ModBridge.getThunderstoreModFromMod(value, allMods)!)
                 combo.setVersion(latestVersionMap.get(value.getName())!);
-                console.log("Combo:", combo)
                 return combo;
             });
+
+        // TODO - Iterate dependencies of mods requiring update to find missing dependencies to install
     }
 
     public async downloadLatestOfAll(game: Game, mods: ManifestV2[], allMods: ThunderstoreMod[],

--- a/src/r2mm/downloading/BetterThunderstoreDownloader.ts
+++ b/src/r2mm/downloading/BetterThunderstoreDownloader.ts
@@ -93,22 +93,16 @@ export default class BetterThunderstoreDownloader extends ThunderstoreDownloader
     }
 
     public getLatestOfAllToUpdate(mods: ManifestV2[], allMods: ThunderstoreMod[]): ThunderstoreCombo[] {
-
-        const latestVersionMap = ThunderstorePackages.LATEST_VERSIONS;
-
-        return mods.filter(value => {
-            if (latestVersionMap.has(value.getName())) {
-                const latestVersion = latestVersionMap.get(value.getName())!;
-                return latestVersion.getVersionNumber().isNewerThan(value.getVersionNumber());
-            }
-            return false;
-        })
-            .map(value => {
-                const combo = new ThunderstoreCombo()
-                combo.setMod(ModBridge.getThunderstoreModFromMod(value, allMods)!)
-                combo.setVersion(latestVersionMap.get(value.getName())!);
+        return mods.filter(mod => !ModBridge.isCachedLatestVersion(mod))
+            .map(mod => ModBridge.getCachedThunderstoreModFromMod(mod))
+            .filter(value => value != undefined)
+            .map(mod => {
+                const latestVersion = mod!.getVersions().sort((a, b) => a.getVersionNumber().compareToDescending(b.getVersionNumber()))[0];
+                const combo = new ThunderstoreCombo();
+                combo.setMod(mod!);
+                combo.setVersion(latestVersion);
                 return combo;
-            });
+            })
     }
 
     public async downloadLatestOfAll(game: Game, mods: ManifestV2[], allMods: ThunderstoreMod[],

--- a/src/r2mm/downloading/BetterThunderstoreDownloader.ts
+++ b/src/r2mm/downloading/BetterThunderstoreDownloader.ts
@@ -109,8 +109,6 @@ export default class BetterThunderstoreDownloader extends ThunderstoreDownloader
                 combo.setVersion(latestVersionMap.get(value.getName())!);
                 return combo;
             });
-
-        // TODO - Iterate dependencies of mods requiring update to find missing dependencies to install
     }
 
     public async downloadLatestOfAll(game: Game, mods: ManifestV2[], allMods: ThunderstoreMod[],


### PR DESCRIPTION
There was some code iterating dependencies in the previous version however it doesn't appear to actually be needed. The dependencies are still downloaded as expected and the visual indication of the mods that are required to be updated are identical.

Overall this saves around 5 seconds of hanging when uninstalling, disabling, and dragging items in the installed mod view.

The reason for the performance impact is due to the localModList state update also triggering a check to fetch available updates for the update all banner. We could probably further improve performance by not doing the check when the banner is no longer visible however the performance gain from that is neglible in comparison.

**For TMM**
As pointed out by @anttimaki this will need updating on the TMM implementation, however should be able to be copy/pasted without any changes for now.