### PR TITLE
Make Uninstall Buttons Red

### DIFF
--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -175,7 +175,7 @@ function dependencyStringToModName(x: string) {
         </template>
 
         <!-- Show bottom button row -->
-        <a @click="uninstallMod()" class='card-footer-item'>
+        <a @click="uninstallMod()" class='card-footer-item is-danger'>
             Uninstall
         </a>
 

--- a/src/components/views/LocalModList/UninstallModModal.vue
+++ b/src/components/views/LocalModList/UninstallModModal.vue
@@ -64,7 +64,7 @@ export default class UninstallModModal extends Vue {
             </div>
         </template>
         <template v-slot:footer>
-            <button class="button is-info"
+            <button class="button is-warning"
                     :disabled="isLocked"
                     @click="onUninstallIncludeDependents(mod)">
                 Uninstall all (recommended)

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -174,13 +174,30 @@ select {
         border-radius: 4px;
     }
 
+    &.is-danger::before {
+        border: 1px solid $danger; // Set default border color to $danger for .is-danger items
+    }
+
     &:hover, &:active, &:focus {
         color: #ffffff;
         &::before {
-            background-color: $scheme-primary;
+            background-color: $scheme-primary; // Default interaction background color
             border: 0;
         }
     }
+
+    &.is-danger:hover, &.is-danger:active, &.is-danger:focus {
+        color: #ffffff; // Text color remains white for readability
+        &::before {
+            background-color: $danger; // Background color for danger state interactions
+            border: 0; // Removes the border on interaction states
+        }
+    }
+}
+
+.card-footer-item.is-danger, .card-footer-item.is-danger::before {
+    color: inherit; /* Takes the color from the parent element */
+    background-color: initial; /* Resets to the default value, which might not be necessary for color but can be used for other properties */
 }
 
 .card-byline, .card-timestamp {


### PR DESCRIPTION
## Enhancements to Uninstall Buttons

In line with the suggestions discussed in [this thread](https://github.com/ebkr/r2modmanPlus/discussions/1223):

### Changes:
- **LocalModCard.vue**: Applied `is-danger` class to the "Uninstall" button for visual emphasis on action's risk.
- **UninstallModModal.vue**: Used `is-warning` for the "Uninstall All" button to distinguish between single and bulk uninstall actions.
- **custom.scss**: Updated to ensure `is-danger` class applies correct border and background color changes on hover, focus, and active states.

### Visuals:
- Uninstall button now red: ![Uninstall Button](https://github.com/ebkr/r2modmanPlus/assets/90518536/43c72f3e-bdf4-428a-9ae6-08219e0a9f24)
- Uninstall All button in modal: ![Uninstall All Modal](https://github.com/ebkr/r2modmanPlus/assets/90518536/51702996-a1e1-49fd-b7ad-4e9af585119c)