### PR TITLE
Improve empty mod list notification

### DIFF
--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -54,7 +54,7 @@
         </div>
         <div class="in-mod-list" v-else-if="getPaginationSize() === 0">
             <p class="notification margin-right">
-                No mods with that name found
+                {{thunderstoreModList.length ? "No mods matching search found": "No mods available"}}
             </p>
         </div>
         <br/>


### PR DESCRIPTION
Use more generic message if the online mod list empty due to user's choices, since e.g. category filters may cause empty list be shown too.

Show a different message if the mod list is completely empty due to the user being in offline mode or community having no mods yet.