### PR TITLE
Use cached mod methods in remaining files

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -250,7 +250,7 @@ let assignId = 0;
                 this.$emit('error', localMods);
                 return;
             }
-            const outdatedMods = localMods.filter(mod => !ModBridge.isLatestVersion(mod));
+            const outdatedMods = localMods.filter(mod => !ModBridge.isCachedLatestVersion(mod));
             const currentAssignId = assignId++;
             const progressObject = {
                 progress: 0,

--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -461,9 +461,8 @@ import { DeferredInput } from '../all';
 
         updateMod(vueMod: any) {
             this.selectedManifestMod = new ManifestV2().fromReactive(vueMod);
-            const mod = ModBridge.getThunderstoreModFromMod(
-                this.selectedManifestMod,
-                this.thunderstorePackages
+            const mod = ModBridge.getCachedThunderstoreModFromMod(
+                this.selectedManifestMod
             );
             if (mod instanceof ThunderstoreMod) {
                 this.$store.commit("openDownloadModModal", mod);

--- a/src/model/ManifestV2.ts
+++ b/src/model/ManifestV2.ts
@@ -269,7 +269,7 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
     }
 
     public isDeprecated(): boolean {
-        const tsMod = ModBridge.getThunderstoreModFromMod(this, ThunderstorePackages.PACKAGES);
+        const tsMod = ModBridge.getCachedThunderstoreModFromMod(this);
         return tsMod !== undefined ? tsMod.isDeprecated() : false;
     }
 

--- a/src/r2mm/mods/ModBridge.ts
+++ b/src/r2mm/mods/ModBridge.ts
@@ -24,10 +24,16 @@ export default class ModBridge {
         return matchingMod.getVersions().reduce(reduceToNewestVersion);
     }
 
+    /**
+     * @deprecated Please use {@link ModBridge.getCachedThunderstoreModFromMod} instead.
+     */
     public static getThunderstoreModFromMod(mod: ManifestV2, modList: ThunderstoreMod[]): ThunderstoreMod | undefined {
         return modList.find((tsMod: ThunderstoreMod) => tsMod.getFullName() === mod.getName());
     }
 
+    /**
+     * @deprecated Please use {@link ModBridge.isCachedLatestVersion} instead.
+     */
     public static isLatestVersion(vueMod: any): boolean {
         const mod: ManifestV2 = new ManifestV2().fromReactive(vueMod);
         const latestVersion: ThunderstoreVersion | void = ModBridge.getLatestVersion(mod, ThunderstorePackages.PACKAGES);
@@ -41,7 +47,7 @@ export default class ModBridge {
         const cacheKey = `${mod.getName()}-${mod.getVersionNumber()}`;
 
         if (ModBridge.CACHE[cacheKey] === undefined) {
-            const tsMod = ThunderstorePackages.PACKAGES.find((tsMod) => tsMod.getFullName() === mod.getName());
+            const tsMod = ThunderstorePackages.PACKAGES_MAP.get(mod.getName());
 
             if (tsMod === undefined) {
                 ModBridge.CACHE[cacheKey] = { tsMod: undefined, isLatest: true };


### PR DESCRIPTION
Additionally adds a `@deprecated` JSDoc to the old methods and links to the new, cached ones