### PR TITLE
Move localModList from main Vuex store to ProfileModule

### DIFF
--- a/src/components/importing/LocalFileImportModal.vue
+++ b/src/components/importing/LocalFileImportModal.vue
@@ -297,7 +297,7 @@ export default class LocalFileImportModal extends Vue {
                 this.showError(updatedModListResult);
                 return;
             }
-            await this.$store.dispatch("updateModList", updatedModListResult);
+            await this.$store.dispatch("profile/updateModList", updatedModListResult);
             this.emitClose();
         });
 

--- a/src/components/mixins/UtilityMixin.vue
+++ b/src/components/mixins/UtilityMixin.vue
@@ -51,7 +51,7 @@ export default class UtilityMixin extends Vue {
         const modList = await ProfileModList.getModList(profile);
 
         if (!(modList instanceof R2Error)) {
-            this.$store.dispatch("updateModList", modList);
+            await this.$store.dispatch("profile/updateModList", modList);
         }
     }
 

--- a/src/components/navigation/NavigationMenu.vue
+++ b/src/components/navigation/NavigationMenu.vue
@@ -91,7 +91,7 @@ export default class NavigationMenu extends Vue {
     }
 
     get localModCount(): number {
-        return (this.$store.state.localModList || []).length;
+        return this.$store.state.profile.modList.length;
     }
 
     getTagLinkClasses(routeNames: string[]) {

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -87,7 +87,7 @@ import UtilityMixin from '../mixins/UtilityMixin.vue';
         private activeGame!: Game;
 
         get localModList(): ManifestV2[] {
-            return this.$store.state.localModList || [];
+            return this.$store.state.profile.modList;
         }
 
         get appName(): string {
@@ -247,7 +247,7 @@ import UtilityMixin from '../mixins/UtilityMixin.vue';
                 'Update all mods',
                 'Quickly update every installed mod to their latest versions.',
                 async () => {
-                    const outdatedMods = this.$store.getters.localModsWithUpdates;
+                    const outdatedMods = this.$store.getters['profile/modsWithUpdates'];
                     if (outdatedMods.length === 1) {
                         return "1 mod has an update available";
                     }

--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -81,7 +81,7 @@
                         <p>The following mods will be downloaded and installed:</p>
                         <br/>
                         <ul class="list">
-                            <li class="list-item" v-for='(key, index) in $store.getters.localModsWithUpdates'
+                            <li class="list-item" v-for='(key, index) in $store.getters["profile/modsWithUpdates"]'
                                 :key='`to-update-${index}-${key.getVersion().getFullName()}`'>
                                 {{key.getVersion().getName()}} will be updated to: {{key.getVersion().getVersionNumber().toString()}}
                             </li>
@@ -299,7 +299,7 @@ let assignId = 0;
                     this.downloadingMod = false;
                     const modList = await ProfileModList.getModList(this.contextProfile!);
                     if (!(modList instanceof R2Error)) {
-                        await this.$store.dispatch('updateModList', modList);
+                        await this.$store.dispatch('profile/updateModList', modList);
                         const err = await ConflictManagementProvider.instance.resolveConflicts(modList, this.contextProfile!);
                         if (err instanceof R2Error) {
                             this.$emit('error', err);
@@ -360,7 +360,7 @@ let assignId = 0;
                         this.downloadingMod = false;
                         const modList = await ProfileModList.getModList(this.contextProfile!);
                         if (!(modList instanceof R2Error)) {
-                            await this.$store.dispatch('updateModList', modList);
+                            await this.$store.dispatch('profile/updateModList', modList);
                             const err = await ConflictManagementProvider.instance.resolveConflicts(modList, this.contextProfile!);
                             if (err instanceof R2Error) {
                                 this.$emit('error', err);

--- a/src/components/views/InstalledModView.vue
+++ b/src/components/views/InstalledModView.vue
@@ -56,11 +56,11 @@ export default class InstalledModView extends Vue {
     }
 
     get localModList(): ManifestV2[] {
-        return this.$store.state.localModList;
+        return this.$store.state.profile.modList;
     }
 
     get numberOfModsWithUpdates(): number {
-        return this.$store.getters.localModsWithUpdates.length;
+        return this.$store.getters['profile/modsWithUpdates'].length;
     }
 };
 </script>

--- a/src/components/views/LocalModList.vue
+++ b/src/components/views/LocalModList.vue
@@ -121,7 +121,7 @@ import SearchAndSort from './LocalModList/SearchAndSort.vue';
         }
 
         async updateModListAfterChange(updatedList: ManifestV2[]) {
-            await this.$store.dispatch("updateModList", updatedList);
+            await this.$store.dispatch('profile/updateModList', updatedList);
 
             const err = await ConflictManagementProvider.instance.resolveConflicts(updatedList, this.contextProfile!);
             if (err instanceof R2Error) {
@@ -130,11 +130,11 @@ import SearchAndSort from './LocalModList/SearchAndSort.vue';
         }
 
         getDependantList(mod: ManifestV2): Set<ManifestV2> {
-            return Dependants.getDependantList(mod, this.$store.state.localModList);
+            return Dependants.getDependantList(mod, this.$store.state.profile.modList);
         }
 
         getDependencyList(mod: ManifestV2): Set<ManifestV2> {
-            return Dependants.getDependencyList(mod, this.$store.state.localModList);
+            return Dependants.getDependencyList(mod, this.$store.state.profile.modList);
         }
 
         async performUninstallMod(mod: ManifestV2, updateModList=true): Promise<ManifestV2[] | R2Error> {

--- a/src/components/views/LocalModList/DisableModModal.vue
+++ b/src/components/views/LocalModList/DisableModModal.vue
@@ -14,7 +14,7 @@ export default class DisableModModal extends Vue {
     modBeingDisabled: string | null = null;
 
     get dependants() {
-        return Dependants.getDependantList(this.mod, this.$store.state.localModList);
+        return Dependants.getDependantList(this.mod, this.$store.state.profile.modList);
     }
 
     get isLocked(): boolean {

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -40,7 +40,7 @@ export default class LocalModCard extends Vue {
     }
 
     get localModList(): ManifestV2[] {
-        return this.$store.state.localModList;
+        return this.$store.state.profile.modList;
     }
 
     get tsMod() {
@@ -76,7 +76,7 @@ export default class LocalModCard extends Vue {
     }
 
     async disableMod() {
-        const dependants = Dependants.getDependantList(this.mod, this.$store.state.localModList);
+        const dependants = Dependants.getDependantList(this.mod, this.localModList);
 
         for (const mod of dependants) {
             if (mod.isEnabled()) {

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -91,7 +91,7 @@ export default class OnlineModList extends Vue {
     private funkyMode: boolean = false;
 
     get localModList(): ManifestV2[] {
-        return this.$store.state.localModList;
+        return this.$store.state.profile.modList;
     }
 
     get deprecationMap(): Map<string, boolean> {

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -102,7 +102,7 @@ export default class OnlineModView extends Vue {
     thunderstoreSearchFilter = "";
 
     get localModList(): ManifestV2[] {
-        return this.$store.state.localModList;
+        return this.$store.state.profile.modList;
     }
 
     get thunderstoreModList(): ThunderstoreMod[] {

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -212,7 +212,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
         }
 
 		get localModList(): ManifestV2[] {
-			return this.$store.state.localModList || [];
+			return this.$store.state.profile.modList;
 		}
 
 		showError(error: R2Error) {
@@ -524,7 +524,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                 this.showError(R2Error.fromThrownValue(e, "Error enabling mods"));
             } finally {
                 if (lastSuccessfulUpdate.length) {
-                    await this.$store.dispatch("updateModList", lastSuccessfulUpdate);
+                    await this.$store.dispatch('profile/updateModList', lastSuccessfulUpdate);
                 }
             }
 
@@ -618,7 +618,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                 case "DisableAll":
                     await this.$store.dispatch(
                         "profile/disableModsFromActiveProfile",
-                        {mods: this.$store.state.localModList}
+                        {mods: this.localModList}
                     );
                     await this.$router.push({name: "manager.installed"});
                     break;
@@ -635,9 +635,9 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                     CacheUtil.clean();
                     break;
                 case "RefreshedThunderstorePackages":
-                    ProfileModList.getModList(this.contextProfile!).then(value => {
+                    ProfileModList.getModList(this.contextProfile!).then(async value => {
                         if (!(value instanceof R2Error)) {
-                            this.$store.dispatch("updateModList", value);
+                            await this.$store.dispatch("profile/updateModList", value);
                         }
                     });
                     break;
@@ -654,7 +654,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 			this.launchParametersModel = this.settings.getContext().gameSpecific.launchParameters;
 			const newModList: ManifestV2[] | R2Error = await ProfileModList.getModList(this.contextProfile!);
 			if (!(newModList instanceof R2Error)) {
-				await this.$store.dispatch("updateModList", newModList);
+				await this.$store.dispatch('profile/updateModList', newModList);
 			} else {
                 LoggerProvider.instance.Log(LogSeverity.ACTION_STOPPED, `Failed to retrieve local mod list\n-> ${newModList.message}`);
                 this.$emit('error', newModList);
@@ -672,7 +672,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                     .then(async value => {
                         const modList = await ProfileModList.getModList(this.contextProfile!);
                         if (!(modList instanceof R2Error)) {
-                            await this.$store.dispatch('updateModList', modList);
+                            await this.$store.dispatch('profile/updateModList', modList);
                         } else {
                             this.showError(modList);
                         }

--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -444,7 +444,7 @@ export default class Profiles extends Vue {
     }
 
     async setProfileAndContinue() {
-        await this.$store.dispatch('updateModList', []);
+        await this.$store.dispatch('profile/updateModList', []);
         await settings.setProfile(Profile.getActiveProfile().getProfileName());
         await this.$router.push({name: 'manager.installed'});
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,9 +5,7 @@ import ModalsModule from './modules/ModalsModule';
 import ModFilterModule from './modules/ModFilterModule';
 import ProfileModule from './modules/ProfileModule';
 import { FolderMigration } from '../migrations/FolderMigration';
-import ManifestV2 from '../model/ManifestV2';
 import ThunderstoreMod from '../model/ThunderstoreMod';
-import ThunderstoreDownloaderProvider from "../providers/ror2/downloading/ThunderstoreDownloaderProvider";
 import ThunderstorePackages from '../r2mm/data/ThunderstorePackages';
 
 Vue.use(Vuex);
@@ -17,7 +15,6 @@ export interface State {
     deprecatedMods: Map<string, boolean>;
     dismissedUpdateAll: boolean;
     isMigrationChecked: boolean;
-    localModList: ManifestV2[];
     thunderstoreModList: ThunderstoreMod[];
 }
 
@@ -30,7 +27,6 @@ type Context = ActionContext<State, State>;
 
 export const store = {
     state: {
-        localModList: [],
         thunderstoreModList: [],
         dismissedUpdateAll: false,
         isMigrationChecked: false,
@@ -38,9 +34,6 @@ export const store = {
         deprecatedMods: new Map<string, boolean>(),
     },
     actions: {
-        updateModList({ commit }: Context, modList: ManifestV2[]) {
-            commit('setLocalModList', modList);
-        },
         updateThunderstoreModList({ commit }: Context, modList: ThunderstoreMod[]) {
             commit('setThunderstoreModList', modList);
             commit('setDeprecatedMods', modList);
@@ -66,9 +59,6 @@ export const store = {
         }
     },
     mutations: {
-        setLocalModList(state: State, list: ManifestV2[]) {
-            state.localModList = list;
-        },
         setThunderstoreModList(state: State, list: ThunderstoreMod[]) {
             state.thunderstoreModList = list;
         },
@@ -85,14 +75,7 @@ export const store = {
             state.deprecatedMods = ThunderstorePackages.getDeprecatedPackageMap();
         }
     },
-    getters: {
-        localModsWithUpdates(state: State) {
-            return ThunderstoreDownloaderProvider.instance.getLatestOfAllToUpdate(
-                state.localModList,
-                state.thunderstoreModList
-            );
-        }
-    },
+    getters: {},
     modules: {
         modals: ModalsModule,
         modFilters: ModFilterModule,


### PR DESCRIPTION
"local" in the variable name refers to locally installed mods, i.e. the mods currently included in the profile. It therefore makes sense for the mod list to be part of the ProfileModule.