### PR TITLE
Temporarily hide Risk of Rain Returns from the game list

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -640,11 +640,12 @@ export default class GameManager {
             [new StorePlatformMetadata(StorePlatform.STEAM, "2695940")], "Panicore.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.SHIMLOADER, ["panicore"]),
 
-        new Game("Risk of Rain Returns", "RiskofRainReturns", "RiskofRainReturns",
-            "Risk of Rain Returns", ["Risk of Rain Returns.exe"], "",
-            "https://thunderstore.io/c/risk-of-rain-returns/api/v1/package/", EXCLUSIONS,
-            [new StorePlatformMetadata(StorePlatform.STEAM, "1337520")], "RiskOfRainReturns.png",
-            GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.RETURN_OF_MODDING, ["rorr"]),
+        // TODO: This is very temporarily disabled to hide the game from TSMM.
+        // new Game("Risk of Rain Returns", "RiskofRainReturns", "RiskofRainReturns",
+        //     "Risk of Rain Returns", ["Risk of Rain Returns.exe"], "",
+        //     "https://thunderstore.io/c/risk-of-rain-returns/api/v1/package/", EXCLUSIONS,
+        //     [new StorePlatformMetadata(StorePlatform.STEAM, "1337520")], "RiskOfRainReturns.png",
+        //     GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.RETURN_OF_MODDING, ["rorr"]),
 
         new Game("Magicraft", "Magicraft", "Magicraft",
             "Magicraft", ["Magicraft.exe"], "Magicraft_Data",


### PR DESCRIPTION
TSMM is not ready to release this game yet, but it blocks other changes from being released. I intend to revert this change once TSMM release has been made. (This is not ideal but it's the path of least resistance to get the release done.)