### PR TITLE
Mod loader recommended versions

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -52,6 +52,9 @@
                                 <span class="tag is-dark" v-if='selectedVersion === null'>
                                     You need to select a version
                                 </span>
+                                <span class="tag is-success" v-else-if='recommendedVersion === selectedVersion'>
+                                    {{selectedVersion}} is the recommended version
+                                </span>
                                 <span class="tag is-success" v-else-if='versionNumbers[0] === selectedVersion'>
                                     {{selectedVersion}} is the latest version
                                 </span>
@@ -113,6 +116,7 @@ import Profile from '../../model/Profile';
 import { Progress } from '../all';
 import Game from '../../model/game/Game';
 import ConflictManagementProvider from '../../providers/generic/installing/ConflictManagementProvider';
+import { MOD_LOADER_VARIANTS } from '../../r2mm/installing/profile_installers/ModLoaderVariantRecord';
 
 interface DownloadProgress {
     assignId: number;
@@ -132,6 +136,7 @@ let assignId = 0;
     export default class DownloadModModal extends Vue {
 
         versionNumbers: string[] = [];
+        recommendedVersion: string | null = null;
         downloadObject: DownloadProgress | null = null;
         downloadingMod: boolean = false;
         selectedVersion: string | null = null;
@@ -224,6 +229,25 @@ let assignId = 0;
                 this.selectedVersion = this.thunderstoreMod.getVersions()[0].getVersionNumber().toString();
                 this.versionNumbers = this.thunderstoreMod.getVersions()
                     .map(value => value.getVersionNumber().toString());
+
+                const foundRecommendedVersion = MOD_LOADER_VARIANTS[this.activeGame.internalFolderName]
+                    .find(value => value.packageName === this.thunderstoreMod!.getFullName());
+
+                if (foundRecommendedVersion === undefined || foundRecommendedVersion.recommendedVersion === undefined) {
+                    this.recommendedVersion = null;
+                    this.selectedVersion = this.thunderstoreMod.getVersions()[0].getVersionNumber().toString();
+                } else {
+                    this.recommendedVersion = foundRecommendedVersion.recommendedVersion.toString();
+
+                    // Bind to recommended version or fall back to latest
+                    const thunderstoreRecommendedVersion = this.thunderstoreMod.getVersions()
+                        .find(value => value.getVersionNumber().isEqualTo(foundRecommendedVersion.recommendedVersion!));
+                    if (thunderstoreRecommendedVersion !== undefined) {
+                        this.selectedVersion = thunderstoreRecommendedVersion.getVersionNumber().toString();
+                    } else {
+                        this.selectedVersion = this.thunderstoreMod.getVersions()[0].getVersionNumber().toString()
+                    }
+                }
 
                 const modListResult = await ProfileModList.getModList(this.profile);
                 if (!(modListResult instanceof R2Error)) {

--- a/src/model/installing/ModLoaderPackageMapping.ts
+++ b/src/model/installing/ModLoaderPackageMapping.ts
@@ -1,15 +1,18 @@
 import { PackageLoader } from '../../model/installing/PackageLoader';
+import VersionNumber from '../../model/VersionNumber';
 
 export default class ModLoaderPackageMapping {
 
     private readonly _packageName: string;
     private readonly _rootFolder: string;
     private readonly _loaderType: PackageLoader;
+    private readonly _recommendedVersion: VersionNumber | undefined;
 
-    constructor(packageName: string, rootFolder: string, loaderType: PackageLoader) {
+    constructor(packageName: string, rootFolder: string, loaderType: PackageLoader, recommendedVersion?: VersionNumber) {
         this._packageName = packageName;
         this._rootFolder = rootFolder;
         this._loaderType = loaderType;
+        this._recommendedVersion = recommendedVersion;
     }
 
     get packageName() {
@@ -22,5 +25,9 @@ export default class ModLoaderPackageMapping {
 
     get loaderType(): PackageLoader {
         return this._loaderType;
+    }
+
+    get recommendedVersion(): VersionNumber | undefined {
+        return this._recommendedVersion;
     }
 }

--- a/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
+++ b/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
@@ -1,5 +1,6 @@
 import ModLoaderPackageMapping from '../../../model/installing/ModLoaderPackageMapping';
 import { PackageLoader } from '../../../model/installing/PackageLoader';
+import VersionNumber from '../../../model/VersionNumber';
 
 
 /**
@@ -22,7 +23,6 @@ export const MODLOADER_PACKAGES = [
     new ModLoaderPackageMapping("BepInEx-BepInExPack_ROUNDS", "BepInExPack_ROUNDS", PackageLoader.BEPINEX),
     new ModLoaderPackageMapping("Zinal001-BepInExPack_MECHANICA", "BepInExPack_MECHANICA", PackageLoader.BEPINEX),
     new ModLoaderPackageMapping("BepInEx-BepInExPack_Muck", "BepInExPack_Muck", PackageLoader.BEPINEX),
-    new ModLoaderPackageMapping("LavaGang-MelonLoader", "", PackageLoader.MELON_LOADER),
     new ModLoaderPackageMapping("BepInEx-BepInExPack_LLBlaze", "BepInExPack_LLBlaze", PackageLoader.BEPINEX),
     new ModLoaderPackageMapping("BepInEx-BepInExPack_Timberborn", "BepInExPack_Timberborn", PackageLoader.BEPINEX),
     new ModLoaderPackageMapping("BepInEx-BepInExPack_TABS", "BepInExPack_TABS", PackageLoader.BEPINEX),
@@ -90,7 +90,7 @@ const VARIANTS = {
     ROUNDS: MODLOADER_PACKAGES,
     Mechanica: MODLOADER_PACKAGES,
     Muck: MODLOADER_PACKAGES,
-    BONEWORKS: MODLOADER_PACKAGES,
+    BONEWORKS: [new ModLoaderPackageMapping("LavaGang-MelonLoader", "", PackageLoader.MELON_LOADER, new VersionNumber("0.5.4"))],
     LethalLeagueBlaze: MODLOADER_PACKAGES,
     Timberborn: MODLOADER_PACKAGES,
     TABS: MODLOADER_PACKAGES,
@@ -121,7 +121,7 @@ const VARIANTS = {
     Aloft: MODLOADER_PACKAGES,
     COTL: MODLOADER_PACKAGES,
     ChronoArk: MODLOADER_PACKAGES,
-    BONELAB: MODLOADER_PACKAGES,
+    BONELAB: [new ModLoaderPackageMapping("LavaGang-MelonLoader", "", PackageLoader.MELON_LOADER, new VersionNumber("0.5.7"))],
     TromboneChamp: MODLOADER_PACKAGES,
     RogueGenesia: MODLOADER_PACKAGES,
     AcrossTheObelisk: MODLOADER_PACKAGES,


### PR DESCRIPTION
BONEWORKS has the problem where the latest release of MelonLoader is incompatible with the game. This is warned against on the site, however there is no indicator in the manager.

Without blocking downloads of MelonLoader, we can specify versions to use inside the MOD_LOADER_VARIANT_RECORD.