### PR TITLE
Handle errors thrown by profile export zip creation

### DIFF
--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -251,7 +251,12 @@ export default class ProfileModList {
         if (exportBuilder instanceof R2Error) {
             return exportBuilder;
         } else {
-            await exportBuilder.createZip(exportPath);
+            try {
+                await exportBuilder.createZip(exportPath);
+            } catch (e) {
+                return R2Error.fromThrownValue(e);
+            }
+
             const profileBuffer = '#r2modman\n' + (await fs.base64FromZip(exportPath));
             try {
                 const storageResponse = await ProfileApiClient.createProfile(profileBuffer);


### PR DESCRIPTION
One identified source for errors when exporting a profile as a code is when the zip file is already open in another app. This doesn't affect export as a file operations, since the zip used there is timestamped. I assume the zip in code export is not to avoid bloating the data directory with multiple archives of the same profile over time.