### PR TITLE
Tale spire demo support

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -87,7 +87,7 @@ export default class GameManager {
         new Game('TaleSpire', 'TaleSpire', 'TaleSpire',
             'TaleSpire', ['TaleSpire.exe'], 'TaleSpire_Data',
             'https://talespire.thunderstore.io/api/v1/package/', EXCLUSIONS,
-            [new StorePlatformMetadata(StorePlatform.STEAM, "720620")], "TaleSpire.jpg",
+            [new StorePlatformMetadata(StorePlatform.STEAM, "720620"), new StorePlatformMetadata(StorePlatform.STEAM_DEMO, "2881860")], "TaleSpire.jpg",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["TS"]),
 
         new Game("H3VR", "H3VR", "H3VR",

--- a/src/model/game/StorePlatform.ts
+++ b/src/model/game/StorePlatform.ts
@@ -1,6 +1,7 @@
 export enum StorePlatform {
     STEAM = "Steam",
     STEAM_DIRECT = "Steam ", // Add a space so that there's no conflict in the PlatformInterceptor listing
+    STEAM_DEMO = "Steam Demo",
     EPIC_GAMES_STORE = "Epic Games Store",
     OCULUS_STORE = "Oculus Store",
     ORIGIN = "Origin / EA Desktop",

--- a/src/providers/generic/game/platform_interceptor/PlatformInterceptorImpl.ts
+++ b/src/providers/generic/game/platform_interceptor/PlatformInterceptorImpl.ts
@@ -71,6 +71,7 @@ function buildRunners(runners: PlatformRunnersType): LoaderRunnersType {
 
 const RUNNERS: RunnerType = {
     [StorePlatform.STEAM]: buildRunners(STEAM_RUNNERS),
+    [StorePlatform.STEAM_DEMO]: buildRunners(STEAM_RUNNERS),
     [StorePlatform.STEAM_DIRECT]: buildRunners(DIRECT_RUNNERS),
     [StorePlatform.EPIC_GAMES_STORE]: buildRunners(EGS_RUNNERS),
     [StorePlatform.OCULUS_STORE]: buildRunners(DIRECT_RUNNERS),
@@ -81,6 +82,11 @@ const RUNNERS: RunnerType = {
 
 const RESOLVERS: ResolverType = {
     [StorePlatform.STEAM]: {
+        "win32": new GameDirectoryResolverImpl_Steam_Win,
+        "linux": new GameDirectoryResolverImpl_Steam_Linux(),
+        "darwin": new DarwinGameDirectoryResolver()
+    },
+    [StorePlatform.STEAM_DEMO]: {
         "win32": new GameDirectoryResolverImpl_Steam_Win,
         "linux": new GameDirectoryResolverImpl_Steam_Linux(),
         "darwin": new DarwinGameDirectoryResolver()

--- a/src/r2mm/manager/PreloaderFixer.ts
+++ b/src/r2mm/manager/PreloaderFixer.ts
@@ -11,7 +11,7 @@ import { StorePlatform } from '../../model/game/StorePlatform';
 export default class PreloaderFixer {
 
     public static async fix(game: Game): Promise<R2Error | void> {
-        if (![StorePlatform.STEAM, StorePlatform.STEAM_DIRECT].includes(game.activePlatform.storePlatform)) {
+        if (![StorePlatform.STEAM, StorePlatform.STEAM_DIRECT, StorePlatform.STEAM_DEMO].includes(game.activePlatform.storePlatform)) {
             return new R2Error(
                 "PreloaderFix is not available on non-Steam platforms.",
                 `The preloader fix deletes the ${path.join(game.dataFolderName, 'Managed')} folder and verifies files. You can do the same manually.`,


### PR DESCRIPTION
TaleSpire has a "TaleSpire - Guest Edition" on Steam which is a separate version of TaleSpire under a different Steam ID. By adding Demo support, users of "Guest Edition" can use the mod manager for their version.