### PR TITLE
Update game install rule validation

### DIFF
--- a/src/installers/InstallRuleInstaller.ts
+++ b/src/installers/InstallRuleInstaller.ts
@@ -216,7 +216,7 @@ async function installState(args: InstallRuleArgs) {
 }
 
 export class InstallRuleInstaller extends PackageInstaller {
-    private readonly rule: CoreRuleType;
+    public readonly rule: CoreRuleType;
 
     constructor(rules: CoreRuleType) {
         super();

--- a/src/installers/PackageInstaller.ts
+++ b/src/installers/PackageInstaller.ts
@@ -11,5 +11,6 @@ export type InstallArgs = {
 
 export abstract class PackageInstaller {
     abstract install(args: InstallArgs): Promise<void>;
+    // abstract disable(args: InstallArgs): Promise<void>; // TODO: Implement
     // abstract uninstall(): Promise<void>;  // TODO: Implement
 }

--- a/src/r2mm/installing/InstallationRules.ts
+++ b/src/r2mm/installing/InstallationRules.ts
@@ -1,6 +1,7 @@
 import GameManager from '../../model/game/GameManager';
 import * as path from 'path';
 import { GAME_NAME } from '../../r2mm/installing/profile_installers/ModLoaderVariantRecord';
+import { GetInstallerIdForPlugin } from '../../model/installing/PackageLoader';
 
 export type CoreRuleType = {
     gameName: GAME_NAME,
@@ -39,7 +40,9 @@ export default class InstallationRules {
     public static validate() {
         GameManager.gameList.forEach(value => {
             if (this._RULES.find(rule => rule.gameName === value.internalFolderName) === undefined) {
-                throw new Error(`Missing installation rule for game: ${value.internalFolderName}`);
+                if (GetInstallerIdForPlugin(value.packageLoader) === null) {
+                    throw new Error(`Missing installation rule for game: ${value.internalFolderName}`);
+                }
             }
         })
     }

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -10,22 +10,22 @@ import ModFileTracker from '../../../model/installing/ModFileTracker';
 import yaml from 'yaml';
 import ConflictManagementProvider from '../../../providers/generic/installing/ConflictManagementProvider';
 import ModMode from '../../../model/enums/ModMode';
-import InstallationRules, { CoreRuleType, ManagedRule, RuleSubtype } from '../../installing/InstallationRules';
+import InstallationRules, { CoreRuleType } from '../../installing/InstallationRules';
 import PathResolver from '../../../r2mm/manager/PathResolver';
 import GameManager from '../../../model/game/GameManager';
 import { MOD_LOADER_VARIANTS } from '../../installing/profile_installers/ModLoaderVariantRecord';
 import FileWriteError from '../../../model/errors/FileWriteError';
 import FileUtils from '../../../utils/FileUtils';
 import { GetInstallerIdForLoader, GetInstallerIdForPlugin } from '../../../model/installing/PackageLoader';
-import ZipProvider from "../../../providers/generic/zip/ZipProvider";
-import { PackageInstallerId, PackageInstallers } from "../../../installers/registry";
+import { PackageInstallers } from "../../../installers/registry";
 import { InstallArgs } from "../../../installers/PackageInstaller";
 import { InstallRuleInstaller } from "../../../installers/InstallRuleInstaller";
+import { ShimloaderPluginInstaller } from "../../../installers/ShimloaderInstaller";
 
 
 export default class GenericProfileInstaller extends ProfileInstallerProvider {
 
-    private readonly rule: CoreRuleType;
+    private readonly rule: CoreRuleType | undefined;
     private readonly legacyInstaller: InstallRuleInstaller;
 
     constructor() {
@@ -35,8 +35,27 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
     }
 
     private async applyModModeForSubdir(mod: ManifestV2, tree: FileTree, profile: Profile, location: string, mode: number): Promise<R2Error | void> {
-        const subDirPaths = InstallationRules.getAllManagedPaths(this.rule.rules)
+        // TODO: Call through the installer interface. For now we hardcode the only known case because expanding the
+        //       installer system is out of scope.
+        //
+        //       In other words, this entire functionality of enabling & disabling mods should exist as a callable on
+        //       installers rather than here. Below is a dirty hack to fetch the install rules for the current only
+        //       known case.
+        let rule = this.rule;
+        const installerId = GetInstallerIdForPlugin(GameManager.activeGame.packageLoader);
+        if (installerId) {
+            const installer = PackageInstallers[installerId];
+            if (installer instanceof ShimloaderPluginInstaller) {
+                rule = installer.installer.rule;
+            }
+        }
+        if (!rule) {
+            return;
+        }
+
+        const subDirPaths = InstallationRules.getAllManagedPaths(rule.rules)
             .filter(value => value.trackingMethod === "SUBDIR");
+
         for (const dir of subDirPaths) {
             if (await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), dir.route))) {
                 const dirContents = await FsProvider.instance.readdir(path.join(profile.getPathOfProfile(), dir.route));


### PR DESCRIPTION
Update the game install rule validation check to account for games which are bound to specific installer IDs instead of relying on install rules