### PR TITLE
Add Assets install rule to Distance

### DIFF
--- a/src/r2mm/installing/default_installation_rules/InstallationRuleApplicator.ts
+++ b/src/r2mm/installing/default_installation_rules/InstallationRuleApplicator.ts
@@ -146,7 +146,12 @@ export default class InstallationRuleApplicator {
             buildBepInExRules("PaqueretteDownTheBunburrows"),
             buildBepInExRules("HardTime3"),
             buildBepInExRules("TankTeam"),
-            buildBepInExRules("Distance"),
+            buildBepInExRules("Distance", [{
+                route: path.join("BepInEx", "Assets"),
+                defaultFileExtensions: [],
+                trackingMethod: "STATE",
+                subRoutes: []
+            }]),
             buildBepInExRules("FiveNightsAtFreddysIntoThePit"),
         ]
     }


### PR DESCRIPTION
One of the most widely-used mods for Distance is the [Custom Car](https://github.com/Distance-Modding/Mod.CustomCar) mod, adding the ability to use custom car models which are all made by different authors and historically managed [in this repo](https://github.com/Distance-Modding/Custom-Cars).

With Distance being added to Thunderstore, we'd like individual car model authors to be able to publish their cars there as separate packages users can install individually, but each car isn't a mod itself, just a Unity asset file, and previously, pre-Thunderstore, they would all be placed within an Assets folder inside the core mod's plugin folder (`..\BepInEx\plugins\CustomCar\Assets\<any structure>\CarFile` with `..\BepInEx\plugins\CustomCar\CustomCar.dll`). However, that structure, putting assets inside the folder of a different plugin, doesn't seem to be possible with r2's install rules. So this PR change would allow us to use a top-level Assets folder (`..\BepInEx\Assets\`) similar to GTFO (as per the "[Structuring your Thunderstore package](https://github.com/ebkr/r2modmanPlus/wiki/Structuring-your-Thunderstore-package)" wiki page), and we can update our core custom car mod to read from both locations.

If there is a way to structure the individual car asset packages such that they would get installed to `..\BepInEx\plugins\<team>-CustomCar\Assets\<car author>\CarFile` or similar without this PR and us having to update our existing core mod, please let me know.

There is also already a PR open to add a Cars section to Thunderstore where these custom car assets will be listed: https://github.com/thunderstore-io/ecosystem-schema/pull/74
And if this change also needs to be made separately somewhere for the Thunderstore App, I couldn't find where to do that.