### PR TITLE
Disable MacOS from CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,10 @@ jobs:
           - kind: windows
             os: windows-latest
             platform: win
-          - kind: mac
-            os: macos-11
-            platform: osx
+          # Macos-11 is deprecated, macos-12 would require package updates, see PR #1409
+          # - kind: mac
+          #   os: macos-11
+          #   platform: osx
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,10 @@ jobs:
                     - kind: windows
                       os: windows-latest
                       platform: win
-                    - kind: mac
-                      os: macos-11
-                      platform: osx
+                    # Macos-11 is deprecated, macos-12 would require package updates, see PR #1409
+                    # - kind: mac
+                    #   os: macos-11
+                    #   platform: osx
         steps:
             - uses: actions/checkout@v3
 


### PR DESCRIPTION
GitHub actions dropped the support for MacOS 11, causing all CI jobs to fail. Updating to MacOS 12 would require updating 3rd party dependencies, namely electron-builder (see PR #1409).

MacOS isn't officially supported by this project, and it was added to CI pipeline just because doing so was easy and only required a few lines of config code. Now keeping MacOS on the CI pipeline would require testing that updating electron-builder has no ill side-effects. That work seems to have a low return of investment, so changes are it won't get done anytime soon.