### PR TITLE
Ignore error about double navigation to splash screen

### DIFF
--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -289,7 +289,13 @@ export default class GameSelectionScreen extends Vue {
         await GameManager.activate(this.selectedGame, this.selectedPlatform);
         await this.$store.dispatch("setActiveGame", this.selectedGame);
 
-        await this.$router.push({name: "splash"});
+        try {
+            await this.$router.push({name: "splash"});
+        } catch (error) {
+            if (!(error instanceof Error) || error.name !== "NavigationDuplicated") {
+                throw error;
+            }
+        }
     }
 
     private async proceedDefault() {


### PR DESCRIPTION
The error is silenced to reduce noise in Thunderstore Sentry logs.

I'm not entirely sure how the user managed to trigger the error, since it seems they pressed the button multiple times over several seconds. Their manager must have been really slowed down since I had to add some sleep time to actually be able to duplicate the issue.