### PR TITLE
Fix regression in Lethal Company/Content Warning data folder settings

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -547,7 +547,7 @@ export default class GameManager {
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["cs2"]),
 
         new Game("Lethal Company", "LethalCompany", "LethalCompany",
-            "Lethal Company", ["Lethal Company.exe"], "LethalCompany_Data",
+            "Lethal Company", ["Lethal Company.exe"], "Lethal Company_Data",
             "https://thunderstore.io/c/lethal-company/api/v1/package-listing-index/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "1966720")], "LethalCompany.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["lc"]),
@@ -591,7 +591,7 @@ export default class GameManager {
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, []),
 
             new Game("Content Warning", "ContentWarning", "ContentWarning",
-            "Content Warning", ["Content Warning.exe"], "ContentWarning_Data",
+            "Content Warning", ["Content Warning.exe"], "Content Warning_Data",
             "https://thunderstore.io/c/content-warning/api/v1/package-listing-index/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "2881650")], "ContentWarning.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["cw"]),


### PR DESCRIPTION
The folder paths had been fixed earlier, but merging a long running dev branch brought back the old, incorrect values.