### PR TITLE
Improved online category filtering

### DIFF
--- a/src/components/modals/CategoryFilterModal.vue
+++ b/src/components/modals/CategoryFilterModal.vue
@@ -4,39 +4,30 @@
             <p class="card-header-title">Filter mod categories</p>
         </template>
         <template v-slot:body>
-            <div class="input-group">
-                <label>Categories</label>
-                <select class="select select--content-spacing" @change="selectCategory($event)">
-                    <option selected disabled>
-                        Select a category
-                    </option>
-                    <option v-for="(key, index) in unselectedCategories" :key="`category--${key}-${index}`">
-                        {{ key }}
-                    </option>
-                </select>
-            </div>
-            <br/>
-            <div class="input-group">
-                <label>Selected categories:</label>
-                <div class="field has-addons" v-if="selectedCategories.length > 0">
-                    <div class="control" v-for="(key, index) in selectedCategories" :key="`${key}-${index}`">
-                        <span class="block margin-right">
-                            <a href="#" @click="unselectCategory(key)">
-                                <span class="tags has-addons">
-                                    <span class="tag">{{ key }}</span>
-                                    <span class="tag is-danger">
-                                        <i class="fas fa-times"></i>
-                                    </span>
-                                </span>
-                            </a>
-                        </span>
-                    </div>
-                </div>
-                <div class="field has-addons" v-else>
-                    <span class="tags">
-                        <span class="tag">No categories selected</span>
-                    </span>
-                </div>
+            <div>
+                <CategorySelectorModal
+                    title="Mods must contain at least one of these categories"
+                    :selected-categories="selectedCategoriesCompareOne"
+                    :selectable-categories="unselectedCategories"
+                    @selected-category="selectCompareOneCategory"
+                    @deselected-category="unselectCategory"
+                />
+                <hr/>
+                <CategorySelectorModal
+                    title="Mods must contain all of these categories"
+                    :selected-categories="selectedCategoriesCompareAll"
+                    :selectable-categories="unselectedCategories"
+                    @selected-category="selectCompareAllCategory"
+                    @deselected-category="unselectCategory"
+                />
+                <hr/>
+                <CategorySelectorModal
+                    title="Mods cannot contain any of these categories"
+                    :selected-categories="selectedCategoriesToExclude"
+                    :selectable-categories="unselectedCategories"
+                    @selected-category="selectToExcludeCategory"
+                    @deselected-category="unselectCategory"
+                />
             </div>
             <hr/>
             <div>
@@ -61,22 +52,6 @@
                     <label for="showDeprecatedCheckbox">Show deprecated mods</label>
                 </div>
             </div>
-            <br/>
-            <div>
-                <div v-for="(key, index) in categoryFilterValues" :key="`cat-filter-${key}-${index}`">
-                    <input
-                        name="categoryFilterCondition"
-                        type="radio"
-                        :id="`cat-filter-${key}-${index}`"
-                        :value=key
-                        :checked="index === 0 ? true : undefined" v-model="categoryFilterMode"
-                    />
-                    <label :for="`cat-filter-${key}-${index}`">
-                        <span class="margin-right margin-right--half-width" />
-                        {{ key }}
-                    </label>
-                </div>
-            </div>
         </template>
         <template v-slot:footer>
             <button class="button is-info" @click="close">
@@ -90,10 +65,10 @@
 import { Component, Vue } from "vue-property-decorator";
 
 import { Modal } from '../../components/all';
-import CategoryFilterMode from '../../model/enums/CategoryFilterMode';
+import CategorySelectorModal from '../../components/modals/CategorySelectorModal.vue';
 
 @Component({
-    components: { Modal }
+    components: { CategorySelectorModal, Modal }
 })
 export default class CategoryFilterModal extends Vue {
     get allowNsfw(): boolean {
@@ -102,18 +77,6 @@ export default class CategoryFilterModal extends Vue {
 
     set allowNsfw(value: boolean) {
         this.$store.commit("modFilters/setAllowNsfw", value);
-    }
-
-    get categoryFilterMode(): CategoryFilterMode {
-        return this.$store.state.modFilters.categoryFilterMode;
-    }
-
-    set categoryFilterMode(value: CategoryFilterMode) {
-        this.$store.commit("modFilters/setCategoryFilterMode", value);
-    }
-
-    get categoryFilterValues() {
-        return Object.values(CategoryFilterMode);
     }
 
     get showDeprecatedPackages(): boolean {
@@ -136,17 +99,43 @@ export default class CategoryFilterModal extends Vue {
         return this.$store.state.modals.isCategoryFilterModalOpen;
     }
 
-    selectCategory(event: Event) {
+    selectCompareOneCategory(event: Event) {
         if (!(event.target instanceof HTMLSelectElement)) {
             return;
         }
 
-        this.$store.commit("modFilters/selectCategory", event.target.value);
+        this.$store.commit("modFilters/selectCategoryToCompareOne", event.target.value);
         event.target.selectedIndex = 0;
     }
 
-    get selectedCategories(): string[] {
-        return this.$store.state.modFilters.selectedCategories;
+    selectCompareAllCategory(event: Event) {
+        if (!(event.target instanceof HTMLSelectElement)) {
+            return;
+        }
+
+        this.$store.commit("modFilters/selectCategoryToCompareAll", event.target.value);
+        event.target.selectedIndex = 0;
+    }
+
+    selectToExcludeCategory(event: Event) {
+        if (!(event.target instanceof HTMLSelectElement)) {
+            return;
+        }
+
+        this.$store.commit("modFilters/selectCategoryToExclude", event.target.value);
+        event.target.selectedIndex = 0;
+    }
+
+    get selectedCategoriesCompareOne(): string[] {
+        return this.$store.state.modFilters.selectedCategoriesCompareOne;
+    }
+
+    get selectedCategoriesCompareAll(): string[] {
+        return this.$store.state.modFilters.selectedCategoriesCompareAll;
+    }
+
+    get selectedCategoriesToExclude(): string[] {
+        return this.$store.state.modFilters.selectedCategoriesToExclude;
     }
 
     unselectCategory(category: string) {

--- a/src/components/modals/CategorySelectorModal.vue
+++ b/src/components/modals/CategorySelectorModal.vue
@@ -11,19 +11,15 @@
                 </option>
             </select>
         </div>
-        <div class="field has-addons" v-if="selectedCategories.length > 0">
-            <div class="control" v-for="(key, index) in selectedCategories" :key="`${key}-${index}`">
-                <span class="block margin-right">
-                    <a href="#" @click="emitDeselected(key)">
-                        <span class="tags has-addons">
-                            <span class="tag">{{ key }}</span>
-                            <span class="tag is-danger">
-                                <i class="fas fa-times"></i>
-                            </span>
-                        </span>
-                    </a>
-                </span>
-            </div>
+        <div class="tags has-addons" v-if="selectedCategories.length > 0">
+            <span class="margin-right" v-for="(key, index) in selectedCategories" :key="`${key}-${index}`">
+                <a href="#" @click="emitDeselected(key)">
+                    <div class="tag has-addons">
+                        <span>{{ key }}</span>
+                    </div>
+                    <span class="tag is-delete is-danger">&nbsp;</span>
+                </a>
+            </span>
         </div>
         <div class="field has-addons" v-else>
             <span class="tags">

--- a/src/components/modals/CategorySelectorModal.vue
+++ b/src/components/modals/CategorySelectorModal.vue
@@ -1,0 +1,60 @@
+<template>
+    <div class="input-group">
+        <label>{{ title }}:</label>
+        <div class="input-group margin-bottom">
+            <select class="select select--content-spacing" @change="emitSelected">
+                <option selected disabled>
+                    Select a category
+                </option>
+                <option v-for="(key, index) in selectableCategories" :key="`category--${key}-${index}`">
+                    {{ key }}
+                </option>
+            </select>
+        </div>
+        <div class="field has-addons" v-if="selectedCategories.length > 0">
+            <div class="control" v-for="(key, index) in selectedCategories" :key="`${key}-${index}`">
+                <span class="block margin-right">
+                    <a href="#" @click="emitDeselected(key)">
+                        <span class="tags has-addons">
+                            <span class="tag">{{ key }}</span>
+                            <span class="tag is-danger">
+                                <i class="fas fa-times"></i>
+                            </span>
+                        </span>
+                    </a>
+                </span>
+            </div>
+        </div>
+        <div class="field has-addons" v-else>
+            <span class="tags">
+                <span class="tag">No categories selected</span>
+            </span>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+@Component
+export default class ChangeSelectorModal extends Vue {
+
+    @Prop({required: true})
+    private title!: string;
+
+    @Prop({required: true})
+    private selectedCategories!: string[]
+
+    @Prop({required: true})
+    private selectableCategories!: string[]
+
+    emitSelected(event: Event) {
+        this.$emit("selected-category", event);
+    }
+
+    emitDeselected(key: string) {
+        this.$emit("deselected-category", key);
+    }
+
+}
+</script>

--- a/src/model/enums/CategoryFilterMode.ts
+++ b/src/model/enums/CategoryFilterMode.ts
@@ -1,7 +1,0 @@
-enum CategoryFilterMode {
-    OR = 'Mod has at least one of these categories',
-    AND = 'Mod has all of these categories',
-    EXCLUDE = 'Mod has none of these categories'
-};
-
-export default CategoryFilterMode;

--- a/src/store/modules/ModFilterModule.ts
+++ b/src/store/modules/ModFilterModule.ts
@@ -1,12 +1,12 @@
 import { GetterTree } from 'vuex';
 
 import { State as RootState } from '../index';
-import CategoryFilterMode from '../../model/enums/CategoryFilterMode';
 
 interface State {
     allowNsfw: boolean;
-    categoryFilterMode: CategoryFilterMode;
-    selectedCategories: string[];
+    selectedCategoriesCompareOne: string[];
+    selectedCategoriesCompareAll: string[];
+    selectedCategoriesToExclude: string[];
     showDeprecatedPackages: boolean;
 }
 
@@ -18,39 +18,52 @@ export default {
 
     state: (): State => ({
         allowNsfw: false,
-        categoryFilterMode: CategoryFilterMode.OR,
-        selectedCategories: [],
+        selectedCategoriesCompareOne: [],
+        selectedCategoriesCompareAll: [],
+        selectedCategoriesToExclude: [],
         showDeprecatedPackages: false
     }),
 
     getters: <GetterTree<State, RootState>>{
         unselectedCategories (state, _getters, _rootState, rootGetters) {
             const categories: string[] = rootGetters['tsMods/categories'];
-            return categories.filter((c: string) => !state.selectedCategories.includes(c));
+            const selectedCategories = [
+                ...state.selectedCategoriesCompareOne,
+                ...state.selectedCategoriesCompareAll,
+                ...state.selectedCategoriesToExclude
+            ]
+            return categories.filter((c: string) => !selectedCategories.includes(c));
         }
     },
 
     mutations: {
         reset: function(state: State) {
             state.allowNsfw = false;
-            state.categoryFilterMode = CategoryFilterMode.OR;
-            state.selectedCategories = [];
+            state.selectedCategoriesCompareOne = [];
+            state.selectedCategoriesCompareAll = [];
+            state.selectedCategoriesToExclude = [];
         },
 
-        selectCategory: function(state: State, category: string) {
-            state.selectedCategories = [...state.selectedCategories, category];
+        selectCategoryToCompareOne: function(state: State, category: string) {
+            state.selectedCategoriesCompareOne = [...state.selectedCategoriesCompareOne, category];
+        },
+
+        selectCategoryToCompareAll: function(state: State, category: string) {
+            state.selectedCategoriesCompareAll = [...state.selectedCategoriesCompareAll, category];
+        },
+
+        selectCategoryToExclude: function(state: State, category: string) {
+            state.selectedCategoriesToExclude = [...state.selectedCategoriesToExclude, category];
         },
 
         setAllowNsfw: function(state: State, value: boolean) {
             state.allowNsfw = value;
         },
 
-        setCategoryFilterMode: function(state: State, value: CategoryFilterMode) {
-            state.categoryFilterMode = value;
-        },
-
         unselectCategory: function(state: State, category: string) {
-            state.selectedCategories = state.selectedCategories.filter((c) => c !== category);
+            state.selectedCategoriesCompareOne = state.selectedCategoriesCompareOne.filter((c) => c !== category);
+            state.selectedCategoriesCompareAll = state.selectedCategoriesCompareAll.filter((c) => c !== category);
+            state.selectedCategoriesToExclude = state.selectedCategoriesToExclude.filter((c) => c !== category);
         },
 
         setShowDeprecatedPackages: function(state: State, value: boolean) {


### PR DESCRIPTION
All three filtering options are now present alongside each other in the filter modal. The user no longer needs to select only one filter behaviour type.

It's a fairly common criticism that the app doesn't match the filter behaviour on the site.

This is still somewhat the case however expands to support the actual behaviour that people are after, which is to filter on both include and exclude.

The existing behaviour was for:
- Contains at least one category
- Contains all categories
- Exclude category

These three are now present in the modal under tag selections as opposed to being a radio option.

### Screenshots
![image](https://github.com/ebkr/r2modmanPlus/assets/10426228/8b9e3919-ed37-42ad-a96b-1d91e85d1054)
