### PR TITLE
Harden chunked package list API requests against CDN problems

### DIFF
--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -29,6 +29,7 @@ export const getPropertyFromPath = (object: Mappable, path: string | string[]): 
 export async function retry<T>(
     fn: () => Promise<T>,
     attempts: number = 3,
+    interval: number = 5000,
     canRetry: () => boolean = () => true,
     onError: (e: Error | unknown) => void = console.error
 ): Promise<T> {
@@ -43,7 +44,7 @@ export async function retry<T>(
             onError(e);
 
             if (currentAttempt < attempts) {
-                await sleep(5000);
+                await sleep(interval);
             }
         }
     }


### PR DESCRIPTION
Thunderstore's main CDN regularly just fails to respond to requests. Now that package list chunks are downloaded from the CDN, the issue also affects this part of the program. While the only real fix is to migrate to more reliable service provider, ETA on that is unknown. Meanwhile do what can be done to mitigate the issue.

- Increase the number of retries and reduce the interval between them when loading the index chunk. Sometimes spamming the same request makes the CDN "wake up" and serve the file
- Add "preferred CDN" query parameter to index chunk request. If the Thunderstore API endpoint supports the received value, it will uses that CDN when returning the redirect response. Intercepting the redirect response to manipulate the redirect URL in the browser environment has proven hacky in the past and is avoided here
- Change the CDN on the fly on client when requesting the package list chunks. Since these request point directly to the CDN rather than Thunderstore API, manipulating them directly is feasible.