### PR TITLE
Option to use Flatpaks under Linux

### DIFF
--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -299,6 +299,23 @@ let settingsList = [
         'fa-file-alt',
         () => emitInvoke('ShowDependencyStrings')
     ),
+    new SettingsRow(
+        'Other',
+        'Launch as Flatpak (Linux)',
+        'Launch Steam via flatpak',
+        async () => {
+            switch (settings.value.getContext().global.linuxUseFlatpak) {
+                case null:
+                    return 'Automatic';
+                case true:
+                    return 'Flatpak';
+                case false:
+                    return 'Native';
+            }
+        },
+        'fa-exchange-alt',
+        () => emitInvoke('ToggleLinuxUseFlatpak')
+    ),
 ];
 
 watch(search, () => {

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -338,6 +338,10 @@ function setFunkyMode(value: boolean) {
     settings.value.setFunkyMode(value);
 }
 
+function setLinuxUseFlatpak(value: boolean) {
+    settings.value.setLinuxUseFlatpak(value);
+}
+
 function browseDataFolder() {
     LinkProvider.instance.openLink('file://' + PathResolver.ROOT);
 }
@@ -510,6 +514,9 @@ async function handleSettingsCallbacks(invokedSetting: any) {
             break;
         case "ToggleFunkyMode":
             setFunkyMode(!settings.value.getContext().global.funkyModeEnabled);
+            break;
+        case "ToggleLinuxUseFlatpak":
+            setLinuxUseFlatpak(!settings.value.getContext().global.linuxUseFlatpak);
             break;
         case "SwitchTheme":
             toggleDarkTheme();

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -98,6 +98,11 @@ export default class ManagerSettings {
         await this.save();
     }
 
+    public async setLinuxUseFlatpak(enabled: boolean) {
+        ManagerSettings.CONTEXT.global.linuxUseFlatpak = enabled;
+        await this.save();
+    }
+
     public async expandCards() {
         ManagerSettings.CONTEXT.global.expandedCards = true;
         await this.save();

--- a/src/r2mm/manager/SettingsDexieStore.ts
+++ b/src/r2mm/manager/SettingsDexieStore.ts
@@ -123,6 +123,7 @@ export default class SettingsDexieStore extends Dexie {
                 defaultStore: undefined,
                 gameSelectionViewMode: GameSelectionViewMode.CARD,
                 previewPanelWidth: 500,
+                linuxUseFlatpak: null,
             },
             gameSpecific: {
                 version: 2,
@@ -212,6 +213,7 @@ export interface ManagerSettingsInterfaceGlobal_V2 {
     defaultStore: Platform | undefined;
     gameSelectionViewMode: GameSelectionViewMode;
     previewPanelWidth: number;
+    linuxUseFlatpak: boolean | null;
 }
 
 /**


### PR DESCRIPTION
This adds a configuration setting "linuxUseFlatpak" which controls whether Steam should be launched as a Flatpak or not. By default this is detected automatically based on the path, but an option in the settings can override the behaviour.

If this option is enabled, we first check if we are able to read from our config directory. If not, we display an error and ask the user to give us permission. If we do, then we launch Steam through flatpak rather than the binary directly.

Closes: #1144, #1051