### PR TITLE
Unfix getDeprecatedPackageMap

### DIFF
--- a/src/utils/Deprecations.ts
+++ b/src/utils/Deprecations.ts
@@ -45,42 +45,49 @@ export class Deprecations {
             return true;
         }
 
-        for (const dependencyNameAndVersion of mod.getLatestVersion().getDependencies()) {
-            const dependencyName = dependencyNameAndVersion.substring(0, dependencyNameAndVersion.lastIndexOf('-'));
-
-            if (currentChain.has(dependencyName)) {
-                continue;
-            }
-            const dependency = packageMap.get(dependencyName);
-
-            // Package isn't available on Thunderstore, so we can't tell
-            // if it's deprecated or not. This will also include deps of
-            // packages uploaded into wrong community since the
-            // packageMap contains only packages from this community.
-            // Based on manual testing with real data, caching these to
-            // deprecationMap doesn't seem to improve overall performance.
-            if (dependency === undefined) {
-                continue;
-            }
-
-            // Keep track of the dependency chain currently under
-            // investigation to avoid infinite recursive loops.
-            currentChain.add(mod.getFullName());
-            const dependencyDeprecated = this._populateDeprecatedPackageMapForModChain(
-                dependency, packageMap, deprecationMap, currentChain
-            );
-            currentChain.delete(mod.getFullName());
-            deprecationMap.set(dependencyName, dependencyDeprecated);
-
-            // Eject early on the first deprecated dependency for performance.
-            if (dependencyDeprecated) {
-                deprecationMap.set(mod.getFullName(), true);
-                return true;
-            }
-        }
-
-        // Package is not depreceated by itself nor due to dependencies.
+        // TODO: it was deemed that just fixing this function would be a
+        // breaking change. We need to make changes to UI before the fix
+        // can go live. Once ready, remove the two lines below and
+        // uncomment the rest.
         deprecationMap.set(mod.getFullName(), false);
         return false;
+
+        // for (const dependencyNameAndVersion of mod.getLatestVersion().getDependencies()) {
+        //     const dependencyName = dependencyNameAndVersion.substring(0, dependencyNameAndVersion.lastIndexOf('-'));
+
+        //     if (currentChain.has(dependencyName)) {
+        //         continue;
+        //     }
+        //     const dependency = packageMap.get(dependencyName);
+
+        //     // Package isn't available on Thunderstore, so we can't tell
+        //     // if it's deprecated or not. This will also include deps of
+        //     // packages uploaded into wrong community since the
+        //     // packageMap contains only packages from this community.
+        //     // Based on manual testing with real data, caching these to
+        //     // deprecationMap doesn't seem to improve overall performance.
+        //     if (dependency === undefined) {
+        //         continue;
+        //     }
+
+        //     // Keep track of the dependency chain currently under
+        //     // investigation to avoid infinite recursive loops.
+        //     currentChain.add(mod.getFullName());
+        //     const dependencyDeprecated = this._populateDeprecatedPackageMapForModChain(
+        //         dependency, packageMap, deprecationMap, currentChain
+        //     );
+        //     currentChain.delete(mod.getFullName());
+        //     deprecationMap.set(dependencyName, dependencyDeprecated);
+
+        //     // Eject early on the first deprecated dependency for performance.
+        //     if (dependencyDeprecated) {
+        //         deprecationMap.set(mod.getFullName(), true);
+        //         return true;
+        //     }
+        // }
+
+        // // Package is not depreceated by itself nor due to dependencies.
+        // deprecationMap.set(mod.getFullName(), false);
+        // return false;
     }
 }

--- a/test/jest/__tests__/utils/utils.getDeprecatedPackageMap.ts.spec.ts
+++ b/test/jest/__tests__/utils/utils.getDeprecatedPackageMap.ts.spec.ts
@@ -2,6 +2,10 @@ import ThunderstoreMod from "../../../../src/model/ThunderstoreMod";
 import ThunderstoreVersion from "../../../../src/model/ThunderstoreVersion";
 import { Deprecations } from "../../../../src/utils/Deprecations";
 
+
+// TODO: The implementation is currently intentionally broken (see the
+// TODO comment in the function). Commented out test cases in this test
+// suite will work once the implementation is unbroken.
 describe("Deprecations.getDeprecatedPackageMap", () => {
     let spyedPopulator: jest.SpyInstance;
 
@@ -30,22 +34,22 @@ describe("Deprecations.getDeprecatedPackageMap", () => {
         expect(actual.get('TeamC-Mod1')).toStrictEqual(false);
     });
 
-    it("Handles simple chain with deprecation", () => {
-        const mods =[
-            createStubMod('TeamA-Mod1', false, ['TeamA-Mod2', 'TeamB-Mod1']),
-            createStubMod('TeamA-Mod2'),
-            createStubMod('TeamB-Mod1', true, ['TeamC-Mod1']),
-            createStubMod('TeamC-Mod1')
-        ];
+    // it("Handles simple chain with deprecation", () => {
+    //     const mods =[
+    //         createStubMod('TeamA-Mod1', false, ['TeamA-Mod2', 'TeamB-Mod1']),
+    //         createStubMod('TeamA-Mod2'),
+    //         createStubMod('TeamB-Mod1', true, ['TeamC-Mod1']),
+    //         createStubMod('TeamC-Mod1')
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        expect(actual.size).toBe(4);
-        expect(actual.get('TeamA-Mod1')).toStrictEqual(true);
-        expect(actual.get('TeamA-Mod2')).toStrictEqual(false);
-        expect(actual.get('TeamB-Mod1')).toStrictEqual(true);
-        expect(actual.get('TeamC-Mod1')).toStrictEqual(false);
-    });
+    //     expect(actual.size).toBe(4);
+    //     expect(actual.get('TeamA-Mod1')).toStrictEqual(true);
+    //     expect(actual.get('TeamA-Mod2')).toStrictEqual(false);
+    //     expect(actual.get('TeamB-Mod1')).toStrictEqual(true);
+    //     expect(actual.get('TeamC-Mod1')).toStrictEqual(false);
+    // });
 
     it("Doesn't infinite-loop on direct dependency loop", () => {
         const mods =[
@@ -75,143 +79,143 @@ describe("Deprecations.getDeprecatedPackageMap", () => {
         expect(actual.get('Loop1-Mod3')).toStrictEqual(false);
     });
 
-    it("Marks all mods deprecated on dependency loop", () => {
-        const mods =[
-            createStubMod('Loop2-Mod1', false, ['Loop2-Mod4']),
-            createStubMod('Loop2-Mod2', false, ['Loop2-Mod3']),
-            createStubMod('Loop2-Mod3', true, ['Loop2-Mod1']),
-            createStubMod('Loop2-Mod4', false, ['Loop2-Mod2']),
-        ];
+    // it("Marks all mods deprecated on dependency loop", () => {
+    //     const mods =[
+    //         createStubMod('Loop2-Mod1', false, ['Loop2-Mod4']),
+    //         createStubMod('Loop2-Mod2', false, ['Loop2-Mod3']),
+    //         createStubMod('Loop2-Mod3', true, ['Loop2-Mod1']),
+    //         createStubMod('Loop2-Mod4', false, ['Loop2-Mod2']),
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        expect(actual.size).toBe(4);
-        expect(actual.get('Loop2-Mod1')).toStrictEqual(true);
-        expect(actual.get('Loop2-Mod2')).toStrictEqual(true);
-        expect(actual.get('Loop2-Mod3')).toStrictEqual(true);
-        expect(actual.get('Loop2-Mod4')).toStrictEqual(true);
-    });
+    //     expect(actual.size).toBe(4);
+    //     expect(actual.get('Loop2-Mod1')).toStrictEqual(true);
+    //     expect(actual.get('Loop2-Mod2')).toStrictEqual(true);
+    //     expect(actual.get('Loop2-Mod3')).toStrictEqual(true);
+    //     expect(actual.get('Loop2-Mod4')).toStrictEqual(true);
+    // });
 
-    it("Doesn't recheck already processed chains (top-down)", () => {
-        const mods =[
-            createStubMod('X-Root1', false, ['X-ChainTop']),
-            createStubMod('X-Root2', false, ['X-ChainTop']),
-            createStubMod('X-Root3', false, ['X-ChainTop']),
-            createStubMod('X-ChainTop', false, ['X-ChainMiddle']),
-            createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
-            createStubMod('X-ChainBottom'),
-        ];
+    // it("Doesn't recheck already processed chains (top-down)", () => {
+    //     const mods =[
+    //         createStubMod('X-Root1', false, ['X-ChainTop']),
+    //         createStubMod('X-Root2', false, ['X-ChainTop']),
+    //         createStubMod('X-Root3', false, ['X-ChainTop']),
+    //         createStubMod('X-ChainTop', false, ['X-ChainMiddle']),
+    //         createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
+    //         createStubMod('X-ChainBottom'),
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        // Each mod causes one call due to for-loop (6 calls).
-        // Root1 causes three recursive calls down the chain (total 9 calls).
-        // Root2 and Root3 should each recursively call X-ChainTop, but
-        // no further down the chain (total 11 calls).
-        expect(spyedPopulator).toBeCalledTimes(11);
-        expect(actual.size).toBe(6);
-        expect(actual.get('X-Root1')).toStrictEqual(false);
-        expect(actual.get('X-Root2')).toStrictEqual(false);
-        expect(actual.get('X-Root3')).toStrictEqual(false);
-        expect(actual.get('X-ChainTop')).toStrictEqual(false);
-        expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
-        expect(actual.get('X-ChainBottom')).toStrictEqual(false);
-        jest.restoreAllMocks();  // restore the spy created with spyOn
-    });
+    //     // Each mod causes one call due to for-loop (6 calls).
+    //     // Root1 causes three recursive calls down the chain (total 9 calls).
+    //     // Root2 and Root3 should each recursively call X-ChainTop, but
+    //     // no further down the chain (total 11 calls).
+    //     expect(spyedPopulator).toBeCalledTimes(11);
+    //     expect(actual.size).toBe(6);
+    //     expect(actual.get('X-Root1')).toStrictEqual(false);
+    //     expect(actual.get('X-Root2')).toStrictEqual(false);
+    //     expect(actual.get('X-Root3')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainTop')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainBottom')).toStrictEqual(false);
+    //     jest.restoreAllMocks();  // restore the spy created with spyOn
+    // });
 
-    it("Doesn't recheck already processed chains (bottom-up)", () => {
-        const mods =[
-            createStubMod('X-ChainBottom'),
-            createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
-            createStubMod('X-ChainTop', false, ['X-ChainMiddle']),
-            createStubMod('X-Root1', false, ['X-ChainTop']),
-            createStubMod('X-Root2', false, ['X-ChainTop']),
-            createStubMod('X-Root3', false, ['X-ChainTop']),
-        ];
+    // it("Doesn't recheck already processed chains (bottom-up)", () => {
+    //     const mods =[
+    //         createStubMod('X-ChainBottom'),
+    //         createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
+    //         createStubMod('X-ChainTop', false, ['X-ChainMiddle']),
+    //         createStubMod('X-Root1', false, ['X-ChainTop']),
+    //         createStubMod('X-Root2', false, ['X-ChainTop']),
+    //         createStubMod('X-Root3', false, ['X-ChainTop']),
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        // Each mod causes one call due to for-loop (6 calls).
-        // Excluding ChainBottom, each mod should recursively call their
-        // first dependency, but no further down the chain (total 11 calls).
-        expect(spyedPopulator).toBeCalledTimes(11);
-        expect(actual.size).toBe(6);
-        expect(actual.get('X-Root1')).toStrictEqual(false);
-        expect(actual.get('X-Root2')).toStrictEqual(false);
-        expect(actual.get('X-Root3')).toStrictEqual(false);
-        expect(actual.get('X-ChainTop')).toStrictEqual(false);
-        expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
-        expect(actual.get('X-ChainBottom')).toStrictEqual(false);
-    });
+    //     // Each mod causes one call due to for-loop (6 calls).
+    //     // Excluding ChainBottom, each mod should recursively call their
+    //     // first dependency, but no further down the chain (total 11 calls).
+    //     expect(spyedPopulator).toBeCalledTimes(11);
+    //     expect(actual.size).toBe(6);
+    //     expect(actual.get('X-Root1')).toStrictEqual(false);
+    //     expect(actual.get('X-Root2')).toStrictEqual(false);
+    //     expect(actual.get('X-Root3')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainTop')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainBottom')).toStrictEqual(false);
+    // });
 
-    it("Doesn't recheck already processed chains of deprecated mods (top-down)", () => {
-        const mods =[
-            createStubMod('X-Root1', false, ['X-ChainTop']),
-            createStubMod('X-Root2', false, ['X-ChainTop']),
-            createStubMod('X-Root3', false, ['X-ChainTop']),
-            createStubMod('X-ChainTop', true, ['X-ChainMiddle']),
-            createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
-            createStubMod('X-ChainBottom'),
-        ];
+    // it("Doesn't recheck already processed chains of deprecated mods (top-down)", () => {
+    //     const mods =[
+    //         createStubMod('X-Root1', false, ['X-ChainTop']),
+    //         createStubMod('X-Root2', false, ['X-ChainTop']),
+    //         createStubMod('X-Root3', false, ['X-ChainTop']),
+    //         createStubMod('X-ChainTop', true, ['X-ChainMiddle']),
+    //         createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
+    //         createStubMod('X-ChainBottom'),
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        // Each mod causes one call due to for-loop (6 calls).
-        // Each root mod recursively calls X-ChainTop, but the chain is
-        // not processed further since it's deprecated (total 9 calls).
-        // X-ChainMiddle recursively calls X-ChainBottom (total 10 calls).
-        expect(spyedPopulator).toBeCalledTimes(10);
-        expect(actual.size).toBe(6);
-        expect(actual.get('X-Root1')).toStrictEqual(true);
-        expect(actual.get('X-Root2')).toStrictEqual(true);
-        expect(actual.get('X-Root3')).toStrictEqual(true);
-        expect(actual.get('X-ChainTop')).toStrictEqual(true);
-        expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
-        expect(actual.get('X-ChainBottom')).toStrictEqual(false);
-    });
+    //     // Each mod causes one call due to for-loop (6 calls).
+    //     // Each root mod recursively calls X-ChainTop, but the chain is
+    //     // not processed further since it's deprecated (total 9 calls).
+    //     // X-ChainMiddle recursively calls X-ChainBottom (total 10 calls).
+    //     expect(spyedPopulator).toBeCalledTimes(10);
+    //     expect(actual.size).toBe(6);
+    //     expect(actual.get('X-Root1')).toStrictEqual(true);
+    //     expect(actual.get('X-Root2')).toStrictEqual(true);
+    //     expect(actual.get('X-Root3')).toStrictEqual(true);
+    //     expect(actual.get('X-ChainTop')).toStrictEqual(true);
+    //     expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainBottom')).toStrictEqual(false);
+    // });
 
-    it("Doesn't recheck already processed chains of deprecated mods (bottom-up)", () => {
-        const mods =[
-            createStubMod('X-ChainBottom'),
-            createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
-            createStubMod('X-ChainTop', true, ['X-ChainMiddle']),
-            createStubMod('X-Root1', false, ['X-ChainTop']),
-            createStubMod('X-Root2', false, ['X-ChainTop']),
-            createStubMod('X-Root3', false, ['X-ChainTop']),
-        ];
+    // it("Doesn't recheck already processed chains of deprecated mods (bottom-up)", () => {
+    //     const mods =[
+    //         createStubMod('X-ChainBottom'),
+    //         createStubMod('X-ChainMiddle', false, ['X-ChainBottom']),
+    //         createStubMod('X-ChainTop', true, ['X-ChainMiddle']),
+    //         createStubMod('X-Root1', false, ['X-ChainTop']),
+    //         createStubMod('X-Root2', false, ['X-ChainTop']),
+    //         createStubMod('X-Root3', false, ['X-ChainTop']),
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        // Each mod causes one call due to for-loop (6 calls).
-        // Each mod recursively calls it's direct dependency, except for
-        // X-ChainBottom (no dependencies) and X-ChainTop (because it's
-        // deprecated itself) (total 10 calls).
-        expect(spyedPopulator).toBeCalledTimes(10);
-        expect(actual.size).toBe(6);
-        expect(actual.get('X-Root1')).toStrictEqual(true);
-        expect(actual.get('X-Root2')).toStrictEqual(true);
-        expect(actual.get('X-Root3')).toStrictEqual(true);
-        expect(actual.get('X-ChainTop')).toStrictEqual(true);
-        expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
-        expect(actual.get('X-ChainBottom')).toStrictEqual(false);
-    });
+    //     // Each mod causes one call due to for-loop (6 calls).
+    //     // Each mod recursively calls it's direct dependency, except for
+    //     // X-ChainBottom (no dependencies) and X-ChainTop (because it's
+    //     // deprecated itself) (total 10 calls).
+    //     expect(spyedPopulator).toBeCalledTimes(10);
+    //     expect(actual.size).toBe(6);
+    //     expect(actual.get('X-Root1')).toStrictEqual(true);
+    //     expect(actual.get('X-Root2')).toStrictEqual(true);
+    //     expect(actual.get('X-Root3')).toStrictEqual(true);
+    //     expect(actual.get('X-ChainTop')).toStrictEqual(true);
+    //     expect(actual.get('X-ChainMiddle')).toStrictEqual(false);
+    //     expect(actual.get('X-ChainBottom')).toStrictEqual(false);
+    // });
 
-    it("Ingores unknown dependencies", () => {
-        const mods =[
-            createStubMod('Known-Mod1', false, ['Unknown-Mod1', 'Known-Mod2', 'Unknown-Mod2']),
-            createStubMod('Known-Mod2'),
-        ];
+    // it("Ingores unknown dependencies", () => {
+    //     const mods =[
+    //         createStubMod('Known-Mod1', false, ['Unknown-Mod1', 'Known-Mod2', 'Unknown-Mod2']),
+    //         createStubMod('Known-Mod2'),
+    //     ];
 
-        const actual = Deprecations.getDeprecatedPackageMap(mods);
+    //     const actual = Deprecations.getDeprecatedPackageMap(mods);
 
-        // Both known mods cause one call due to for-loop (2 calls).
-        // Known-Mod1 causes 1 recursive call (total 3 calls).
-        // Unknown mods are ignored and don't cause calls
-        expect(spyedPopulator).toBeCalledTimes(3);
-        expect(actual.size).toBe(2);
-        expect(actual.get('Known-Mod1')).toStrictEqual(false);
-        expect(actual.get('Known-Mod2')).toStrictEqual(false);
-    });
+    //     // Both known mods cause one call due to for-loop (2 calls).
+    //     // Known-Mod1 causes 1 recursive call (total 3 calls).
+    //     // Unknown mods are ignored and don't cause calls
+    //     expect(spyedPopulator).toBeCalledTimes(3);
+    //     expect(actual.size).toBe(2);
+    //     expect(actual.get('Known-Mod1')).toStrictEqual(false);
+    //     expect(actual.get('Known-Mod2')).toStrictEqual(false);
+    // });
 });
 
 const createStubMod = (


### PR DESCRIPTION
It was deemed that simply fixing the method would be too drastic change. We want the UI to be able to reflect the deprecation status without fully hiding mods based on deprecated dependencies, and add support for showing various other states like "verified" while we're at it.

Meanwhile, intentionally break the new implementation in a manner that is easily reverted once the UI changes are ready.