### PR TITLE
Fix ThunderstoreMod date field typing

### DIFF
--- a/src/model/ThunderstoreMod.ts
+++ b/src/model/ThunderstoreMod.ts
@@ -6,8 +6,8 @@ export default class ThunderstoreMod extends ThunderstoreVersion implements Reac
     private rating: number = 0;
     private owner: string = '';
     private packageUrl: string = '';
-    private dateCreated: Date = new Date();
-    private dateUpdated: Date = new Date();
+    private dateCreated: string = '';
+    private dateUpdated: string = '';
     private uuid4: string = '';
     private pinned: boolean = false;
     private deprecated: boolean = false;
@@ -104,19 +104,19 @@ export default class ThunderstoreMod extends ThunderstoreVersion implements Reac
         this.packageUrl = url;
     }
 
-    public getDateCreated(): Date {
+    public getDateCreated(): string {
         return this.dateCreated;
     }
 
-    public setDateCreated(date: Date) {
+    public setDateCreated(date: string) {
         this.dateCreated = date;
     }
 
-    public getDateUpdated(): Date {
+    public getDateUpdated(): string {
         return this.dateUpdated;
     }
 
-    public setDateUpdated(date: Date) {
+    public setDateUpdated(date: string) {
         this.dateUpdated = date;
     }
 


### PR DESCRIPTION
The date fields denoting creation and last update date are in fact strings, not dates. IDK if it has always been this way or if e.g. moving the online mod list from disk to IndexedDB changed this.

Luckily the date fields are only used for newer/older than comparisons, and the ISO 8601 date strings yield the same results for those operations as the Date objects would.