### PR TITLE
Simplification and Optimization of Mod Management UI

### DIFF
--- a/src/components/views/LocalModList/SearchAndSort.vue
+++ b/src/components/views/LocalModList/SearchAndSort.vue
@@ -15,6 +15,10 @@ import ManagerSettings from '../../../r2mm/manager/ManagerSettings';
 export default class SearchAndSort extends Vue {
     settings = new ManagerSettings();
 
+    toggleSortingDirection() {
+        this.direction = this.direction === SortDirection.STANDARD ? SortDirection.REVERSE : SortDirection.STANDARD;
+    }
+
     get order() {
         return this.$store.state.profile.order;
     }
@@ -96,22 +100,19 @@ export default class SearchAndSort extends Vue {
 
                 <div class="input-group margin-right">
                     <label for="local-sort-order" class="non-selectable">Sort</label>
-                    <select
-                        v-model="order"
-                        id="local-sort-order"
-                        class="select select--content-spacing margin-right margin-right--half-width">
-                        <option v-for="(option) in orderOptions" :key="`order-option-${option}`">
-                            {{option}}
-                        </option>
-                    </select>
-                    <select
-                        v-model="direction"
-                        id="local-sort-direction"
-                        class="select select--content-spacing">
-                        <option v-for="(option) in directionOptions" :key="`direction-option-${option}`">
-                            {{option}}
-                        </option>
-                    </select>
+                    <div class="sort-container"> <!-- This div wraps the selector and the icon -->
+                        <select
+                            v-model="order"
+                            id="local-sort-order"
+                            class="select select--content-spacing margin-right margin-right--half-width">
+                            <option v-for="(option) in orderOptions" :key="`order-option-${option}`">
+                                {{ option }}
+                            </option>
+                        </select>
+                        <div class="icon-container" @click="toggleSortingDirection" :style="{ cursor: 'pointer' }"> <!-- New div to center the icon vertically -->
+                            <i :class="['fas', 'fa-caret-up', 'sorting-icon', { 'rotated': direction === 'Reverse' }]" class="icon--margin-right"></i>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="input-group">

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -481,3 +481,37 @@ code {
     border-radius: 8px;
     background-color: rgba(0, 0, 0, 0.15);
 }
+
+.category-filter:focus {
+    color: #fff;
+}
+
+.category-filter-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.category-filter {
+    align-self: flex-end; /* This aligns the button to the right */
+    margin-left: auto; /* This also pushes the button to the right */
+}
+
+.sort-container {
+    display: flex;
+    align-items: center; /* This centers the selector and the icon vertically */
+}
+
+.icon-container {
+    display: flex;
+    align-items: center; /* This centers the icon within the div */
+    margin-left: 0.5em;
+}
+
+.sorting-icon {
+    transition: transform 0.3s ease;
+}
+
+.rotated {
+    transform: rotate(180deg);
+}


### PR DESCRIPTION
In an effort to streamline the mod management interface as outlined in [this thread](https://github.com/ebkr/r2modmanPlus/discussions/1223), I've implemented a set of UI enhancements focusing on mod sorting and category filtering.

### Changes:
- **SearchAndSort.vue** & **OnlineModView.vue**: Replaced the "Standard / Reverse" button with a simple caret icon that points up for "Standard" and down for "Reverse". This change simplifies the UI and saves space if you ever need to add more options. Added an animation for the caret in `custom.scss` to rotate upon toggling, enhancing the visual feedback.
  
- **OnlineModView.vue**: Updated the "Filter Categories" UI by replacing the text button with a FontAwesome icon, improving the interface's overall aesthetic and consistency. Fixed a visibility issue where the button's "focus" state significantly reduced contrast between text and background, hindering readability.

### Additional Enhancements:
- **custom.scss**: Introduced animation for the sorting direction toggle, providing a smoother and more intuitive user interaction. Enhanced cursor visibility with a conditional "not-allowed" style, indicating when the action is disabled.

### Visuals:
- Caret icon for sorting direction: ![Sorting Direction Toggle](https://github.com/ebkr/r2modmanPlus/assets/90518536/e99fd60d-2537-4734-8572-f6b672cbb3d5)
- New filter categories icon: ![Filter Categories Icon](https://github.com/ebkr/r2modmanPlus/assets/90518536/60370c97-ffe3-44fc-8e4d-087cdb1c7c43)


These updates aim to refine the user experience by making mod management more intuitive and visually appealing.
