### PR TITLE
Fix watching online mod list for changes

### DIFF
--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -181,7 +181,7 @@ export default class OnlineModView extends Vue {
 
     @Watch("sortingDirectionModel")
     @Watch("sortingStyleModel")
-    @Watch("tsMods.mods")
+    @Watch("thunderstoreModList")
     sortThunderstoreModList() {
         const sortDescending = this.sortingDirectionModel == SortingDirection.STANDARD;
         const sortedList = [...this.thunderstoreModList];


### PR DESCRIPTION
Online mod list was watching a wrong variable, and wouldn't fire an autoupdate if the main mod list changed, i.e. if there was a background update from Thunderstore API while user had the online mod list open.

This was broken some 6 months ago by yours truly while moving the mod list into Vuex store.