### PR TITLE
Fix Thunderstore subdomain change

### DIFF
--- a/src/assets/data/games.json
+++ b/src/assets/data/games.json
@@ -357,7 +357,7 @@
         "internalFolderName": "SubnauticaBZ",
         "dataFolderName": "SubnauticaZero_Data",
         "settingsIdentifier": "SubnauticaBZ",
-        "packageIndex": "https://thunderstore.io/c/belowzero/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/subnautica-below-zero/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "SubnauticaZero",
         "exeNames": [

--- a/src/assets/data/games.json
+++ b/src/assets/data/games.json
@@ -146,7 +146,7 @@
         "internalFolderName": "AGAINST",
         "dataFolderName": "AGAINST_Data",
         "settingsIdentifier": "AGAINST",
-        "packageIndex": "https://against.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/against/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "AGAINST_steam",
         "exeNames": [
@@ -357,7 +357,7 @@
         "internalFolderName": "SubnauticaBZ",
         "dataFolderName": "SubnauticaZero_Data",
         "settingsIdentifier": "SubnauticaBZ",
-        "packageIndex": "https://belowzero.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/belowzero/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "SubnauticaZero",
         "exeNames": [
@@ -583,7 +583,7 @@
         "internalFolderName": "BONEWORKS",
         "dataFolderName": "BONEWORKS_Data",
         "settingsIdentifier": "BONEWORKS",
-        "packageIndex": "https://boneworks.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/boneworks/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "BONEWORKS\\BONEWORKS",
         "exeNames": [
@@ -738,7 +738,7 @@
         "internalFolderName": "CatsAreLiquidABP",
         "dataFolderName": "CaL-ABP-Windows_Data",
         "settingsIdentifier": "CatsAreLiquidABP",
-        "packageIndex": "https://cats-are-liquid.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/cats-are-liquid/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Cats are Liquid - A Better Place",
         "exeNames": [
@@ -868,7 +868,7 @@
         "internalFolderName": "CoreKeeper",
         "dataFolderName": "CoreKeeper_Data",
         "settingsIdentifier": "CoreKeeper",
-        "packageIndex": "https://core-keeper.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/core-keeper/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Core Keeper",
         "exeNames": [
@@ -1000,7 +1000,7 @@
         "internalFolderName": "DysonSphereProgram",
         "dataFolderName": "DSPGAME_Data",
         "settingsIdentifier": "DysonSphereProgram",
-        "packageIndex": "https://dsp.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/dsp/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Dyson Sphere Program",
         "exeNames": [
@@ -1139,7 +1139,7 @@
         "internalFolderName": "ForTheKing",
         "dataFolderName": "FTK_Data",
         "settingsIdentifier": "ForTheKing",
-        "packageIndex": "https://for-the-king.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/for-the-king/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "For The King",
         "exeNames": [
@@ -1270,7 +1270,7 @@
         "internalFolderName": "GTFO",
         "dataFolderName": "GTFO_Data",
         "settingsIdentifier": "GTFO",
-        "packageIndex": "https://gtfo.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/gtfo/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "GTFO",
         "exeNames": [
@@ -1342,7 +1342,7 @@
         "internalFolderName": "H3VR",
         "dataFolderName": "h3vr_Data",
         "settingsIdentifier": "H3VR",
-        "packageIndex": "https://h3vr.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/h3vr/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "H3VR",
         "exeNames": [
@@ -1499,7 +1499,7 @@
         "internalFolderName": "HOTDS",
         "dataFolderName": "dyingsun_Data",
         "settingsIdentifier": "HOTDS",
-        "packageIndex": "https://hotds.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/hotds/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "DyingSun",
         "exeNames": [
@@ -1566,7 +1566,7 @@
         "internalFolderName": "Inscryption",
         "dataFolderName": "Inscryption_Data",
         "settingsIdentifier": "Inscryption",
-        "packageIndex": "https://inscryption.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/inscryption/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Inscryption",
         "exeNames": [
@@ -1630,7 +1630,7 @@
         "internalFolderName": "LethalLeagueBlaze",
         "dataFolderName": "LLBlaze_Data",
         "settingsIdentifier": "LethalLeagueBlaze",
-        "packageIndex": "https://lethal-league-blaze.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/lethal-league-blaze/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "LLBlaze",
         "exeNames": [
@@ -1697,7 +1697,7 @@
         "internalFolderName": "Mechanica",
         "dataFolderName": "Mechanica_Data",
         "settingsIdentifier": "Mechanica",
-        "packageIndex": "https://mechanica.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/mechanica/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Mechanica",
         "exeNames": [
@@ -1761,7 +1761,7 @@
         "internalFolderName": "Muck",
         "dataFolderName": "Muck_Data",
         "settingsIdentifier": "Muck",
-        "packageIndex": "https://muck.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/muck/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Muck",
         "exeNames": [
@@ -1826,7 +1826,7 @@
         "internalFolderName": "NASB",
         "dataFolderName": "Nickelodeon All-Star Brawl_Data",
         "settingsIdentifier": "NASB",
-        "packageIndex": "https://nasb.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/nasb/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Nickelodeon All-Star Brawl",
         "exeNames": [
@@ -1912,7 +1912,7 @@
         "internalFolderName": "NearlyDead",
         "dataFolderName": "Nearly Dead_Data",
         "settingsIdentifier": "NearlyDead",
-        "packageIndex": "https://nearly-dead.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/nearly-dead/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Nearly Dead",
         "exeNames": [
@@ -1980,7 +1980,7 @@
         "internalFolderName": "Titanfall2",
         "dataFolderName": "",
         "settingsIdentifier": "Titanfall2",
-        "packageIndex": "https://northstar.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/northstar/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Titanfall2",
         "exeNames": [
@@ -2034,7 +2034,7 @@
         "internalFolderName": "OutwardDe",
         "dataFolderName": "Outward Definitive Edition_Data",
         "settingsIdentifier": "OutwardDe",
-        "packageIndex": "https://outward.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/outward/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Outward/Outward_Defed",
         "exeNames": [
@@ -2165,7 +2165,7 @@
         "internalFolderName": "PotionCraft",
         "dataFolderName": "Potion Craft_Data",
         "settingsIdentifier": "PotionCraft",
-        "packageIndex": "https://potion-craft.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/potion-craft/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Potion Craft",
         "exeNames": [
@@ -2421,7 +2421,7 @@
         "internalFolderName": "RogueTower",
         "dataFolderName": "Rogue Tower_Data",
         "settingsIdentifier": "RogueTower",
-        "packageIndex": "https://rogue-tower.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/rogue-tower/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Rogue Tower",
         "exeNames": [
@@ -2485,7 +2485,7 @@
         "internalFolderName": "ROUNDS",
         "dataFolderName": "Rounds_Data",
         "settingsIdentifier": "ROUNDS",
-        "packageIndex": "https://rounds.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/rounds/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "ROUNDS",
         "exeNames": [
@@ -2617,7 +2617,7 @@
         "internalFolderName": "Starsand",
         "dataFolderName": "Starsand_Data",
         "settingsIdentifier": "Starsand",
-        "packageIndex": "https://starsand.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/starsand/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Starsand",
         "exeNames": [
@@ -2689,7 +2689,7 @@
         "internalFolderName": "Subnautica",
         "dataFolderName": "Subnautica_Data",
         "settingsIdentifier": "Subnautica",
-        "packageIndex": "https://subnautica.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/subnautica/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Subnautica",
         "exeNames": [
@@ -2766,7 +2766,7 @@
         "internalFolderName": "TaleSpire",
         "dataFolderName": "TaleSpire_Data",
         "settingsIdentifier": "TaleSpire",
-        "packageIndex": "https://talespire.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/talespire/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "TaleSpire",
         "exeNames": [
@@ -2837,7 +2837,7 @@
         "internalFolderName": "Timberborn",
         "dataFolderName": "Timberborn_Data",
         "settingsIdentifier": "Timberborn",
-        "packageIndex": "https://timberborn.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/timberborn/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Timberborn",
         "exeNames": [
@@ -2913,7 +2913,7 @@
         "internalFolderName": "TABS",
         "dataFolderName": "TotallyAccurateBattleSimulator_Data",
         "settingsIdentifier": "TotallyAccurateBattleSimulator",
-        "packageIndex": "https://totally-accurate-battle-simulator.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/totally-accurate-battle-simulator/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Totally Accurate Battle Simulator",
         "exeNames": [
@@ -3105,7 +3105,7 @@
         "internalFolderName": "Valheim",
         "dataFolderName": "valheim_server_Data",
         "settingsIdentifier": "ValheimServer",
-        "packageIndex": "https://valheim.thunderstore.io/api/v1/package/",
+        "packageIndex": "https://thunderstore.io/c/valheim/api/v1/package/",
         "exclusionsUrl": "https://raw.githubusercontent.com/ebkr/r2modmanPlus/master/modExclusions.md",
         "steamFolderName": "Valheim dedicated server",
         "exeNames": [

--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -219,7 +219,7 @@ export default class GameManager {
 
         new Game('Subnautica: Below Zero', 'SubnauticaBZ', 'SubnauticaBZ',
             'SubnauticaZero', ['SubnauticaZero.exe'], 'SubnauticaZero_Data',
-            'https://thunderstore.io/c/belowzero/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/subnautica-below-zero/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, '848450'),
                 new StorePlatformMetadata(StorePlatform.XBOX_GAME_PASS, "UnknownWorldsEntertainmen.SubnauticaBelowZero"),

--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -39,7 +39,7 @@ export default class GameManager {
 
         new Game('Dyson Sphere Program', 'DysonSphereProgram', 'DysonSphereProgram',
             'Dyson Sphere Program', ['DSPGAME.exe'], 'DSPGAME_Data',
-            'https://dsp.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/dsp/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "1366540"),
                 new StorePlatformMetadata(StorePlatform.XBOX_GAME_PASS, "GameraGame.DysonSphereProgram")
@@ -47,7 +47,7 @@ export default class GameManager {
 
         new Game('Valheim', 'Valheim', 'Valheim',
             'Valheim', ['valheim.exe', 'valheim.x86_64'], 'valheim_Data',
-            'https://valheim.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/valheim/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "892970"),
                 new StorePlatformMetadata(StorePlatform.XBOX_GAME_PASS, "CoffeeStainStudios.Valheim")
@@ -55,20 +55,20 @@ export default class GameManager {
 
         new Game('Valheim Dedicated Server', 'Valheim', 'ValheimServer',
             'Valheim dedicated server', ['valheim_server.exe', 'valheim_server.x86_64'], 'valheim_server_Data',
-            'https://valheim.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/valheim/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "896660")
             ], "Valheim.jpg", GameSelectionDisplayMode.VISIBLE, GameInstanceType.SERVER, PackageLoader.BEPINEX),
 
         new Game('GTFO', 'GTFO', 'GTFO',
             'GTFO', ['GTFO.exe'], 'GTFO_Data',
-            'https://gtfo.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/gtfo/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "493520")], "GTFO.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX),
 
         new Game('Outward', 'Outward', 'Outward',
             'Outward', ['Outward.exe'], 'Outward_Data',
-            'https://outward.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/outward/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "794260"),
                 new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "Viola"),
@@ -77,7 +77,7 @@ export default class GameManager {
 
         new Game('Outward Definitive', 'OutwardDe', 'OutwardDe',
             'Outward/Outward_Defed', ['Outward Definitive Edition.exe'], 'Outward Definitive Edition_Data',
-            'https://outward.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/outward/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "1758860"),
                 new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "f07a51af8ac845ea96f792fb485e04a3"),
@@ -86,55 +86,55 @@ export default class GameManager {
 
         new Game('TaleSpire', 'TaleSpire', 'TaleSpire',
             'TaleSpire', ['TaleSpire.exe'], 'TaleSpire_Data',
-            'https://talespire.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/talespire/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "720620")], "TaleSpire.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["TS"]),
 
         new Game("H3VR", "H3VR", "H3VR",
             "H3VR", ["h3vr.exe"], "h3vr_Data",
-            "https://h3vr.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/h3vr/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "450540")], "H3VR.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["Hot Dogs, Horseshoes & Hand Grenades", "Hot Dogs, Horseshoes and Hand Grenades"]),
 
         new Game("ROUNDS", "ROUNDS", "ROUNDS",
             "ROUNDS", ["Rounds.exe"], "Rounds_Data",
-            "https://rounds.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/rounds/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1557740")], "ROUNDS.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX),
 
         new Game("Mechanica", "Mechanica", "Mechanica",
             "Mechanica", ["Mechanica.exe"], "Mechanica_Data",
-            "https://mechanica.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/mechanica/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1226990")], "Mechanica.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX),
 
         new Game("Muck", "Muck", "Muck",
             "Muck", ["Muck.exe", "Muck.x86_64"], "Muck_Data",
-            "https://muck.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/muck/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1625450")], "Muck.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX),
 
         new Game("BONEWORKS", "BONEWORKS", "BONEWORKS",
             path.join("BONEWORKS", "BONEWORKS"), ["BONEWORKS.exe", "Boneworks_Oculus_Windows64.exe"], "BONEWORKS_Data",
-            "https://boneworks.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/boneworks/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "823500"), new StorePlatformMetadata(StorePlatform.OCULUS_STORE)], "BONEWORKS.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.MELON_LOADER, ["BW"]),
 
         new Game("Lethal League Blaze", "LethalLeagueBlaze", "LethalLeagueBlaze",
             "LLBlaze", ["LLBlaze.exe", "LLBlaze.x86_64", "LLBlaze.x86", "LLBlaze.app"], "LLBlaze_Data",
-            "https://lethal-league-blaze.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/lethal-league-blaze/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "553310")], "LethalLeagueBlaze.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["LLB"]),
 
         new Game("Timberborn", "Timberborn", "Timberborn",
             "Timberborn", ["Timberborn.exe"], "Timberborn_Data",
-            "https://timberborn.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/timberborn/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1062090"), new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "972a4ca2631e43b4ba7bc3b7586ad8c4"), new StorePlatformMetadata(StorePlatform.OTHER)], "Timberborn.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["TB"]),
 
         new Game("TABS", "TABS", "TotallyAccurateBattleSimulator",
             "Totally Accurate Battle Simulator", ["TotallyAccurateBattleSimulator.exe"], "TotallyAccurateBattleSimulator_Data",
-            "https://totally-accurate-battle-simulator.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/totally-accurate-battle-simulator/api/v1/package/", EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "508440"),
                 new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "Driftfish"),
@@ -144,25 +144,25 @@ export default class GameManager {
 
         new Game("Nickelodeon All‑Star Brawl", "NASB", "NASB",
             "Nickelodeon All-Star Brawl", ["Nickelodeon All-Star Brawl.exe"], "Nickelodeon All-Star Brawl_Data",
-            "https://nasb.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/nasb/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1414850")], "NASB.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["Nickelodeon All-Star Brawl", "NASB"]),
 
         new Game("Inscryption", "Inscryption", "Inscryption",
             "Inscryption", ["Inscryption.exe"], "Inscryption_Data",
-            "https://inscryption.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/inscryption/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1092790"), new StorePlatformMetadata(StorePlatform.OTHER)], "Inscryption.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX),
 
         new Game("Starsand", "Starsand", "Starsand",
             "Starsand", ["Starsand.exe"], "Starsand_Data",
-            "https://starsand.thunderstore.io/api/v1/package/", EXCLUSIONS,
+            "https://thunderstore.io/c/starsand/api/v1/package/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1380220"), new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "a774278c0813447c96a76b053cbf73ff")], "Starsand.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX),
 
         new Game('Cats are Liquid - A Better Place', 'CatsAreLiquidABP', 'CatsAreLiquidABP',
             'Cats are Liquid - A Better Place', ['CaL-ABP-Windows.exe', "CaL-ABP-Linux.x86_64", 'CaL-ABP-macOS.app'], 'CaL-ABP-Windows_Data',
-            'https://cats-are-liquid.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/cats-are-liquid/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "1188080"),
                 new StorePlatformMetadata(StorePlatform.OTHER)
@@ -172,45 +172,45 @@ export default class GameManager {
 
         new Game('Potion Craft', 'PotionCraft', 'PotionCraft',
             'Potion Craft', ['Potion Craft.exe'], 'Potion Craft_Data',
-            'https://potion-craft.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/potion-craft/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1210320")], 'PotionCraft.jpg',
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX,
             ['pc']),
 
         new Game('Nearly Dead', 'NearlyDead', 'NearlyDead',
             'Nearly Dead', ['Nearly Dead.exe'], 'Nearly Dead_Data',
-            'https://nearly-dead.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/nearly-dead/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1268900")], 'NearlyDead.png',
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX,
             ['nd']),
 
         new Game('AGAINST', 'AGAINST', 'AGAINST',
             'AGAINST_steam', ['AGAINST.exe'], "AGAINST_Data",
-            'https://against.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/against/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1584840")], "AGAINST.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, []),
 
         new Game('Rogue Tower', 'RogueTower', 'RogueTower',
             'Rogue Tower', ['Rogue Tower.exe'], "Rogue Tower_Data",
-            'https://rogue-tower.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/rogue-tower/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1843760")], "RogueTower.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ['rt']),
 
         new Game('House of the Dying Sun', 'HOTDS', 'HOTDS',
             'DyingSun', ['dyingsun.exe'], 'dyingsun_Data',
-            'https://hotds.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/hotds/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, '283160')], "HOTDS.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ['hotds']),
 
         new Game('For The King', 'ForTheKing', 'ForTheKing',
             'For The King', ['FTK.exe'], 'FTK_Data',
-            'https://for-the-king.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/for-the-king/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "527230"), new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "Discus")], "ForTheKing.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["ftk"]),
 
         new Game('Subnautica', 'Subnautica', 'Subnautica',
             'Subnautica', ['Subnautica.exe'], 'Subnautica_Data',
-            'https://subnautica.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/subnautica/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "264710"),
                 new StorePlatformMetadata(StorePlatform.EPIC_GAMES_STORE, "Jaguar"),
@@ -219,7 +219,7 @@ export default class GameManager {
 
         new Game('Subnautica: Below Zero', 'SubnauticaBZ', 'SubnauticaBZ',
             'SubnauticaZero', ['SubnauticaZero.exe'], 'SubnauticaZero_Data',
-            'https://belowzero.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/belowzero/api/v1/package/', EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, '848450'),
                 new StorePlatformMetadata(StorePlatform.XBOX_GAME_PASS, "UnknownWorldsEntertainmen.SubnauticaBelowZero"),
@@ -227,13 +227,13 @@ export default class GameManager {
 
         new Game("Core Keeper", "CoreKeeper", "CoreKeeper",
             "Core Keeper", ["CoreKeeper.exe"], "CoreKeeper_Data",
-            'https://core-keeper.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/core-keeper/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1621690")], "CoreKeeper.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["ck"]),
 
         new Game("Titanfall 2", "Titanfall2", "Titanfall2",
             "Titanfall2", ["NorthstarLauncher.exe", "Titanfall2.exe"], "",
-            'https://northstar.thunderstore.io/api/v1/package/', EXCLUSIONS,
+            'https://thunderstore.io/c/northstar/api/v1/package/', EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM_DIRECT, "1237970"), new StorePlatformMetadata(StorePlatform.ORIGIN, "")], "Titanfall2.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.NORTHSTAR, ["northstar", "ns", "tf2", "tf|2"]),
 


### PR DESCRIPTION
Thunderstore recently changed all old subdomains to the new scope community style, breaking the mod manager API requests.

The replacement was done with a regex. For the possibility a community has a different community name, it will still be broken. I only tested a handful of games to verify that the new url works.