### PR TITLE
Fix invalid VotV game definition and invalid UE4SS-settings link behavior

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -569,7 +569,7 @@ export default class GameManager {
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, []),
         new Game(
             "Voices of the Void", "VotV", "VotV",
-            "", ["VotV-Win64-Shipping.exe"], "VotV",
+            "", ["VotV.exe"], "VotV",
             "https://thunderstore.io/c/voices-of-the-void/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.OTHER)], "VotV.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.SHIMLOADER, ["votv"]),

--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -84,11 +84,8 @@ export default class ModLinker {
         }
 
         if (game.packageLoader == PackageLoader.SHIMLOADER) {
-            if (["ue4ss.dll", "dwmapi.dll"].indexOf(lowercased) > -1) {
+            if (["ue4ss.dll", "dwmapi.dll", "ue4ss-settings.ini"].indexOf(lowercased) > -1) {
                 return path.join(installDirectory, game.dataFolderName, "Binaries", "Win64");
-            }
-            if (lowercased == "ue4ss-settings.ini") {
-                return installDirectory;
             }
             return null;
         } else {


### PR DESCRIPTION
- Fix the VotV game definition to target the correct top-level game binary.
- Fix invalid UE4SS-settings.ini runtime file linkage. Prior to this change this file was incorrectly moved into the root-most game dir, instead of alongside the other UE4SS and shimloader files within `GAME/Binaries/Win64`.