### PR TITLE
fix(linux): Fix linux game directory resolver ignoring Game.steamFolderName variable

### DIFF
--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -69,7 +69,12 @@ export default class GameDirectoryResolverImpl extends GameDirectoryResolverProv
             const folderName = parsedVdf.AppState.installdir;
             const gamePath = path.join(manifestLocation, 'common', folderName);
             if (await fs.exists(gamePath)) {
-                return gamePath;
+                if (gamePath.endsWith(path.dirname(GameManager.activeGame.steamFolderName))) {
+                    const dir = path.dirname(gamePath);
+                    return path.join(dir, GameManager.activeGame.steamFolderName);
+                } else {
+                    return gamePath;
+                }
             } else {
                 return new FileNotFoundError(
                     `${game.displayName} does not exist in Steam\'s specified location`,


### PR DESCRIPTION
I checked and its the only resolver from the 3 that had this problem, kinda went unnoticted cause most games don't have a nested folder for their game .exe, neither are people using linux as their regular machines