### PR TITLE
[SECURITY FIX] Profile import RCE

### DIFF
--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -539,25 +539,27 @@ export default class Profiles extends Vue {
                                     if (files[0].endsWith('.r2z')) {
                                         const entries = await ZipProvider.instance.getEntries(files[0]);
                                         for (const entry of entries) {
-                                            if (entry.entryName.startsWith('config/') || entry.entryName.startsWith("config\\")) {
-                                                await ZipProvider.instance.extractEntryTo(
-                                                    files[0],
-                                                    entry.entryName,
-                                                    path.join(
-                                                        Profile.getDirectory(),
-                                                        profileName,
-                                                        'BepInEx'
+                                            if (!entry.entryName.endsWith('.dll')) {
+                                                if (entry.entryName.startsWith('config/') || entry.entryName.startsWith("config\\")) {
+                                                    await ZipProvider.instance.extractEntryTo(
+                                                        files[0],
+                                                        entry.entryName,
+                                                        path.join(
+                                                            Profile.getDirectory(),
+                                                            profileName,
+                                                            'BepInEx'
+                                                        )
+                                                    );
+                                                } else if (entry.entryName.toLowerCase() !== "export.r2x") {
+                                                    await ZipProvider.instance.extractEntryTo(
+                                                        files[0],
+                                                        entry.entryName,
+                                                        path.join(
+                                                            Profile.getDirectory(),
+                                                            profileName
+                                                        )
                                                     )
-                                                );
-                                            } else if (entry.entryName.toLowerCase() !== "export.r2x") {
-                                                await ZipProvider.instance.extractEntryTo(
-                                                    files[0],
-                                                    entry.entryName,
-                                                    path.join(
-                                                        Profile.getDirectory(),
-                                                        profileName
-                                                    )
-                                                )
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
Hi! Whenever importing a profile from a code or a file, r2modman would arbitrarily extract all files without checking the type. This allows the user to add DLL files to the modpack that aren't included on the mod list, allowing a malicious party to add malware that is automatically loaded by BepInEx and run in the game without appearing on the modlist of the pack. This change ignores DLL files when extracting, not allowing them to be extracted to the user's installation directory.

Suggested remediation in the future would be to add more security onto the profile code APIs, as any user can upload any data permanently and receive a profile code that can be used to download their arbitrary content from your servers. This can be used in many malicious ways, for example allowing a hacker to shift blame to you for holding exploit code on your local servers.