### PR TITLE
Separate installModAfterDownload function from UI component

### DIFF
--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -12,8 +12,6 @@ import ExportMod from "../../model/exports/ExportMod";
 import ManifestV2 from "../../model/ManifestV2";
 import Profile from "../../model/Profile";
 import ThunderstoreCombo from "../../model/ThunderstoreCombo";
-import ThunderstoreMod from "../../model/ThunderstoreMod";
-import ThunderstoreVersion from "../../model/ThunderstoreVersion";
 import FsProvider from "../../providers/generic/file/FsProvider";
 import ZipProvider from "../../providers/generic/zip/ZipProvider";
 import ThunderstoreDownloaderProvider from "../../providers/ror2/downloading/ThunderstoreDownloaderProvider";
@@ -158,21 +156,6 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
         this.activeStep = 'ADDING_PROFILE';
     }
 
-    async installModAfterDownload(mod: ThunderstoreMod, version: ThunderstoreVersion): Promise<R2Error | ManifestV2> {
-        const manifestMod: ManifestV2 = new ManifestV2().fromThunderstoreMod(mod, version);
-        const installError: R2Error | null = await ProfileInstallerProvider.instance.installMod(manifestMod, this.activeProfile);
-        if (!(installError instanceof R2Error)) {
-            const newModList: ManifestV2[] | R2Error = await ProfileModList.addMod(manifestMod, this.activeProfile);
-            if (newModList instanceof R2Error) {
-                return newModList;
-            }
-            return manifestMod;
-        } else {
-            // (mod failed to be placed in /{profile} directory)
-            return installError;
-        }
-    }
-
     async readProfileFile(file: string) {
         let read = '';
         if (file.endsWith('.r2x')) {
@@ -267,7 +250,7 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
             if (!keepIterating) {
                 return;
             }
-            const installResult: R2Error | ManifestV2 = await this.installModAfterDownload(comboMod.getMod(), comboMod.getVersion());
+            const installResult: R2Error | ManifestV2 = await ProfileUtils.installModAfterDownload(comboMod.getMod(), comboMod.getVersion(), this.activeProfile);
             if (installResult instanceof R2Error) {
                 this.$store.commit('error/handleError', installResult);
                 keepIterating = false;

--- a/src/utils/ProfileUtils.ts
+++ b/src/utils/ProfileUtils.ts
@@ -40,16 +40,16 @@ export async function extractZippedProfileFile(file: string, profileName: string
     }
 }
 
-export async function installModAfterDownload(mod: ThunderstoreMod, version: ThunderstoreVersion, profile: Profile): Promise<R2Error | ManifestV2> {
+export async function installModAfterDownload(mod: ThunderstoreMod, version: ThunderstoreVersion, profile: Profile): Promise<ManifestV2> {
     const manifestMod: ManifestV2 = new ManifestV2().fromThunderstoreMod(mod, version);
     const installError: R2Error | null = await ProfileInstallerProvider.instance.installMod(manifestMod, profile);
     if (installError instanceof R2Error) {
-        return installError;
+        throw installError;
     }
 
     const newModList: ManifestV2[] | R2Error = await ProfileModList.addMod(manifestMod, profile);
     if (newModList instanceof R2Error) {
-        return newModList;
+        throw newModList;
     }
 
     return manifestMod;

--- a/src/utils/ProfileUtils.ts
+++ b/src/utils/ProfileUtils.ts
@@ -2,11 +2,17 @@ import path from "path";
 
 import * as yaml from "yaml";
 
+import R2Error from "../model/errors/R2Error";
 import ExportFormat from "../model/exports/ExportFormat";
 import ExportMod from "../model/exports/ExportMod";
+import ManifestV2 from "../model/ManifestV2";
 import Profile from "../model/Profile";
+import ThunderstoreMod from "../model/ThunderstoreMod";
+import ThunderstoreVersion from "../model/ThunderstoreVersion";
 import VersionNumber from "../model/VersionNumber";
 import ZipProvider from "../providers/generic/zip/ZipProvider";
+import ProfileInstallerProvider from "../providers/ror2/installing/ProfileInstallerProvider";
+import ProfileModList from "../r2mm/mods/ProfileModList";
 
 export async function extractZippedProfileFile(file: string, profileName: string) {
     const entries = await ZipProvider.instance.getEntries(file);
@@ -32,6 +38,21 @@ export async function extractZippedProfileFile(file: string, profileName: string
             )
         }
     }
+}
+
+export async function installModAfterDownload(mod: ThunderstoreMod, version: ThunderstoreVersion, profile: Profile): Promise<R2Error | ManifestV2> {
+    const manifestMod: ManifestV2 = new ManifestV2().fromThunderstoreMod(mod, version);
+    const installError: R2Error | null = await ProfileInstallerProvider.instance.installMod(manifestMod, profile);
+    if (installError instanceof R2Error) {
+        return installError;
+    }
+
+    const newModList: ManifestV2[] | R2Error = await ProfileModList.addMod(manifestMod, profile);
+    if (newModList instanceof R2Error) {
+        return newModList;
+    }
+
+    return manifestMod;
 }
 
 export async function parseYamlToExportFormat(yamlContent: string) {


### PR DESCRIPTION
Separate installModAfterDownload function from UI component and use early return pattern consistently.