### PR TITLE
Use Vuex to manage error modal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,25 +1,7 @@
 <template>
     <div>
-
-        <router-view @error="showError" v-if="visible"/>
-
-        <div id='errorModal' :class="['modal', 'z-top', {'is-active':(errorMessage !== '')}]">
-            <div class="modal-background" @click="closeErrorModal()"></div>
-            <div class='modal-content'>
-                <div class='notification is-danger'>
-                    <h3 class='title'>Error</h3>
-                    <h5 class="title is-5">{{errorMessage}}</h5>
-                    <p>{{errorStack}}</p>
-                    <div v-if="errorSolution !== ''">
-                        <br/>
-                        <h5 class="title is-5">Suggestion</h5>
-                        <p>{{errorSolution}}</p>
-                    </div>
-                </div>
-            </div>
-            <button class="modal-close is-large" aria-label="close" @click="closeErrorModal()"></button>
-        </div>
-
+        <router-view v-if="visible"/>
+        <ErrorModal />
     </div>
 </template>
 
@@ -64,8 +46,13 @@ import GenericProfileInstaller from './r2mm/installing/profile_installers/Generi
 import ConnectionProviderImpl from './r2mm/connection/ConnectionProviderImpl';
 import ConnectionProvider from './providers/generic/connection/ConnectionProvider';
 import UtilityMixin from './components/mixins/UtilityMixin.vue';
+import ErrorModal from './components/modals/ErrorModal.vue';
 
-@Component
+@Component({
+    components: {
+        ErrorModal,
+    }
+})
 export default class App extends mixins(UtilityMixin) {
     private settings: ManagerSettings | null = null;
     private visible: boolean = false;

--- a/src/components/config-components/ConfigSelectionLayout.vue
+++ b/src/components/config-components/ConfigSelectionLayout.vue
@@ -145,9 +145,9 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                 this.configFiles = this.configFiles.filter(value => value.getName() !== file.getName());
                 this.textChanged();
             } catch (e) {
-                this.$emit("error", new R2Error(
+                this.$store.commit("error/handleError", R2Error.fromThrownValue(
+                    e,
                     "Failed to delete config file",
-                    (e as Error).message,
                     `Try running ${ManagerInformation.APP_NAME} as an administrator.`
                 ));
             }

--- a/src/components/importing/LocalFileImportModal.vue
+++ b/src/components/importing/LocalFileImportModal.vue
@@ -289,12 +289,12 @@ export default class LocalFileImportModal extends Vue {
 
         const installCallback = (async (success: boolean, error: any | null) => {
             if (!success && error !== null) {
-                this.showError(error);
+                this.$store.commit("error/handleError", R2Error.fromThrownValue(error));
                 return;
             }
             const updatedModListResult = await ProfileModList.getModList(this.contextProfile!);
             if (updatedModListResult instanceof R2Error) {
-                this.showError(updatedModListResult);
+                this.$store.commit("error/handleError", updatedModListResult);
                 return;
             }
             await this.$store.dispatch("updateModList", updatedModListResult);
@@ -306,10 +306,6 @@ export default class LocalFileImportModal extends Vue {
         } else {
             LocalModInstallerProvider.instance.placeFileInCache(this.contextProfile!, this.fileToImport, this.resultingManifest, installCallback);
         }
-    }
-
-    private showError(err: R2Error) {
-        this.$emit("error", err);
     }
 
     created() {

--- a/src/components/mixins/UtilityMixin.vue
+++ b/src/components/mixins/UtilityMixin.vue
@@ -6,31 +6,14 @@ import R2Error from '../../model/errors/R2Error';
 import GameManager from '../../model/game/GameManager';
 import Profile from '../../model/Profile';
 import CdnProvider from '../../providers/generic/connection/CdnProvider';
-import LoggerProvider, { LogSeverity } from '../../providers/ror2/logging/LoggerProvider';
 import ThunderstorePackages from '../../r2mm/data/ThunderstorePackages';
 import ProfileModList from '../../r2mm/mods/ProfileModList';
 import ApiCacheUtils from '../../utils/ApiCacheUtils';
 
 @Component
 export default class UtilityMixin extends Vue {
-    private errorMessage: string = '';
-    private errorStack: string = '';
-    private errorSolution: string = '';
     readonly REFRESH_INTERVAL = 5 * 60 * 1000;
     private tsRefreshFailed = false;
-
-    showError(error: R2Error) {
-        this.errorMessage = error.name;
-        this.errorStack = error.message;
-        this.errorSolution = error.solution;
-        LoggerProvider.instance.Log(LogSeverity.ERROR, `[${error.name}]: ${error.message}`);
-    }
-
-    closeErrorModal() {
-        this.errorMessage = '';
-        this.errorStack = '';
-        this.errorSolution = '';
-    }
 
     hookProfileModListRefresh() {
         setInterval(this.refreshProfileModList, this.REFRESH_INTERVAL);
@@ -101,7 +84,7 @@ export default class UtilityMixin extends Vue {
             await CdnProvider.checkCdnConnection();
         } catch (error: unknown) {
             if (error instanceof R2Error) {
-                this.showError(error);
+                this.$store.commit('error/handleError', error);
             } else {
                 console.error(error);
             }

--- a/src/components/modals/ErrorModal.vue
+++ b/src/components/modals/ErrorModal.vue
@@ -1,0 +1,51 @@
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import R2Error from "../../model/errors/R2Error";
+
+@Component
+export default class ErrorModal extends Vue {
+    get error(): R2Error | null {
+        return this.$store.state.error.error;
+    }
+
+    get name() {
+        return this.error ? this.error.name : '';
+    }
+
+    get message() {
+        return this.error ? this.error.message : '';
+    }
+
+    get solution() {
+        return this.error ? this.error.solution : '';
+    }
+
+    close() {
+        this.$store.commit('error/discardError');
+    }
+}
+</script>
+
+<template>
+    <div v-if="error !== null" id="errorModal" class="modal z-top is-active">
+        <div class="modal-background" @click="close"></div>
+        <div class="modal-content">
+            <div class="notification is-danger">
+                <h3 class="title">Error</h3>
+                <h5 class="title is-5">{{name}}</h5>
+                <p>{{message}}</p>
+                <div v-if="solution">
+                    <h5 class="title is-5">Suggestion</h5>
+                    <p>{{solution}}</p>
+                </div>
+            </div>
+        </div>
+        <button class="modal-close is-large" aria-label="close" @click="close"></button>
+    </div>
+</template>
+
+<style scoped lang="scss">
+    p + div {
+        margin-top: 1.5rem;
+    }
+</style>

--- a/src/components/navigation/NavigationLayout.vue
+++ b/src/components/navigation/NavigationLayout.vue
@@ -1,10 +1,10 @@
 <template>
     <div id="content" class="columns">
         <div class="column non-selectable is-one-quarter">
-            <NavigationMenu @error="$emit('error', $event)" />
+            <NavigationMenu />
         </div>
         <div class="column">
-            <router-view @error="$emit('error', $event)" />
+            <router-view />
         </div>
         <GameRunningModal :activeGame="activeGame" />
     </div>

--- a/src/components/navigation/NavigationMenu.vue
+++ b/src/components/navigation/NavigationMenu.vue
@@ -111,14 +111,9 @@ export default class NavigationMenu extends Vue {
             this.$store.commit("openGameRunningModal");
             await launch(this.activeGame, this.contextProfile!, mode);
         } catch (error) {
-            if (error instanceof R2Error) {
-                this.$store.commit("closeGameRunningModal");
-                this.$emit("error", error);
-            } else {
-                throw error;
-            }
+            this.$store.commit("closeGameRunningModal");
+            this.$store.commit("error/handleError", R2Error.fromThrownValue(error));
         }
-
     }
 
     created() {

--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -247,7 +247,7 @@ let assignId = 0;
             const localMods = await ProfileModList.getModList(this.contextProfile!);
             if (localMods instanceof R2Error) {
                 this.downloadingMod = false;
-                this.$emit('error', localMods);
+                this.$store.commit('error/handleError', localMods);
                 return;
             }
             const outdatedMods = localMods.filter(mod => !ModBridge.isCachedLatestVersion(mod));
@@ -270,7 +270,7 @@ let assignId = 0;
                         const existing = DownloadModModal.allVersions[assignIndex]
                         existing[1].failed = true;
                         this.$set(DownloadModModal.allVersions, assignIndex, [currentAssignId, existing[1]]);
-                        this.$emit('error', err);
+                        this.$store.commit('error/handleError', err);
                         return;
                     }
                 } else if (status === StatusEnum.PENDING) {
@@ -302,7 +302,7 @@ let assignId = 0;
                         await this.$store.dispatch('updateModList', modList);
                         const err = await ConflictManagementProvider.instance.resolveConflicts(modList, this.contextProfile!);
                         if (err instanceof R2Error) {
-                            this.$emit('error', err);
+                            this.$store.commit('error/handleError', err);
                         }
                     }
                 });
@@ -331,7 +331,7 @@ let assignId = 0;
                             const existing = DownloadModModal.allVersions[assignIndex]
                             existing[1].failed = true;
                             this.$set(DownloadModModal.allVersions, assignIndex, [currentAssignId, existing[1]]);
-                            this.$emit('error', err);
+                            this.$store.commit('error/handleError', err);
                             return;
                         }
                     } else if (status === StatusEnum.PENDING) {
@@ -363,7 +363,7 @@ let assignId = 0;
                             await this.$store.dispatch('updateModList', modList);
                             const err = await ConflictManagementProvider.instance.resolveConflicts(modList, this.contextProfile!);
                             if (err instanceof R2Error) {
-                                this.$emit('error', err);
+                                this.$store.commit('error/handleError', err);
                             }
                         }
                     });

--- a/src/components/views/InstalledModView.vue
+++ b/src/components/views/InstalledModView.vue
@@ -16,8 +16,7 @@
             </div>
         </div>
         <template v-else-if="localModList.length > 0">
-            <LocalModList
-                @error="$emit('error', $event)">
+            <LocalModList>
                 <template v-slot:above-list v-if="numberOfModsWithUpdates > 0 && !dismissedUpdateAll">
                     <div class="margin-bottom">
                         <div class="notification is-warning margin-right">
@@ -42,7 +41,6 @@ import Component from "vue-class-component";
 
 import ManifestV2 from "../../model/ManifestV2";
 import LocalModListProvider from "../../providers/components/loaders/LocalModListProvider";
-import ThunderstoreDownloaderProvider from "../../providers/ror2/downloading/ThunderstoreDownloaderProvider";
 
 @Component({
     components: {

--- a/src/components/views/LocalModList/DisableModModal.vue
+++ b/src/components/views/LocalModList/DisableModModal.vue
@@ -53,9 +53,10 @@ export default class DisableModModal extends Vue {
                 { mods, onProgress }
             );
         } catch (e) {
-            const err: Error = e as Error;
-            LoggerProvider.instance.Log(LogSeverity.ACTION_STOPPED, `${err.name}\n-> ${err.message}`);
-            this.$emit('error', e);
+            this.$store.commit('error/handleError', {
+                error: R2Error.fromThrownValue(e),
+                severity: LogSeverity.ACTION_STOPPED
+            });
         } finally {
             this.onClose();
             this.modBeingDisabled = null;

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -2,8 +2,9 @@
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { ExpandableCard, Link } from '../../all';
 import DonateButton from '../../buttons/DonateButton.vue';
+import R2Error from '../../../model/errors/R2Error';
 import ManifestV2 from '../../../model/ManifestV2';
-import LoggerProvider, { LogSeverity } from '../../../providers/ror2/logging/LoggerProvider';
+import { LogSeverity } from '../../../providers/ror2/logging/LoggerProvider';
 import Dependants from '../../../r2mm/mods/Dependants';
 import ModBridge from '../../../r2mm/mods/ModBridge';
 
@@ -91,9 +92,10 @@ export default class LocalModCard extends Vue {
                 { mods: [this.mod] }
             );
         } catch (e) {
-            this.$emit('error', e);
-            const err: Error = e as Error;
-            LoggerProvider.instance.Log(LogSeverity.ACTION_STOPPED, `${err.name}\n-> ${err.message}`);
+            this.$store.commit('error/handleError', {
+                error: R2Error.fromThrownValue(e),
+                severity: LogSeverity.ACTION_STOPPED
+            });
         }
     }
 

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -68,7 +68,6 @@ import ManagerSettings from '../../r2mm/manager/ManagerSettings';
 import { ExpandableCard, Link } from '../all';
 import DownloadModModal from './DownloadModModal.vue';
 import ManifestV2 from '../../model/ManifestV2';
-import R2Error from '../../model/errors/R2Error';
 import DonateButton from '../../components/buttons/DonateButton.vue';
 import CdnProvider from '../../providers/generic/connection/CdnProvider';
 
@@ -127,10 +126,6 @@ export default class OnlineModList extends Vue {
         return CdnProvider.replaceCdnHost(
             tsMod.getVersions()[0].getIcon()
         );
-    }
-
-    emitError(error: R2Error) {
-        this.$emit('error', error);
     }
 
     async created() {

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -46,7 +46,6 @@
         <OnlineModList
             :local-mod-list="localModList"
             :paged-mod-list="pagedThunderstoreModList"
-            @error="$emit('error', $event)"
         />
         <div class="in-mod-list" v-if="getPaginationSize() > 1">
             <p class="notification margin-right">

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -277,7 +277,7 @@ export default class GameSelectionScreen extends Vue {
             ProviderUtils.setupGameProviders(this.selectedGame, this.selectedPlatform);
         } catch (error) {
             if (error instanceof R2Error) {
-                this.$emit("error", error);
+                this.$store.commit('error/handleError', error);
                 return;
             }
 

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -128,11 +128,10 @@
 		</modal>
 
         <CategoryFilterModal />
-        <LocalFileImportModal :visible="importingLocalMod" @close-modal="importingLocalMod = false" @error="showError($event)"/>
-        <DownloadModModal @error="showError($event)" />
+        <LocalFileImportModal :visible="importingLocalMod" @close-modal="importingLocalMod = false" />
+        <DownloadModModal />
 
         <router-view name="subview"
-                     @error="showError"
                      v-on:setting-invoked="handleSettingsCallbacks($event)" />
     </div>
 </template>
@@ -149,7 +148,7 @@ import ProfileInstallerProvider from '../providers/ror2/installing/ProfileInstal
 import PathResolver from '../r2mm/manager/PathResolver';
 import PreloaderFixer from '../r2mm/manager/PreloaderFixer';
 
-import LoggerProvider, { LogSeverity } from '../providers/ror2/logging/LoggerProvider';
+import { LogSeverity } from '../providers/ror2/logging/LoggerProvider';
 
 import Profile from '../model/Profile';
 import VersionNumber from '../model/VersionNumber';
@@ -215,10 +214,6 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 			return this.$store.state.localModList || [];
 		}
 
-		showError(error: R2Error) {
-			this.$emit("error", error);
-		}
-
 		closePreloaderFixModal() {
 			this.fixingPreloader = false;
 		}
@@ -226,7 +221,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 		async fixPreloader() {
 			const res = await PreloaderFixer.fix(this.activeGame);
 			if (res instanceof R2Error) {
-				this.showError(res);
+				this.$store.commit('error/handleError', res);
 			} else {
 				this.fixingPreloader = true;
 			}
@@ -277,12 +272,8 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                             this.showRor2IncorrectDirectoryModal = true;
                         }
                     } catch (e) {
-                        const err: Error = e as Error;
-                        this.showError(new R2Error(
-                            "Failed to change the game directory",
-                            err.message,
-                            null
-                        ));
+                        const err = R2Error.fromThrownValue(e, 'Failed to change the game directory');
+                        this.$store.commit('error/handleError', err);
                     }
                 }
             });
@@ -305,12 +296,8 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 							throw new Error("The selected executable is not gamelaunchhelper.exe");
 						}
 					} catch (e) {
-						const err: Error = e as Error;
-						this.showError(new R2Error(
-							"Failed to change the game directory",
-							err.message,
-							null
-						));
+						const err = R2Error.fromThrownValue(e, 'Failed to change the game directory');
+						this.$store.commit('error/handleError', err);
 					}
 				}
 			});
@@ -361,12 +348,8 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                             this.showSteamIncorrectDirectoryModal = true;
                         }
                     } catch (e) {
-				        const err: Error = e as Error;
-				        this.showError(new R2Error(
-				            "Failed to change the Steam directory",
-                            err.message,
-                            null
-                        ));
+                        const err = R2Error.fromThrownValue(e, 'Failed to change the Steam directory');
+                        this.$store.commit('error/handleError', err);
                     }
 				}
             });
@@ -379,21 +362,21 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 		async exportProfile() {
 			const exportErr = await ProfileModList.exportModListToFile(this.contextProfile!);
 			if (exportErr instanceof R2Error) {
-				this.showError(exportErr);
+				this.$store.commit('error/handleError', exportErr);
 			}
 		}
 
 		async exportProfileAsCode() {
 			const exportErr = await ProfileModList.exportModListAsCode(this.contextProfile!, (code: string, err: R2Error | null) => {
 				if (err !== null) {
-					this.showError(err);
+					this.$store.commit('error/handleError', err);
 				} else {
 					this.exportCode = code;
 					InteractionProvider.instance.copyToClipboard(code);
 				}
 			});
 			if (exportErr instanceof R2Error) {
-				this.showError(exportErr);
+				this.$store.commit('error/handleError', exportErr);
 			}
 		}
 
@@ -510,18 +493,18 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 
                     const profileErr = await ProfileInstallerProvider.instance.enableMod(mod, this.contextProfile!);
                     if (profileErr instanceof R2Error) {
-                        this.showError(profileErr);
+                        this.$store.commit('error/handleError', profileErr);
                         continue;
                     }
                     const update = await ProfileModList.updateMod(mod, this.contextProfile!, async (mod) => mod.enable());
                     if (update instanceof R2Error) {
-                        this.showError(update);
+                        this.$store.commit('error/handleError', update);
                     } else {
                         lastSuccessfulUpdate = update;
                     }
                 }
             } catch (e) {
-                this.showError(R2Error.fromThrownValue(e, "Error enabling mods"));
+                this.$store.commit('error/handleError', R2Error.fromThrownValue(e, "Error enabling mods"));
             } finally {
                 if (lastSuccessfulUpdate.length) {
                     await this.$store.dispatch("updateModList", lastSuccessfulUpdate);
@@ -553,8 +536,11 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                         await fs.writeFile(path.join(files[0], dataDirectoryOverrideFile), "");
                         InteractionProvider.instance.restartApp();
                     } else {
-                        this.showError(new R2Error("Selected directory is not empty", `Directory is not empty: ${files[0]}. Contains ${filesInDirectory.length} files.`, "Select an empty directory or create a new one."));
-                        return;
+                        this.$store.commit('error/handleError', new R2Error(
+                            "Selected directory is not empty",
+                            `Directory is not empty: ${files[0]}. Contains ${filesInDirectory.length} files.`,
+                            "Select an empty directory or create a new one."
+                        ));
                     }
                 }
             });
@@ -656,16 +642,21 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 			if (!(newModList instanceof R2Error)) {
 				await this.$store.dispatch("updateModList", newModList);
 			} else {
-                LoggerProvider.instance.Log(LogSeverity.ACTION_STOPPED, `Failed to retrieve local mod list\n-> ${newModList.message}`);
-                this.$emit('error', newModList);
+				this.$store.commit('error/handleError', {
+					error: newModList,
+					severity: LogSeverity.ACTION_STOPPED,
+					logMessage: `Failed to retrieve local mod list\n-> ${newModList.message}`
+				});
 			}
 			this.$store.commit("modFilters/reset");
 
 			InteractionProvider.instance.hookModInstallProtocol(async data => {
                 const combo: ThunderstoreCombo | R2Error = ThunderstoreCombo.fromProtocol(data, this.thunderstoreModList);
                 if (combo instanceof R2Error) {
-                    this.showError(combo);
-                    LoggerProvider.instance.Log(LogSeverity.ACTION_STOPPED, `${combo.name}\n-> ${combo.message}`);
+                    this.$store.commit('error/handleError', {
+                        error: combo,
+                        severity: LogSeverity.ACTION_STOPPED
+                    });
                     return;
                 }
                 DownloadModModal.downloadSpecific(this.activeGame, this.contextProfile!, combo, this.thunderstoreModList)
@@ -674,10 +665,12 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                         if (!(modList instanceof R2Error)) {
                             await this.$store.dispatch('updateModList', modList);
                         } else {
-                            this.showError(modList);
+                            this.$store.commit('error/handleError', modList);
                         }
                     })
-                    .catch(this.showError);
+                    .catch(
+                        (err: R2Error) => this.$store.commit('error/handleError', err)
+                    );
             });
 
 			this.isManagerUpdateAvailable();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex, { ActionContext } from 'vuex';
 
+import ErrorModule from './modules/ErrorModule';
 import ModalsModule from './modules/ModalsModule';
 import ModFilterModule from './modules/ModFilterModule';
 import ProfileModule from './modules/ProfileModule';
@@ -94,6 +95,7 @@ export const store = {
         }
     },
     modules: {
+        error: ErrorModule,
         modals: ModalsModule,
         modFilters: ModFilterModule,
         profile: ProfileModule,

--- a/src/store/modules/ErrorModule.ts
+++ b/src/store/modules/ErrorModule.ts
@@ -1,0 +1,40 @@
+import R2Error from "../../model/errors/R2Error";
+import LoggerProvider, { LogSeverity } from '../../providers/ror2/logging/LoggerProvider';
+
+interface State {
+    error: R2Error | null;
+}
+
+interface ErrorWithLogging {
+    error: R2Error;
+    severity: LogSeverity;
+    logMessage?: string;
+}
+
+export default {
+    namespaced: true,
+
+    state: (): State => ({
+        error: null,
+    }),
+
+    mutations: {
+        discardError: function(state: State): void {
+            state.error = null;
+        },
+
+        handleError: function(
+            state: State,
+            error: R2Error | ErrorWithLogging
+        ): void {
+            state.error = error instanceof R2Error ? error : error.error;
+
+            if (error instanceof R2Error) {
+                LoggerProvider.instance.Log(LogSeverity.ERROR, `[${error.name}]: ${error.message}`);
+            } else {
+                const msg = error.logMessage || `[${error.error.name}]: ${error.error.message}`;
+                LoggerProvider.instance.Log(error.severity, msg);
+            }
+        },
+    }
+}


### PR DESCRIPTION
- Main benefit is that emitted errors no longer need to bubble all the way to the App.vue to get shown. This should prevent situations where refactoring components distrupts the emit chain and leaves the error unshown
- Refactors the modal to a single standalone component
- Fixes the odd naming where R2Error's "name" was stored in variable called "message", and "message" was stored in "stack" variable
- Unifies some logged messages from "name\n-> message" format to "[name]: message" format