### PR TITLE
Clean up ThunderstoreDownloaderProvider

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -152,7 +152,17 @@ let assignId = 0;
             return this.$store.getters['profile/activeProfile'];
         }
 
-        public static async downloadSpecific(game: Game, profile: Profile, combo: ThunderstoreCombo, thunderstorePackages: ThunderstoreMod[]): Promise<void> {
+        get ignoreCache(): boolean {
+            const settings = this.$store.getters['settings'];
+            return settings.getContext().global.ignoreCache;
+        }
+
+        public static async downloadSpecific(
+            profile: Profile,
+            combo: ThunderstoreCombo,
+            thunderstorePackages: ThunderstoreMod[],
+            ignoreCache: boolean
+        ): Promise<void> {
             return new Promise((resolve, reject) => {
                 const tsMod = combo.getMod();
                 const tsVersion = combo.getVersion();
@@ -166,7 +176,7 @@ let assignId = 0;
                 };
                 DownloadModModal.allVersions.push([currentAssignId, progressObject]);
                 setTimeout(() => {
-                    ThunderstoreDownloaderProvider.instance.download(game, profile, tsMod, tsVersion, thunderstorePackages, (progress: number, modName: string, status: number, err: R2Error | null) => {
+                    ThunderstoreDownloaderProvider.instance.download(profile, tsMod, tsVersion, thunderstorePackages, ignoreCache, (progress: number, modName: string, status: number, err: R2Error | null) => {
                         const assignIndex = DownloadModModal.allVersions.findIndex(([number, val]) => number === currentAssignId);
                         if (status === StatusEnum.FAILURE) {
                             if (err !== null) {
@@ -280,7 +290,7 @@ let assignId = 0;
         }
 
         // TODO: rethink how this method and provider's downloadLatestOfAll()
-        // access the active game, local mod list and TS mod list.
+        // access the local mod list and TS mod list.
         async downloadLatest() {
             this.closeModal();
             const modsWithUpdates: ThunderstoreCombo[] = this.$store.getters['profile/modsWithUpdates'];
@@ -295,7 +305,7 @@ let assignId = 0;
             this.downloadObject = progressObject;
             DownloadModModal.allVersions.push([currentAssignId, this.downloadObject]);
             this.downloadingMod = true;
-            ThunderstoreDownloaderProvider.instance.downloadLatestOfAll(this.activeGame, modsWithUpdates, this.thunderstorePackages, (progress: number, modName: string, status: number, err: R2Error | null) => {
+            ThunderstoreDownloaderProvider.instance.downloadLatestOfAll(modsWithUpdates, this.thunderstorePackages, this.ignoreCache, (progress: number, modName: string, status: number, err: R2Error | null) => {
                 const assignIndex = DownloadModModal.allVersions.findIndex(([number, val]) => number === currentAssignId);
                 if (status === StatusEnum.FAILURE) {
                     if (err !== null) {
@@ -337,7 +347,7 @@ let assignId = 0;
             DownloadModModal.allVersions.push([currentAssignId, this.downloadObject]);
             this.downloadingMod = true;
             setTimeout(() => {
-                ThunderstoreDownloaderProvider.instance.download(this.activeGame, this.profile, tsMod, tsVersion, this.thunderstorePackages, (progress: number, modName: string, status: number, err: R2Error | null) => {
+                ThunderstoreDownloaderProvider.instance.download(this.profile, tsMod, tsVersion, this.thunderstorePackages, this.ignoreCache, (progress: number, modName: string, status: number, err: R2Error | null) => {
                     const assignIndex = DownloadModModal.allVersions.findIndex(([number, val]) => number === currentAssignId);
                     if (status === StatusEnum.FAILURE) {
                         if (err !== null) {

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -615,6 +615,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
 
 		async created() {
 			this.launchParametersModel = this.settings.getContext().gameSpecific.launchParameters;
+			const ignoreCache = this.settings.getContext().global.ignoreCache;
 
 			InteractionProvider.instance.hookModInstallProtocol(async data => {
                 const combo: ThunderstoreCombo | R2Error = ThunderstoreCombo.fromProtocol(data, this.thunderstoreModList);
@@ -625,7 +626,7 @@ import CategoryFilterModal from '../components/modals/CategoryFilterModal.vue';
                     });
                     return;
                 }
-                DownloadModModal.downloadSpecific(this.activeGame, this.profile, combo, this.thunderstoreModList)
+                DownloadModModal.downloadSpecific(this.profile, combo, this.thunderstoreModList, ignoreCache)
                     .then(async value => {
                         const modList = await ProfileModList.getModList(this.profile);
                         if (!(modList instanceof R2Error)) {

--- a/src/providers/ror2/downloading/ThunderstoreDownloaderProvider.ts
+++ b/src/providers/ror2/downloading/ThunderstoreDownloaderProvider.ts
@@ -2,11 +2,8 @@ import ProviderUtils from '../../generic/ProviderUtils';
 import ThunderstoreVersion from '../../../model/ThunderstoreVersion';
 import ThunderstoreMod from '../../../model/ThunderstoreMod';
 import ThunderstoreCombo from '../../../model/ThunderstoreCombo';
-import ManifestV2 from '../../../model/ManifestV2';
 import R2Error from '../../../model/errors/R2Error';
 import ExportMod from '../../../model/exports/ExportMod';
-import ManagerSettings from '../../../r2mm/manager/ManagerSettings';
-import Game from '../../../model/game/Game';
 import Profile from '../../../model/Profile';
 
 export default abstract class ThunderstoreDownloaderProvider {
@@ -48,39 +45,40 @@ export default abstract class ThunderstoreDownloaderProvider {
     /**
      * A top-level method to download the latest version of all mods passed in, including their dependencies.
      *
-     * @param game              Currently selected game
      * @param modsWithUpdate    An array of ThunderstoreCombo objects to be updated.
      * @param allMods           An array of all mods available from the Thunderstore API.
+     * @param ignoreCache       Download mod even if it already exists in the cache.
      * @param callback          Callback to show the current state of the downloads.
      * @param completedCallback Callback to perform final actions against. Only called if {@param callback} has not returned a failed status.
      */
-    public abstract downloadLatestOfAll(game: Game, modsWithUpdate: ThunderstoreCombo[], allMods: ThunderstoreMod[],
+    public abstract downloadLatestOfAll(modsWithUpdate: ThunderstoreCombo[], allMods: ThunderstoreMod[], ignoreCache: boolean,
                                callback: (progress: number, modName: string, status: number, err: R2Error | null) => void,
                                completedCallback: (modList: ThunderstoreCombo[]) => void): void;
 
     /**
      * A top-level method to download the latest version of a mod including its dependencies.
      *
-     * @param game              Currently selected game
      * @param mod               The mod to be downloaded.
      * @param modVersion        The version of the mod to download.
      * @param allMods           An array of all mods available from the Thunderstore API.
+     * @param ignoreCache       Download mod even if it already exists in the cache.
      * @param callback          Callback to show the current state of the downloads.
      * @param completedCallback Callback to perform final actions against. Only called if {@param callback} has not returned a failed status.
      */
-    public abstract download(game: Game, profile: Profile, mod: ThunderstoreMod, modVersion: ThunderstoreVersion, allMods: ThunderstoreMod[],
+    public abstract download(profile: Profile, mod: ThunderstoreMod, modVersion: ThunderstoreVersion, allMods: ThunderstoreMod[], ignoreCache: boolean,
                     callback: (progress: number, modName: string, status: number, err: R2Error | null) => void,
                     completedCallback: (modList: ThunderstoreCombo[]) => void): void;
 
     /**
      * A top-level method to download exact versions of exported mods.
      *
-     * @param game              Currently selected game
      * @param modList           An array of {@class ExportMod} mods to download.
+     * @param allMods           An array of all mods available from the Thunderstore API.
+     * @param ignoreCache       Download mod even if it already exists in the cache.
      * @param callback          See {@method download}.
      * @param completedCallback See {@method download}
      */
-    public abstract downloadImportedMods(game: Game, modList: ExportMod[],
+    public abstract downloadImportedMods(modList: ExportMod[], allMods: ThunderstoreMod[], ignoreCache: boolean,
                                 callback: (progress: number, modName: string, status: number, err: R2Error | null) => void,
                                 completedCallback: (mods: ThunderstoreCombo[]) => void): void;
 
@@ -97,28 +95,27 @@ export default abstract class ThunderstoreDownloaderProvider {
      * Iterate the {@class ThunderstoreCombo} array to perform the download for each mod.
      * Progress to the next one recursively once the callback received has been successful.
      *
-     * @param settings  Instance of ManagerSettings.
-     * @param entries   IterableIterator of entries for {@class ThunderstoreCombo} mods to download.
-     * @param callback  See {@method download}
+     * @param entries      IterableIterator of entries for {@class ThunderstoreCombo} mods to download.
+     * @param ignoreCache  Should mod be downloaded even if it already exists in the cache?
+     * @param callback     See {@method download}
      */
-    public abstract queueDownloadDependencies(settings: ManagerSettings, entries: IterableIterator<[number, ThunderstoreCombo]>, callback: (progress: number, modName: string, status: number, err: R2Error | null) => void): void
+    public abstract queueDownloadDependencies(entries: IterableIterator<[number, ThunderstoreCombo]>, ignoreCache: boolean, callback: (progress: number, modName: string, status: number, err: R2Error | null) => void): void
 
     /**
      * Generate the total count of mods to be downloaded. Cached mods are not included in this count unless download cache is disabled.
      *
-     * @param settings  Instance of ManagerSettings.
      * @param list      List of mods generated by a dependency building method including the primary mod to be downloaded.
      */
-    public abstract calculateInitialDownloadSize(settings: ManagerSettings, list: ThunderstoreCombo[]): number;
+    public abstract calculateInitialDownloadSize(list: ThunderstoreCombo[]): number;
 
     /**
      * Perform the download of the given {@class ThunderstoreCombo}.
      *
-     * @param combo     The current mod to download.
-     * @param settings  Instance of ManagerSettings.
-     * @param callback  See {@method download}
+     * @param combo        The current mod to download.
+     * @param ignoreCache  Should mod be downloaded even if it already exists in the cache?
+     * @param callback     See {@method download}
      */
-    public abstract downloadAndSave(combo: ThunderstoreCombo, settings: ManagerSettings, callback: (progress: number, status: number, err: R2Error | null) => void): void;
+    public abstract downloadAndSave(combo: ThunderstoreCombo, ignoreCache: boolean, callback: (progress: number, status: number, err: R2Error | null) => void): void;
 
     /**
      * Save the download buffer to a zip file in the cache.


### PR DESCRIPTION
Remove references to settings and active game from the download provider, as these were mostly used to only access the setting telling whether to ignore the cached mod downloads. Instead pass the settings as a boolean argument.

Implement related changes to provider implementation and their callsites.

In downloadAndSave, switch to checking the variable for ignoring the cache first, before checking if the mod actually exists on the disk, as this might reduce the number of unnecessary file operations.