### PR TITLE
Move resetting mod list back to Profiles.vue

### DIFF
--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -638,10 +638,6 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
             // accesses visibleModList from Vuex store.
             await this.$store.dispatch('profile/loadOrderingSettings');
 
-            // Reset the mod list to prevent the previous profile's list
-            // flashing on the screen while a new profile's list is loaded.
-            await this.$store.dispatch('profile/updateModList', []);
-
             // Used by OnlineModView, called here for consistency.
             this.$store.commit('modFilters/reset');
         }

--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -422,6 +422,10 @@ export default class Profiles extends Vue {
     }
 
     async setProfileAndContinue() {
+        // Reset the mod list to prevent the previous profile's list
+        // flashing on the screen while a new profile's list is loaded.
+        await this.$store.dispatch('profile/updateModList', []);
+
         await settings.setProfile(Profile.getActiveProfile().getProfileName());
         await this.$router.push({name: 'manager.installed'});
     }


### PR DESCRIPTION
Commit b17d878 moved this bit of code from Profiles.vue to Manager.vue since it makes for the latter to handle the state manipulation that affects its own contents.

However, Vue doesn't await beforeCreate(), which opened up a race condition where it's technically possible for the updating of the mod list with an empty array to complete last, causing the view to render an empty state.

While placing this bit of code in Profiles.vue is not ideal, at least it works since the method is awaited there.