### PR TITLE
Fixes #1315 - Prevents unsafe URLs being opened

### DIFF
--- a/src/AppWrapper.vue
+++ b/src/AppWrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <div id="q-app">
-        <SettingsLoader :logError="logError" :openLink="openLink">
+        <SettingsLoader :logError="logError" :openWebOnlyLink="openWebOnlyLink">
             <App />
         </SettingsLoader>
     </div>
@@ -23,8 +23,8 @@ export default class AppWrapper extends Vue {
         console.error(error.name, error.message, error.stack);
     }
 
-    openLink(url: string) {
-        new LinkImpl().openLink(url);
+    openWebOnlyLink(url: string) {
+        new LinkImpl().openWebOnlyLink(url);
     }
 }
 </script>

--- a/src/components/Link.vue
+++ b/src/components/Link.vue
@@ -2,7 +2,7 @@
     <component  :is="tag" v-if="target === 'file'" @click="selectFile()" class='target-link' data-semantic="file-selection">
         <slot></slot>
     </component>
-    <component  :is="tag" v-else-if="target !== null" @click="openLink()" class='target-link' data-semantic="external-link">
+    <component  :is="tag" v-else-if="target !== null" @click="openWebOnlyLink()" class='target-link' data-semantic="external-link">
         <slot></slot>
     </component>
     <component  :is="tag" class='target-link' v-else-if="target === null" data-semantic="visual-indicator">
@@ -27,8 +27,8 @@ import LinkProvider from '../providers/components/LinkProvider';
         @Prop({default: 'a'})
         tag: string | undefined;
 
-        openLink() {
-            LinkProvider.instance.openLink(this.url!);
+        openWebOnlyLink() {
+            LinkProvider.instance.openWebOnlyLink(this.url!);
         }
 
         selectFile() {

--- a/src/components/SettingsLoader.vue
+++ b/src/components/SettingsLoader.vue
@@ -34,7 +34,7 @@
                         Resetting of the settings failed. You can still
                         try to reset the settings manually by following
                         these
-                        <a @click="openLink('https://github.com/ebkr/r2modmanPlus/wiki/Error:-White-or-blank-game-select-screen-on-startup#corrupted-settings-on-update')">
+                        <a @click="openWebOnlyLink('https://github.com/ebkr/r2modmanPlus/wiki/Error:-White-or-blank-game-select-screen-on-startup#corrupted-settings-on-update')">
                             instructions.
                         </a>
                     </p>
@@ -78,7 +78,7 @@ export default class SettingsLoader extends Vue {
     private logError!: (error: R2Error) => void;
 
     @Prop({required: true})
-    openLink!: (url: string) => void;
+    openWebOnlyLink!: (url: string) => void;
 
     error: R2Error|null = null;
     PHASES = PHASES;

--- a/src/providers/components/LinkProvider.ts
+++ b/src/providers/components/LinkProvider.ts
@@ -14,6 +14,18 @@ export default abstract class LinkProvider {
         return LinkProvider.provider();
     }
 
+    /**
+     * Safe URL opening, includes http(s):// only
+     *
+     * @param url HTTP / HTTPS Only URL
+     */
+    public abstract openWebOnlyLink(url: string): void;
+
+    /**
+     * Unsafe URL opening, includes file://, steam:// and http(s)://
+     *
+     * @param url URL to open
+     */
     public abstract openLink(url: string): void;
 
     public abstract selectFile(url: string): void;

--- a/src/r2mm/component_override/LinkImpl.ts
+++ b/src/r2mm/component_override/LinkImpl.ts
@@ -7,6 +7,12 @@ export default class LinkImpl extends LinkProvider {
         shell.openExternal(url);
     }
 
+    openWebOnlyLink(url: string): void {
+        if (url.startsWith("http://") || url.startsWith("https://")) {
+            shell.openExternal(url);
+        }
+    }
+
     selectFile(url: string): void {
         shell.showItemInFolder(url);
     }

--- a/test/jest/__tests__/stubs/providers/stub.LinkProvider.ts
+++ b/test/jest/__tests__/stubs/providers/stub.LinkProvider.ts
@@ -6,6 +6,10 @@ export default class StubLinkProvider extends LinkProvider {
         throw new Error("Stub access must be mocked or spied");
     }
 
+    openWebOnlyLink(url: string): void {
+        throw new Error("Stub access must be mocked or spied");
+    }
+
     selectFile(url: string): void {
         throw new Error("Stub access must be mocked or spied");
     }


### PR DESCRIPTION
Fixes #1315 

Adds a second method to open web only URLs (http(s)) - openLink is also used to open `steam://` and `file://` URLs, this method is for customer facing links which are _meant_ to only be web URLs.

