### PR TITLE
Add MS Store version of Bomb Rush Cyberfunk

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -492,8 +492,10 @@ export default class GameManager {
             "Bomb Rush Cyberfunk", "BombRushCyberfunk", "BombRushCyberfunk",
             "BombRushCyberfunk", ["Bomb Rush Cyberfunk.exe"], "Bomb Rush Cyberfunk_Data",
             "https://thunderstore.io/c/bomb-rush-cyberfunk/api/v1/package/", EXCLUSIONS,
-            [new StorePlatformMetadata(StorePlatform.STEAM, "1353230")], "BombRushCyberfunk.jpg",
-            GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["brc"]),
+            [
+                new StorePlatformMetadata(StorePlatform.STEAM, "1353230"),
+                new StorePlatformMetadata(StorePlatform.XBOX_GAME_PASS, "TeamReptile.BombRushCyberfunk")
+            ], "BombRushCyberfunk.jpg", GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["brc"]),
 
         new Game(
             "TouhouLostBranchOfLegend", "TouhouLostBranchOfLegend", "TouhouLostBranchOfLegend",


### PR DESCRIPTION
I don't actually own the MS Store version of the game so I can't test this.

Additionally, the game is *not* on GamePass; it's on the Microsoft Store.  Does that affect the configuration?

I asked someone who has the MS Store version to get some info about the installed package.

```
PS C:\Users\usernameredacted> Get-AppxPackage | ? {$_.name -like '*Cyberfunk*'}

Name              : TeamReptile.BombRushCyberfunk
Publisher         : CN=9E62FE55-F651-4B2F-939E-E0C77E2B64FF
Architecture      : X64
ResourceId        :
Version           : 1.0.19991.0
PackageFullName   : TeamReptile.BombRushCyberfunk_1.0.19991.0_x64__e5dfpr1e2tmgw
InstallLocation   : C:\Program Files\WindowsApps\TeamReptile.BombRushCyberfunk_1.0.19991.0_x64__e5dfpr1e2tmgw
IsFramework       : False
PackageFamilyName : TeamReptile.BombRushCyberfunk_e5dfpr1e2tmgw
PublisherId       : e5dfpr1e2tmgw
IsResourcePackage : False
IsBundle          : False
IsDevelopmentMode : False
NonRemovable      : False
Dependencies      : {Microsoft.VCLibs.140.00.UWPDesktop_14.0.33519.0_x64__8wekyb3d8bbwe}
IsPartiallyStaged : False
SignatureKind     : Store
Status            : Ok
```