### PR TITLE
Attempt to mitigate a race condition corrupting the mods.yml file

### DIFF
--- a/src/store/modules/ProfileModule.ts
+++ b/src/store/modules/ProfileModule.ts
@@ -308,13 +308,22 @@ export default {
         },
 
         async saveModListToDisk(
-            {dispatch},
+            {dispatch, getters},
             params: {
                 mods: ManifestV2[],
                 profile: Profile,
             }
         ) {
             const {mods, profile} = params;
+
+            // Sanity check against race conditions. E.g. using the text filter
+            // disables ordering, but if the user is fast enough they can start
+            // dragging a mod after writing into input. If the dragging is then
+            // finished succesfully after the filter is applied, mods.yml would
+            // be overwritten to contain only the visible, filtered mods.
+            if (!getters['canSortMods']) {
+                return;
+            }
 
             ProfileModList.requestLock(async () => {
                 const err = await ProfileModList.saveModList(profile, mods);


### PR DESCRIPTION
There exists a race condition between disabling the ordering of the local mod list and user starting to drag an item:

1. Have a large, slow profile open on local mod list
2. Have the text filter and ordering dropdowns set to support ordering by dragging
3. Write something to the text filter and start dragging a mod before the UI updates to disable dragging
4. Keep the dragging active by keeping the mouse button pressed
5. Once the text filter is applied to the mod list:
    - If the mod being dragged has been filtered out and is no longer part of the list SortableJS throws unhandled type errors: `Cannot read properties of null (reading 'Sortable1724978245665')`
    - If the mod being dragged is still visible on the mod list and it's released so its ordinal changes, the currently visible mod list is used to overwrite the contents of the `mods.yml` file

Other paths to trigger a similar condition are likely to exists.

Fixing the race condition itself seems difficult. This easy fix can at least prevent the worst outcome in some situations.