### PR TITLE
Add `ProfileLinker` abstract class + Shimloader implementation

### DIFF
--- a/src/installers/ProfileLinker.ts
+++ b/src/installers/ProfileLinker.ts
@@ -1,6 +1,7 @@
 import Profile from "../model/Profile";
 import ManifestV2 from "../model/ManifestV2";
 import { InstallArgs } from "./PackageInstaller";
+import Game from "../model/game/Game";
 
 export type LinkArgs = {
     profile: Profile;
@@ -8,6 +9,6 @@ export type LinkArgs = {
 };
 
 export abstract class ProfileLinker {
-    abstract perform(profile: Profile, gameDir: string): Promise<string[]>;
+    abstract perform(profile: Profile, game: Game, gameDir: string): Promise<string[]>;
     // abstract unwind(args: LinkArgs): Promise<void>; <-- TODO
 }

--- a/src/installers/ProfileLinker.ts
+++ b/src/installers/ProfileLinker.ts
@@ -1,0 +1,13 @@
+import Profile from "../model/Profile";
+import ManifestV2 from "../model/ManifestV2";
+import { InstallArgs } from "./PackageInstaller";
+
+export type LinkArgs = {
+    profile: Profile;
+    installDir: string,
+};
+
+export abstract class ProfileLinker {
+    abstract perform(profile: Profile, gameDir: string): Promise<string[]>;
+    // abstract unwind(args: LinkArgs): Promise<void>; <-- TODO
+}

--- a/src/installers/ProfileLinker.ts
+++ b/src/installers/ProfileLinker.ts
@@ -3,11 +3,6 @@ import ManifestV2 from "../model/ManifestV2";
 import { InstallArgs } from "./PackageInstaller";
 import Game from "../model/game/Game";
 
-export type LinkArgs = {
-    profile: Profile;
-    installDir: string,
-};
-
 export abstract class ProfileLinker {
     abstract perform(profile: Profile, game: Game, gameDir: string): Promise<string[]>;
     // abstract unwind(args: LinkArgs): Promise<void>; <-- TODO

--- a/src/installers/registry.ts
+++ b/src/installers/registry.ts
@@ -4,7 +4,7 @@ import { BepInExInstaller } from "./BepInExInstaller";
 import { GodotMLInstaller } from "./GodotMLInstaller";
 import { MelonLoaderInstaller } from "./MelonLoaderInstaller";
 import { InstallRuleInstaller } from "./InstallRuleInstaller";
-import { ShimloaderInstaller, ShimloaderPluginInstaller } from "./ShimloaderInstaller";
+import { ShimloaderInstaller, ShimloaderPluginInstaller, ShimloaderLinker } from "./ShimloaderInstaller";
 
 
 const _PackageInstallers = {
@@ -17,6 +17,7 @@ const _PackageInstallers = {
 }
 
 const _ProfileLinkers = {
+    "shimloader-linker": new ShimloaderLinker(),
 }
 
 export type PackageInstallerId = keyof typeof _PackageInstallers;

--- a/src/installers/registry.ts
+++ b/src/installers/registry.ts
@@ -1,7 +1,8 @@
+import { PackageInstaller } from "./PackageInstaller";
+import { ProfileLinker } from "./ProfileLinker";
 import { BepInExInstaller } from "./BepInExInstaller";
 import { GodotMLInstaller } from "./GodotMLInstaller";
 import { MelonLoaderInstaller } from "./MelonLoaderInstaller";
-import { PackageInstaller } from "./PackageInstaller";
 import { InstallRuleInstaller } from "./InstallRuleInstaller";
 import { ShimloaderInstaller, ShimloaderPluginInstaller } from "./ShimloaderInstaller";
 
@@ -15,5 +16,11 @@ const _PackageInstallers = {
     "shimloader-plugin": new ShimloaderPluginInstaller(),
 }
 
+const _ProfileLinkers = {
+}
+
 export type PackageInstallerId = keyof typeof _PackageInstallers;
 export const PackageInstallers: {[key in PackageInstallerId]: PackageInstaller} = _PackageInstallers;
+
+export type ProfileLinkerId = keyof typeof _ProfileLinkers;
+export const ProfileLinkers: {[key in ProfileLinkerId]: ProfileLinker} = _ProfileLinkers;

--- a/src/model/installing/PackageLoader.ts
+++ b/src/model/installing/PackageLoader.ts
@@ -1,4 +1,4 @@
-import { PackageInstallerId, PackageInstallers } from "../../installers/registry";
+import { PackageInstallerId, PackageInstallers, ProfileLinkerId } from "../../installers/registry";
 import Game from "../game/Game";
 
 export enum PackageLoader {
@@ -26,6 +26,13 @@ export function GetInstallerIdForLoader(loader: PackageLoader): PackageInstaller
 export function GetInstallerIdForPlugin(loader: PackageLoader): PackageInstallerId | null {
     switch (loader) {
         case PackageLoader.SHIMLOADER: return "shimloader-plugin";
+    }
+
+    return null;
+}
+
+export function GetLinkerIdForLoader(loader: PackageLoader): ProfileLinkerId | null {
+    switch (loader) {
     }
 
     return null;

--- a/src/model/installing/PackageLoader.ts
+++ b/src/model/installing/PackageLoader.ts
@@ -33,6 +33,7 @@ export function GetInstallerIdForPlugin(loader: PackageLoader): PackageInstaller
 
 export function GetLinkerIdForLoader(loader: PackageLoader): ProfileLinkerId | null {
     switch (loader) {
+        case PackageLoader.SHIMLOADER: return "shimloader-linker";
     }
 
     return null;

--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -11,7 +11,8 @@ import ManagerInformation from '../../_managerinf/ManagerInformation';
 import Game from '../../model/game/Game';
 import LinuxGameDirectoryResolver from './linux/GameDirectoryResolver';
 import FileTree from '../../model/file/FileTree';
-import { PackageLoader } from "../../model/installing/PackageLoader";
+import { GetLinkerIdForLoader, PackageLoader } from "../../model/installing/PackageLoader";
+import { ProfileLinkers } from '../../installers/registry';
 
 export default class ModLinker {
 
@@ -32,7 +33,15 @@ export default class ModLinker {
         if (gameDirectory instanceof R2Error) {
             return gameDirectory;
         }
-        return this.performLink(profile, game, gameDirectory);
+
+        const linkerId = GetLinkerIdForLoader(game.packageLoader);
+        if (linkerId == null) {
+            // Default to this behavior if there's no linker associated with this loader.
+            return this.performLink(profile, game, gameDirectory);
+        }
+
+        const linker = ProfileLinkers[linkerId];
+        return linker.perform(profile, gameDirectory);
     }
 
     /**

--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -41,7 +41,7 @@ export default class ModLinker {
         }
 
         const linker = ProfileLinkers[linkerId];
-        return linker.perform(profile, gameDirectory);
+        return linker.perform(profile, game, gameDirectory);
     }
 
     /**


### PR DESCRIPTION
`ProfileLinker` allows for an implementee to control exactly how the profile is linked to the game at runtime, with the objective being to ameliorate the awful hacks present in ModLinker.ts.