### PR TITLE
Sort by install date

### DIFF
--- a/src/components/ExpandableCard.vue
+++ b/src/components/ExpandableCard.vue
@@ -28,7 +28,6 @@
                     <div class='content'>
                         <p ref="description">{{description}}</p>
                         <slot name='description'></slot>
-                        <slot name='metadata'></slot>
                     </div>
                 </div>
                 <footer class='card-footer card-footer-borderless' v-show='visible' ref="footer">

--- a/src/components/ExpandableCard.vue
+++ b/src/components/ExpandableCard.vue
@@ -28,6 +28,7 @@
                     <div class='content'>
                         <p ref="description">{{description}}</p>
                         <slot name='description'></slot>
+                        <slot name='metadata'></slot>
                     </div>
                 </div>
                 <footer class='card-footer card-footer-borderless' v-show='visible' ref="footer">

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -224,7 +224,7 @@ function dependencyStringToModName(x: string) {
             </span>
         </template>
 
-        <template v-slot:metadata>
+        <template v-slot:description>
             <p class='card-timestamp' v-if="mod.getInstalledAtTime() !== 0"><strong>Installed on:</strong> {{ getReadableDate(mod.getInstalledAtTime()) }}</p>
         </template>
 

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -7,6 +7,7 @@ import ManifestV2 from '../../../model/ManifestV2';
 import ThunderstoreMod from '../../../model/ThunderstoreMod';
 import { LogSeverity } from '../../../providers/ror2/logging/LoggerProvider';
 import Dependants from '../../../r2mm/mods/Dependants';
+import { valueToReadableDate } from '../../../utils/DateUtils';
 
 @Component({
     components: {
@@ -177,6 +178,11 @@ export default class LocalModCard extends Vue {
     created() {
         this.updateDependencies();
     }
+
+    // Need to wrap util call in method to allow access from Vue context
+    getReadableDate(value: number): string {
+        return valueToReadableDate(value);
+    }
 }
 
 function dependencyStringToModName(x: string) {
@@ -216,6 +222,10 @@ function dependencyStringToModName(x: string) {
                     </component>
                 </span>
             </span>
+        </template>
+
+        <template v-slot:metadata>
+            <p class='card-timestamp' v-if="mod.getInstalledAtTime() !== 0"><strong>Installed on:</strong> {{ getReadableDate(mod.getInstalledAtTime()) }}</p>
         </template>
 
         <template v-slot:other-icons>

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -67,6 +67,7 @@ import DownloadModModal from './DownloadModModal.vue';
 import ManifestV2 from '../../model/ManifestV2';
 import DonateButton from '../../components/buttons/DonateButton.vue';
 import CdnProvider from '../../providers/generic/connection/CdnProvider';
+import { valueToReadableDate } from '../../utils/DateUtils';
 
 @Component({
     components: {
@@ -112,8 +113,7 @@ export default class OnlineModList extends Vue {
     }
 
     getReadableDate(date: Date): string {
-        const dateObject: Date = new Date(date);
-        return `${dateObject.toDateString()}, ${dateObject.toLocaleTimeString()}`
+        return valueToReadableDate(date);
     }
 
     getReadableCategories(tsMod: ThunderstoreMod) {

--- a/src/model/ManifestV2.ts
+++ b/src/model/ManifestV2.ts
@@ -24,6 +24,7 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
     private networkMode: string = '';
     private packageType: string = '';
     private installMode: string = '';
+    private installedAtTime: number = 0;
 
     private loaders: string[] = [];
     private dependencies: string[] = [];
@@ -31,9 +32,7 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
     private optionalDependencies: string[] = [];
 
     private versionNumber: VersionNumber = new VersionNumber('0.0.0');
-
     private enabled: boolean = true;
-
     private icon: string = '';
 
     // Will create a ManifestV2 object from a given manifest.
@@ -57,6 +56,7 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
         this.setIncompatibilities(data.Incompatibilities);
         this.setOptionalDependencies(data.OptionalDependencies);
         this.setVersionNumber(new VersionNumber(data.Version));
+        this.setInstalledAtTime(data.installedAtTime || 0);
         return this;
     }
 
@@ -127,6 +127,7 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
         this.setVersionNumber(new VersionNumber(`${versionNumber.major}.${versionNumber.minor}.${versionNumber.patch}`));
         this.setGameVersion(reactive.gameVersion);
         this.icon = path.join(PathResolver.MOD_ROOT, 'cache', this.getName(), this.versionNumber.toString(), 'icon.png');
+        this.setInstalledAtTime(reactive.installedAtTime || 0);
         if (!reactive.enabled) {
             this.disable();
         }
@@ -272,5 +273,13 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
 
     public setIcon(iconUri: string) {
         this.icon = iconUri;
+    }
+
+    public getInstalledAtTime(): number {
+        return this.installedAtTime;
+    }
+
+    public setInstalledAtTime(installedAtTime: number) {
+        this.installedAtTime = installedAtTime;
     }
 }

--- a/src/model/real_enums/sort/SortNaming.ts
+++ b/src/model/real_enums/sort/SortNaming.ts
@@ -3,5 +3,6 @@ export enum SortNaming {
     CUSTOM = "Custom",
     MOD_NAME = "Mod name",
     AUTHOR = "Author name",
+    INSTALL_DATE = "Install date",
 
 }

--- a/src/r2mm/mods/ModListSort.ts
+++ b/src/r2mm/mods/ModListSort.ts
@@ -52,6 +52,8 @@ export default class ModListSort {
                 return a.getDisplayName().localeCompare(b.getDisplayName());
             case SortNaming.AUTHOR:
                 return a.getAuthorName().localeCompare(b.getAuthorName());
+            case SortNaming.INSTALL_DATE:
+                return b.getInstalledAtTime() - a.getInstalledAtTime();
             case SortNaming.CUSTOM:
                 return 0;
         }

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -51,16 +51,18 @@ export default class ProfileModList {
                     if (
                         MOD_LOADER_VARIANTS[GameManager.activeGame.internalFolderName]
                             .find(x => x.packageName === mod.getName()) !== undefined
-                    ) // BepInEx is not a plugin, and the only place where we can get its icon is from the cache
+                    ) {
+                        // BepInEx is not a plugin, and so the only place where we can get its icon is from the cache
                         iconPath = path.resolve(profile.getPathOfProfile(), "BepInEx", "core", "icon.png");
-                    else
+                    } else {
                         iconPath = path.resolve(profile.getPathOfProfile(), "BepInEx", "plugins", mod.getName(), "icon.png");
+                    }
 
-                    if (await fs.exists(iconPath))
+                    if (await fs.exists(iconPath)) {
                         mod.setIcon(iconPath);
-                    else
+                    } else {
                         mod.setIcon(fallbackPath);
-
+                    }
                     value[modIndex] = mod;
                 }
                 return value;
@@ -111,6 +113,7 @@ export default class ProfileModList {
     }
 
     public static async addMod(mod: ManifestV2, profile: Profile): Promise<ManifestV2[] | R2Error> {
+        mod.setInstalledAtTime(Number(new Date())); // Set InstalledAt to current epoch millis
         let currentModList: ManifestV2[] | R2Error = await this.getModList(profile);
         if (currentModList instanceof R2Error) {
             currentModList = [];
@@ -121,6 +124,7 @@ export default class ProfileModList {
         if (currentModList instanceof R2Error) {
             currentModList = [];
         }
+        // Reinsert mod in list at same position if previously found
         if (modIndex >= 0) {
             currentModList.splice(modIndex, 0, mod);
         } else {
@@ -130,7 +134,6 @@ export default class ProfileModList {
         if (saveError !== null) {
             return saveError;
         }
-        // Return mod list, or R2 error. We don't care at this point as this is handled elsewhere.
         return this.getModList(profile);
     }
 

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -1,0 +1,4 @@
+export function valueToReadableDate(date: number | Date): string {
+    const dateObject: Date = new Date(date);
+    return `${dateObject.toDateString()}, ${dateObject.toLocaleTimeString()}`
+}


### PR DESCRIPTION
### Overview
A fairly frequently requested feature - useful for people to work out things what has changed after performing an `Update all` action.

### Screenshots

#### When installed before feature (no install date shown)
![image](https://github.com/ebkr/r2modmanPlus/assets/10426228/0cb18f89-f57e-42a0-8b2b-41f4572a4ef7)

#### When installed after feature (install date shown)
![image](https://github.com/ebkr/r2modmanPlus/assets/10426228/363dac39-a517-4de7-bce7-52fe88c8c4e2)

#### Sorting with a mixture of before/after feature mod install dates.
![image](https://github.com/ebkr/r2modmanPlus/assets/10426228/6a1e8192-47c0-46cf-90f7-2e69d65c3691)

If no date is found, default ordering will be applied.
