### PR TITLE
Refactor Rename Profile Modal by separating it from Profiles.vue

### DIFF
--- a/src/components/profiles-modals/RenameProfileModal.vue
+++ b/src/components/profiles-modals/RenameProfileModal.vue
@@ -13,7 +13,14 @@ export default class RenameProfileModal extends Vue {
 
     @Watch('$store.state.profile.activeProfile')
     activeProfileChanged(newProfile: Profile, oldProfile: Profile|null) {
-        if (oldProfile === null || oldProfile.getProfileName() === this.newProfileName) {
+        if (
+            // Modal was just created and has no value yet, use any available.
+            this.newProfileName === "" ||
+            // Profile was not previously selected, use the new active profile.
+            oldProfile === null ||
+            // Avoid losing user's changes when the profile unexpectedly changes.
+            oldProfile.getProfileName() === this.newProfileName
+        ) {
             this.newProfileName = newProfile.getProfileName();
         }
     }

--- a/src/components/profiles-modals/RenameProfileModal.vue
+++ b/src/components/profiles-modals/RenameProfileModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Vue, Component, Watch } from 'vue-property-decorator';
+import { Vue, Component, Ref, Watch } from 'vue-property-decorator';
 import { ModalCard } from "../all";
 import sanitize from 'sanitize-filename';
 import R2Error from "../../model/errors/R2Error";
@@ -9,6 +9,7 @@ import Profile from "../../model/Profile";
     components: {ModalCard}
 })
 export default class RenameProfileModal extends Vue {
+    @Ref() readonly nameInput: HTMLInputElement | undefined;
     private newProfileName: string = '';
 
     @Watch('$store.state.profile.activeProfile')
@@ -26,7 +27,17 @@ export default class RenameProfileModal extends Vue {
     }
 
     get isOpen(): boolean {
-        return this.$store.state.modals.isRenameProfileModalOpen;
+        const isOpen_ = this.$store.state.modals.isRenameProfileModalOpen;
+
+        if (isOpen_) {
+            this.$nextTick(() => {
+                if (this.nameInput) {
+                    this.nameInput.focus();
+                }
+            });
+        }
+
+        return isOpen_;
     }
 
     get profileList(): string[] {
@@ -73,7 +84,7 @@ export default class RenameProfileModal extends Vue {
         <template v-slot:body>
             <p>This profile will store its own mods independently from other profiles.</p>
 
-            <input class="input" autofocus v-model="newProfileName" />
+            <input class="input" v-model="newProfileName" ref="nameInput" />
 
             <span class="tag is-dark" v-if="newProfileName === '' || makeProfileNameSafe(newProfileName) === ''">
                 Profile name required

--- a/src/components/profiles-modals/RenameProfileModal.vue
+++ b/src/components/profiles-modals/RenameProfileModal.vue
@@ -1,0 +1,87 @@
+<script lang="ts">
+import { Vue, Component, Watch } from 'vue-property-decorator';
+import { ModalCard } from "../all";
+import sanitize from 'sanitize-filename';
+import R2Error from "../../model/errors/R2Error";
+import Profile from "../../model/Profile";
+
+@Component({
+    components: {ModalCard}
+})
+export default class RenameProfileModal extends Vue {
+    private newProfileName: string = '';
+
+    @Watch('$store.state.profile.activeProfile')
+    activeProfileChanged(newProfile: Profile, oldProfile: Profile|null) {
+        if (oldProfile === null || oldProfile.getProfileName() === this.newProfileName) {
+            this.newProfileName = newProfile.getProfileName();
+        }
+    }
+
+    get isOpen(): boolean {
+        return this.$store.state.modals.isRenameProfileModalOpen;
+    }
+
+    get profileList(): string[] {
+        return this.$store.state.profiles.profileList;
+    }
+
+    closeModal() {
+        this.newProfileName = this.$store.state.profile.activeProfile.getProfileName();
+        this.$store.commit('closeRenameProfileModal');
+    }
+
+    makeProfileNameSafe(nameToSanitize: string): string {
+        return sanitize(nameToSanitize);
+    }
+
+    doesProfileExist(nameToCheck: string): boolean {
+        if ((nameToCheck.match(new RegExp('^([a-zA-Z0-9])(\\s|[a-zA-Z0-9]|_|-|[.])*$'))) === null) {
+            return true;
+        }
+        const safe: string = this.makeProfileNameSafe(nameToCheck);
+        return (this.profileList.some(function (profile: string) {
+            return profile.toLowerCase() === safe.toLowerCase()
+        }));
+    }
+
+    async performRename() {
+        try {
+            await this.$store.dispatch('profiles/renameProfile', {newName: this.newProfileName});
+        } catch (e) {
+            const err = R2Error.fromThrownValue(e, 'Error whilst renaming profile');
+            this.$store.commit('error/handleError', err);
+        }
+        this.closeModal();
+    }
+}
+
+</script>
+<template>
+    <ModalCard v-if="isOpen" :is-active="isOpen" @close-modal="closeModal">
+
+        <template v-slot:header>
+            <p class="modal-card-title">Rename a profile</p>
+        </template>
+        <template v-slot:body>
+            <p>This profile will store its own mods independently from other profiles.</p>
+
+            <input class="input" autofocus v-model="newProfileName" />
+
+            <span class="tag is-dark" v-if="newProfileName === '' || makeProfileNameSafe(newProfileName) === ''">
+                Profile name required
+            </span>
+            <span class="tag is-success" v-else-if="!doesProfileExist(newProfileName)">
+                "{{makeProfileNameSafe(newProfileName)}}" is available
+            </span>
+            <span class="tag is-danger" v-else-if="doesProfileExist(newProfileName)">
+                "{{makeProfileNameSafe(newProfileName)}}" is either already in use, or contains invalid characters
+            </span>
+        </template>
+        <template v-slot:footer>
+            <button class="button is-danger" v-if="doesProfileExist(newProfileName)">Rename</button>
+            <button class="button is-info" @click="performRename(newProfileName)" v-else>Rename</button>
+        </template>
+
+    </ModalCard>
+</template>

--- a/src/components/profiles-modals/RenameProfileModal.vue
+++ b/src/components/profiles-modals/RenameProfileModal.vue
@@ -84,7 +84,12 @@ export default class RenameProfileModal extends Vue {
         <template v-slot:body>
             <p>This profile will store its own mods independently from other profiles.</p>
 
-            <input class="input" v-model="newProfileName" ref="nameInput" />
+            <input
+                class="input"
+                v-model="newProfileName"
+                @keyup.enter="!doesProfileExist(newProfileName) && performRename(newProfileName)"
+                ref="nameInput"
+            />
 
             <span class="tag is-dark" v-if="newProfileName === '' || makeProfileNameSafe(newProfileName) === ''">
                 Profile name required
@@ -97,7 +102,7 @@ export default class RenameProfileModal extends Vue {
             </span>
         </template>
         <template v-slot:footer>
-            <button class="button is-danger" v-if="doesProfileExist(newProfileName)">Rename</button>
+            <button class="button is-danger" v-if="doesProfileExist(newProfileName)" disabled>Rename</button>
             <button class="button is-info" @click="performRename(newProfileName)" v-else>Rename</button>
         </template>
 

--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -1,15 +1,16 @@
 <template>
   <div>
     <DeleteProfileModal />
+    <RenameProfileModal />
     <!-- Create modal -->
-    <div :class="['modal', {'is-active':(addingProfile !== false || renamingProfile !== false)}]">
+    <div :class="['modal', {'is-active':(addingProfile !== false)}]">
       <div class="modal-background" @click="closeNewProfileModal()"></div>
       <div class="modal-content">
         <div class="card">
           <header class="card-header">
             <p class="card-header-title">{{addingProfileType}} a profile</p>
           </header>
-            <template v-if="(addingProfile && importUpdateSelection === 'IMPORT') || (addingProfile && importUpdateSelection === null) || renamingProfile">
+            <template v-if="(addingProfile && importUpdateSelection === 'IMPORT') || (addingProfile && importUpdateSelection === null)">
               <div class="card-content">
                 <p>This profile will store its own mods independently from other profiles.</p>
                 <br/>
@@ -46,10 +47,6 @@
               <template v-if="addingProfile && importUpdateSelection === 'UPDATE'">
                   <button id="modal-update-profile-invalid" class="button is-danger" v-if="!doesProfileExist(selectedProfile)">Update profile: {{ selectedProfile }}</button>
                   <button id="modal-update-profile" class="button is-info" v-else @click="updateProfile()">Update profile: {{ selectedProfile }}</button>
-              </template>
-              <template v-if="renamingProfile">
-                  <button id="modal-rename-profile-invalid" class="button is-danger" v-if="doesProfileExist(newProfileName)">Rename</button>
-                  <button id="modal-rename-profile" class="button is-info" @click="performRename(newProfileName)" v-else>Rename</button>
               </template>
           </div>
         </div>
@@ -185,7 +182,7 @@
                     </div>
                       <div class="level-item">
                           <a id="rename-profile-disabled" class="button" v-if="selectedProfile === 'Default'" :disabled="true">Rename</a>
-                          <a id="rename-profile" class="button" @click="renameProfile()" v-else>Rename</a>
+                          <a id="rename-profile" class="button" @click="openRenameProfileModal()" v-else>Rename</a>
                       </div>
                     <div class="level-item">
                       <a id="create-profile" class="button" @click="importUpdateSelection = null; newProfile('Create', undefined)">Create new</a>
@@ -240,6 +237,7 @@ import ManagerInformation from '../_managerinf/ManagerInformation';
 import GameDirectoryResolverProvider from '../providers/ror2/game/GameDirectoryResolverProvider';
 import { ProfileImportExport } from '../r2mm/mods/ProfileImportExport';
 import DeleteProfileModal from "../components/profiles-modals/DeleteProfileModal.vue";
+import RenameProfileModal from "../components/profiles-modals/RenameProfileModal.vue";
 
 let fs: FsProvider;
 
@@ -248,6 +246,7 @@ let fs: FsProvider;
         hero: Hero,
         'progress-bar': Progress,
         DeleteProfileModal,
+        RenameProfileModal,
     },
 })
 export default class Profiles extends Vue {
@@ -269,8 +268,6 @@ export default class Profiles extends Vue {
     private showFileSelectionHang: boolean = false;
 
     private listenerId: number = 0;
-
-    private renamingProfile: boolean = false;
 
     get activeProfile(): Profile {
         return this.$store.getters['profile/activeProfile'];
@@ -321,27 +318,6 @@ export default class Profiles extends Vue {
                     profile.toLowerCase() === safe.toLowerCase())) !== undefined;
     }
 
-    renameProfile() {
-        this.newProfileName = this.selectedProfile;
-        this.addingProfileType = "Rename";
-        this.renamingProfile = true;
-        this.$nextTick(() => {
-            if (this.profileNameInput) {
-                this.profileNameInput.focus();
-            }
-        });
-    }
-
-    async performRename(newName: string) {
-        await fs.rename(
-            path.join(Profile.getDirectory(), this.selectedProfile),
-            path.join(Profile.getDirectory(), newName)
-        );
-        this.closeNewProfileModal();
-        await this.updateProfileList();
-        await this.setSelectedProfile(newName, false);
-    }
-
     // Open modal for entering a name for a new profile. Triggered
     // either through user action or profile importing via file or code.
     newProfile(type: string, nameOverride: string | undefined) {
@@ -376,11 +352,14 @@ export default class Profiles extends Vue {
 
     closeNewProfileModal() {
         this.addingProfile = false;
-        this.renamingProfile = false;
     }
 
     openDeleteProfileModal() {
         this.$store.commit('openDeleteProfileModal');
+    }
+
+    openRenameProfileModal() {
+        this.$store.commit('openRenameProfileModal');
     }
 
     makeProfileNameSafe(nameToSanitize: string): string {
@@ -605,7 +584,6 @@ export default class Profiles extends Vue {
 
     async updateProfileList() {
         const profilesDirectory: string = this.activeProfile.getDirectory();
-
         try {
             const profilesDirectoryContents = await fs.readdir(profilesDirectory);
             let promises = profilesDirectoryContents.map(async function(file) {

--- a/src/store/modules/ModalsModule.ts
+++ b/src/store/modules/ModalsModule.ts
@@ -11,6 +11,7 @@ interface State {
     isDisableModModalOpen: boolean;
     isDownloadModModalOpen: boolean;
     isGameRunningModalOpen: boolean;
+    isRenameProfileModalOpen: boolean;
     isUninstallModModalOpen: boolean;
     uninstallModModalMod: ManifestV2 | null;
 }
@@ -26,6 +27,7 @@ export default {
         isDisableModModalOpen: false,
         isDownloadModModalOpen: false,
         isGameRunningModalOpen: false,
+        isRenameProfileModalOpen: false,
         isUninstallModModalOpen: false,
         uninstallModModalMod: null,
     }),
@@ -58,6 +60,10 @@ export default {
             state.isGameRunningModalOpen = false;
         },
 
+        closeRenameProfileModal: function(state: State): void {
+            state.isRenameProfileModalOpen = false;
+        },
+
         closeUninstallModModal: function(state: State): void {
             state.isUninstallModModalOpen = false;
             state.uninstallModModalMod = null;
@@ -88,6 +94,10 @@ export default {
 
         openGameRunningModal: function(state: State): void {
             state.isGameRunningModalOpen = true;
+        },
+
+        openRenameProfileModal: function(state: State): void {
+            state.isRenameProfileModalOpen = true;
         },
 
         openUninstallModModal: function(state: State, mod: ManifestV2): void {

--- a/src/store/modules/ProfilesModule.ts
+++ b/src/store/modules/ProfilesModule.ts
@@ -62,7 +62,7 @@ export const ProfilesModule = {
             } catch (e) {
                 throw R2Error.fromThrownValue(e, 'Error whilst renaming a profile on disk');
             }
-            await dispatch('setSelectedProfile', { profileName: 'Default', prewarmCache: false });
+            await dispatch('setSelectedProfile', { profileName: params.newName, prewarmCache: false });
             await dispatch('updateProfileList');
         },
 


### PR DESCRIPTION
- `RenameProfileModal` has been separated from `Profiles.vue`
- Actions `renameProfile` and `updateProfileList` have been added to `ProfilesModule`
- Old profile renaming functionality has been removed from `Profiles` page