### PR TITLE
WIP: mod version hiding

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,6 +17,7 @@ Vue.use(Vuex);
 
 export interface State {
     activeGame: Game;
+    activeGameModLoaderTarget: string | null;
     isMigrationChecked: boolean;
     _settings: ManagerSettings | null;
 }
@@ -31,6 +32,7 @@ type Context = ActionContext<State, State>;
 export const store = {
     state: {
         activeGame: GameManager.defaultGame,
+        activeGameModLoaderTarget: null,
         isMigrationChecked: false,
 
         // Access through getters to ensure the settings are loaded.
@@ -68,11 +70,17 @@ export const store = {
             const settings = await ManagerSettings.getSingleton(game);
             commit('setSettings', settings);
             return settings;
+
+            // TODO: update setActiveGameModLoaderTarget once we know
+            // where to read it from.
         }
     },
     mutations: {
         setActiveGame(state: State, game: Game) {
             state.activeGame = game;
+        },
+        setActiveGameModLoaderTarget(state: State, dependencyString: string) {
+            state.activeGameModLoaderTarget = dependencyString;
         },
         setMigrationChecked(state: State) {
             state.isMigrationChecked = true;

--- a/src/store/modules/TsModsModule.ts
+++ b/src/store/modules/TsModsModule.ts
@@ -7,6 +7,7 @@ import ThunderstoreMod from '../../model/ThunderstoreMod';
 import ConnectionProvider from '../../providers/generic/connection/ConnectionProvider';
 import * as PackageDb from '../../r2mm/manager/PackageDexieStore';
 import { Deprecations } from '../../utils/Deprecations';
+import { filterModVersions } from '../../utils/ManagerUtils';
 
 interface CachedMod {
     tsMod: ThunderstoreMod | undefined;
@@ -163,6 +164,11 @@ export const TsModsModule = {
 
         async updateMods({commit, rootState}) {
             const modList = await PackageDb.getPackagesAsThunderstoreMods(rootState.activeGame.internalFolderName);
+
+            if (rootState.activeGameModLoaderTarget) {
+                filterModVersions(modList, rootState.activeGameModLoaderTarget);
+            }
+
             const updated = await PackageDb.getLastPackageListUpdateTime(rootState.activeGame.internalFolderName);
             commit('setMods', modList);
             commit('setModsLastUpdated', updated);

--- a/src/utils/ManagerUtils.ts
+++ b/src/utils/ManagerUtils.ts
@@ -1,6 +1,43 @@
 import GameManager from "../model/game/GameManager";
+import ThunderstoreMod from "../model/ThunderstoreMod";
 import ManagerSettings from "../r2mm/manager/ManagerSettings";
 
+
+/**
+ * Searches the target mod from the list. If present, filters out all versions
+ * except the target version. If target version is not found, removes the whole
+ * package.
+ *
+ * MUTATES THE LIST IN PLACE. Theoretically there's no upper limit to how large
+ * the modList can be, so avoid making a copy unnecessarily.
+ *
+ * This can be used e.g. to effectively pin a version of the mod loader package
+ * to specific version for a specific community. If a newer version of a shared
+ * package is released, it won't be visible for communities that filter out
+ * extra versions using this method.
+ */
+export const filterModVersions = (modList: ThunderstoreMod[], dependencyString: string) => {
+    const match = dependencyString.match(/^([^ -]+-[^ -]+)-([^ -]+)$/);
+
+    if (!match) {
+        throw new Error(`Invalid dependency string "${dependencyString}"`);
+    }
+
+    const [_, modName, versionNumber] = match;
+    const target = modList.findIndex((mod) => mod.getFullName() === modName);
+
+    if (target > -1) {
+        const filtered = modList[target].getVersions().filter(
+            (v) => v.getVersionNumber().toString() === versionNumber
+        );
+
+        if (filtered.length) {
+            modList[target].setVersions(filtered);
+        } else {
+            modList.splice(target, 1);
+        }
+    }
+}
 
 /**
  * Return default game selection needed to skip the game selection screen.

--- a/test/jest/__tests__/utils/utils.ManagerUtils.ts.spec.ts
+++ b/test/jest/__tests__/utils/utils.ManagerUtils.ts.spec.ts
@@ -1,0 +1,96 @@
+import ThunderstoreMod from "src/model/ThunderstoreMod";
+import { filterModVersions } from "../../../../src/utils/ManagerUtils";
+import VersionNumber from "src/model/VersionNumber";
+import ThunderstoreVersion from "src/model/ThunderstoreVersion";
+
+const getMockPackage = (packageName: string, versionStrings: string[]) => {
+    const versions = versionStrings.map((versionString) => {
+        const tv = new ThunderstoreVersion();
+        tv.setVersionNumber(new VersionNumber(versionString));
+        return tv;
+    });
+    const mod = new ThunderstoreMod();
+    mod.setFullName(packageName)
+    mod.setVersions(versions);
+    return mod;
+};
+
+
+describe("ManagerUtils.filterModVersions", () => {
+    it("Validates dependencyString parameter", () => {
+        ["", "Team-Package", "Team-Package-1.0.0-alpha", "--"].forEach((dependencyString) => {
+            const expected = new Error(`Invalid dependency string "${dependencyString}"`);
+            expect(() => filterModVersions([], dependencyString)).toThrowError(expected);
+        });
+    });
+
+    it("Filters out other versions", () => {
+        const packageName = "BepInEx-BepInExPack";
+        const versions = ["5.4.2100", "5.4.2101", "5.4.2200"];
+
+        versions.forEach((version) => {
+            // Get new mods each time as the list is mutated by filterModVersions.
+            const mods = [getMockPackage(packageName, versions)];
+            filterModVersions(mods, `${packageName}-${version}`);
+
+            expect(mods.length).toStrictEqual(1);
+            expect(mods[0].getVersions().length).toStrictEqual(1);
+            expect(mods[0].getVersions()[0].getVersionNumber().toString()).toStrictEqual(version);
+        })
+    });
+
+    it("Doesn't affect other packages", () => {
+        const versions = ["1.0.0", "1.0.1", "1.1.0"];
+        const mods = [
+            getMockPackage("Foo-Bar", versions),
+            getMockPackage("Foo-Baz", versions),
+            getMockPackage("Foo-Bak", versions),
+        ];
+
+        filterModVersions(mods, "Foo-Bak-1.0.0");
+
+        expect(mods.length).toStrictEqual(3);
+        expect(mods[0].getVersions().length).toStrictEqual(3);
+        expect(mods[1].getVersions().length).toStrictEqual(3);
+        expect(mods[2].getVersions().length).toStrictEqual(1);
+        expect(mods[2].getVersions()[0].getVersionNumber().toString()).toStrictEqual("1.0.0");
+    });
+
+    it("Does nothing if there is no mods", () => {
+        const mods: ThunderstoreMod[] = [];
+        filterModVersions(mods, "Bar-Foo-1.0.0");
+
+        expect(mods.length).toStrictEqual(0);
+    });
+
+    it("Does nothing if the target package is not found", () => {
+        const versions = ["1.0.0"];
+        const mods = [
+            getMockPackage("Foo-Bar", versions),
+            getMockPackage("Foo-Baz", versions),
+            getMockPackage("Foo-Bak", versions),
+        ];
+
+        filterModVersions(mods, "Bar-Foo-1.0.0");
+
+        expect(mods.length).toStrictEqual(3);
+        expect(mods[0].getVersions().length).toStrictEqual(1);
+        expect(mods[1].getVersions().length).toStrictEqual(1);
+        expect(mods[2].getVersions().length).toStrictEqual(1);
+    });
+
+    it("Filters out the whole package if target version is not found", () => {
+        const versions = ["1.0.0"];
+        const mods = [
+            getMockPackage("Foo-Bar", versions),
+            getMockPackage("Foo-Baz", versions),
+            getMockPackage("Foo-Bak", versions),
+        ];
+
+        filterModVersions(mods, "Foo-Bar-2.0.0");
+
+        expect(mods.length).toStrictEqual(2);
+        expect(mods[0].getFullName()).toStrictEqual("Foo-Baz");
+        expect(mods[1].getFullName()).toStrictEqual("Foo-Bak");
+    });
+});


### PR DESCRIPTION
Some of the communities share a common BepInEx package. If a newer
version is needed for one community, it's risky to just publish the
new version, since it would trigger the auto update feature for all
these communities, possibly breaking something. To prevent this, the
Thunderstore ecosystem schema will eventually include an optional
field for defining which version a community should use.