### PR TITLE
Added missing Northstar package installer

### DIFF
--- a/src/installers/NorthstarInstaller.ts
+++ b/src/installers/NorthstarInstaller.ts
@@ -8,7 +8,7 @@ const basePackageFiles = ["manifest.json", "readme.md", "icon.png"];
 
 export class NorthstarInstaller extends PackageInstaller {
     /**
-     * Handles installation of BepInEx
+     * Handles installation of Northstar
      */
     async install(args: InstallArgs) {
         const {

--- a/src/installers/NorthstarInstaller.ts
+++ b/src/installers/NorthstarInstaller.ts
@@ -1,0 +1,42 @@
+import { InstallArgs, PackageInstaller } from './PackageInstaller';
+import path from 'path';
+import FsProvider from '../providers/generic/file/FsProvider';
+import { MODLOADER_PACKAGES } from '../r2mm/installing/profile_installers/ModLoaderVariantRecord';
+import { PackageLoader } from '../model/installing/PackageLoader';
+
+const basePackageFiles = ["manifest.json", "readme.md", "icon.png"];
+
+export class NorthstarInstaller extends PackageInstaller {
+    /**
+     * Handles installation of BepInEx
+     */
+    async install(args: InstallArgs) {
+        const {
+            mod,
+            packagePath,
+            profile,
+        } = args;
+
+        const mapping = MODLOADER_PACKAGES.find((entry) =>
+            entry.packageName.toLowerCase() == mod.getName().toLowerCase() &&
+            entry.loaderType == PackageLoader.NORTHSTAR,
+        );
+        const mappingRoot = mapping ? mapping.rootFolder : "";
+
+        let northstarRoot: string;
+        if (mappingRoot.trim().length > 0) {
+            northstarRoot = path.join(packagePath, mappingRoot);
+        } else {
+            northstarRoot = path.join(packagePath);
+        }
+        for (const item of (await FsProvider.instance.readdir(northstarRoot))) {
+            if (!basePackageFiles.includes(item.toLowerCase())) {
+                if ((await FsProvider.instance.stat(path.join(northstarRoot, item))).isFile()) {
+                    await FsProvider.instance.copyFile(path.join(northstarRoot, item), path.join(profile.getPathOfProfile(), item));
+                } else {
+                    await FsProvider.instance.copyFolder(path.join(northstarRoot, item), path.join(profile.getPathOfProfile(), item));
+                }
+            }
+        }
+    }
+}

--- a/src/installers/registry.ts
+++ b/src/installers/registry.ts
@@ -1,15 +1,16 @@
-import { BepInExInstaller } from "./BepInExInstaller";
-import { GodotMLInstaller } from "./GodotMLInstaller";
-import { MelonLoaderInstaller } from "./MelonLoaderInstaller";
-import { PackageInstaller } from "./PackageInstaller";
-import { InstallRuleInstaller } from "./InstallRuleInstaller";
-import { ShimloaderInstaller, ShimloaderPluginInstaller } from "./ShimloaderInstaller";
-import { LovelyInstaller, LovelyPluginInstaller } from "./LovelyInstaller";
+import { BepInExInstaller } from './BepInExInstaller';
+import { GodotMLInstaller } from './GodotMLInstaller';
+import { MelonLoaderInstaller } from './MelonLoaderInstaller';
+import { PackageInstaller } from './PackageInstaller';
+import { ShimloaderInstaller, ShimloaderPluginInstaller } from './ShimloaderInstaller';
+import { LovelyInstaller, LovelyPluginInstaller } from './LovelyInstaller';
+import { NorthstarInstaller } from './NorthstarInstaller';
 
 
 const _PackageInstallers = {
     // "legacy": new InstallRuleInstaller(),  // TODO: Enable
     "bepinex": new BepInExInstaller(),
+    "northstar": new NorthstarInstaller(),
     "godotml": new GodotMLInstaller(),
     "melonloader": new MelonLoaderInstaller(),
     "shimloader": new ShimloaderInstaller(),

--- a/src/model/installing/PackageLoader.ts
+++ b/src/model/installing/PackageLoader.ts
@@ -1,5 +1,4 @@
-import { PackageInstallerId, PackageInstallers } from "../../installers/registry";
-import Game from "../game/Game";
+import { PackageInstallerId } from '../../installers/registry';
 
 export enum PackageLoader {
     BEPINEX,
@@ -18,7 +17,7 @@ export function GetInstallerIdForLoader(loader: PackageLoader): PackageInstaller
         case PackageLoader.BEPINEX: return "bepinex";
         case PackageLoader.MELON_LOADER: return "melonloader";
         case PackageLoader.GODOT_ML: return "godotml";
-        case PackageLoader.NORTHSTAR: return "bepinex";
+        case PackageLoader.NORTHSTAR: return "northstar";
         case PackageLoader.SHIMLOADER: return "shimloader";
         case PackageLoader.LOVELY: return "lovely";
         case PackageLoader.ANCIENT_DUNGEON_VR: return null;


### PR DESCRIPTION
Looks like there was some internal refactor work that mapped the Northstar package installer logic to BepInEx has been unresolved, causing issues with package installs / updates.

Seems to be an easy fix. Currently with the Northstar community to verify.