### PR TITLE
Add GitHub actions workflow for making a release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release for ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kind: linux
+            os: ubuntu-latest
+            platform: linux
+          - kind: windows
+            os: windows-latest
+            platform: win
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # The talk on the street says this might be a good version for building.
+          node-version: 14.20.1
+          cache: yarn
+
+      - name: Install Yarn dependencies
+        run: yarn install --frozen-lockfile
+
+      - if: matrix.platform == 'linux'
+        name: Install bsdtar # Required by electron-builder when targeting pacman.
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libarchive-tools
+
+      - name: Release project
+        id: build
+        uses: StarUbiquitous/command-output@v1.0.1
+        with:
+          run: yarn publish-${{ matrix.platform }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.build.outputs.stderr != ''
+        name: Log stderr
+        continue-on-error: true
+        run: echo '${{ steps.build.outputs.stderr }}'
+
+      # Creating Electron executables can in some cases fail with exit code 0.
+      # Check the output of build step for obvious signs of failure.
+      - if: contains(steps.build.outputs.stderr, '[FAIL]')
+        name: Check STDERR for trouble
+        uses: actions/github-script@v6
+        with:
+          script: core.setFailed('It seems the build process failed silently. See previous step for more info.')

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
         "build-linux": "quasar build --mode electron -T linux",
         "build-osx": "quasar build --mode electron -T mac",
         "publish": "quasar build --mode electron --publish always",
+        "publish-win": "quasar build --mode electron -T win32 --publish always",
+        "publish-linux":  "quasar build --mode electron -T linux --publish always",
         "test:unit": "jest --updateSnapshot",
         "test:unit:ci": "jest --ci",
         "test:unit:coverage": "jest --coverage",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -58,6 +58,11 @@ module.exports = configure(function(/* ctx */) {
                     provider: 'github'
                 }
             },
+            linux: {
+                publish: {
+                    provider: 'github'
+                }
+            },
 
             // transpile: false,
 


### PR DESCRIPTION
Add a manually triggerable GitHub actions workflow for creating a new release. Running the workflow will create a new tag matching the `package.json` version field & a matching draft release under which build artifacts are published.

This PR does not yet include automation for publishing to Thunderstore but might be included as a followup.