### PR TITLE
Add new ImmutableProfile class that doesn't track the active profile

### DIFF
--- a/src/components/config-components/ConfigSelectionLayout.vue
+++ b/src/components/config-components/ConfigSelectionLayout.vue
@@ -103,7 +103,7 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
 
         async created() {
             const fs = FsProvider.instance;
-            const configLocation = this.$store.getters['profile/activeProfile'].getPathOfProfile();
+            const configLocation = this.$store.getters['profile/activeProfile'].getProfilePath();
             const tree = await FileTree.buildFromLocation(configLocation);
             if (tree instanceof R2Error) {
                 return;

--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -173,9 +173,9 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
                     this.activeStep = 'PROFILE_IS_BEING_IMPORTED';
                     if (this.importUpdateSelection === 'UPDATE') {
                         profileName = "_profile_update";
-                        if (await fs.exists(path.join(Profile.getDirectory(), profileName))) {
-                            await FileUtils.emptyDirectory(path.join(Profile.getDirectory(), profileName));
-                            await fs.rmdir(path.join(Profile.getDirectory(), profileName));
+                        if (await fs.exists(path.join(Profile.getRootDir(), profileName))) {
+                            await FileUtils.emptyDirectory(path.join(Profile.getRootDir(), profileName));
+                            await fs.rmdir(path.join(Profile.getRootDir(), profileName));
                         }
                         await this.$store.dispatch('profiles/setSelectedProfile', { profileName: profileName, prewarmCache: true });
                     }
@@ -188,12 +188,12 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
                                 if (this.importUpdateSelection === 'UPDATE') {
                                     this.activeProfileName = event.detail;
                                     try {
-                                        await FileUtils.emptyDirectory(path.join(Profile.getDirectory(), event.detail));
+                                        await FileUtils.emptyDirectory(path.join(Profile.getRootDir(), event.detail));
                                     } catch (e) {
                                         console.log("Failed to empty directory:", e);
                                     }
-                                    await fs.rmdir(path.join(Profile.getDirectory(), event.detail));
-                                    await fs.rename(path.join(Profile.getDirectory(), profileName), path.join(Profile.getDirectory(), event.detail));
+                                    await fs.rmdir(path.join(Profile.getRootDir(), event.detail));
+                                    await fs.rename(path.join(Profile.getRootDir(), profileName), path.join(Profile.getRootDir(), event.detail));
                                 }
                                 await this.$store.dispatch('profiles/setSelectedProfile', { profileName: event.detail, prewarmCache: true });
                                 this.closeModal();

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -135,7 +135,7 @@ import CdnProvider from '../../providers/generic/connection/CdnProvider';
                 'Browse profile folder',
                 'Open the folder where mods are stored for the current profile.',
                 async () => {
-                    return this.$store.getters['profile/activeProfile'].getPathOfProfile();
+                    return this.$store.getters['profile/activeProfile'].getProfilePath();
                 },
                 'fa-door-open',
                 () => this.emitInvoke('BrowseProfileFolder')

--- a/src/installers/BepInExInstaller.ts
+++ b/src/installers/BepInExInstaller.ts
@@ -32,9 +32,9 @@ export class BepInExInstaller implements PackageInstaller {
         for (const item of (await FsProvider.instance.readdir(bepInExRoot))) {
             if (!basePackageFiles.includes(item.toLowerCase())) {
                 if ((await FsProvider.instance.stat(path.join(bepInExRoot, item))).isFile()) {
-                    await FsProvider.instance.copyFile(path.join(bepInExRoot, item), path.join(profile.getPathOfProfile(), item));
+                    await FsProvider.instance.copyFile(path.join(bepInExRoot, item), profile.joinToProfilePath(item));
                 } else {
-                    await FsProvider.instance.copyFolder(path.join(bepInExRoot, item), path.join(profile.getPathOfProfile(), item));
+                    await FsProvider.instance.copyFolder(path.join(bepInExRoot, item), profile.joinToProfilePath(item));
                 }
             }
         }

--- a/src/installers/GodotMLInstaller.ts
+++ b/src/installers/GodotMLInstaller.ts
@@ -10,7 +10,7 @@ export class GodotMLInstaller implements PackageInstaller {
         const { packagePath, profile } = args;
 
         const copyFrom = path.join(packagePath, "addons", "mod_loader");
-        const copyTo = path.join(profile.getPathOfProfile(), "addons", "mod_loader");
+        const copyTo = profile.joinToProfilePath("addons", "mod_loader");
         const fs = FsProvider.instance;
 
         if (await fs.exists(copyFrom)) {

--- a/src/installers/MelonLoaderInstaller.ts
+++ b/src/installers/MelonLoaderInstaller.ts
@@ -14,9 +14,9 @@ export class MelonLoaderInstaller implements PackageInstaller {
         for (const item of (await FsProvider.instance.readdir(packagePath))) {
             if (!basePackageFiles.includes(item.toLowerCase())) {
                 if ((await FsProvider.instance.stat(path.join(packagePath, item))).isFile()) {
-                    await FsProvider.instance.copyFile(path.join(packagePath, item), path.join(profile.getPathOfProfile(), item));
+                    await FsProvider.instance.copyFile(path.join(packagePath, item), profile.joinToProfilePath(item));
                 } else {
-                    await FsProvider.instance.copyFolder(path.join(packagePath, item), path.join(profile.getPathOfProfile(), item));
+                    await FsProvider.instance.copyFolder(path.join(packagePath, item), profile.joinToProfilePath(item));
                 }
             }
         }

--- a/src/installers/NorthstarInstaller.ts
+++ b/src/installers/NorthstarInstaller.ts
@@ -32,9 +32,9 @@ export class NorthstarInstaller implements PackageInstaller {
         for (const item of (await FsProvider.instance.readdir(northstarRoot))) {
             if (!basePackageFiles.includes(item.toLowerCase())) {
                 if ((await FsProvider.instance.stat(path.join(northstarRoot, item))).isFile()) {
-                    await FsProvider.instance.copyFile(path.join(northstarRoot, item), path.join(profile.getPathOfProfile(), item));
+                    await FsProvider.instance.copyFile(path.join(northstarRoot, item), profile.joinToProfilePath(item));
                 } else {
-                    await FsProvider.instance.copyFolder(path.join(northstarRoot, item), path.join(profile.getPathOfProfile(), item));
+                    await FsProvider.instance.copyFolder(path.join(northstarRoot, item), profile.joinToProfilePath(item));
                 }
             }
         }

--- a/src/installers/ReturnOfModdingInstaller.ts
+++ b/src/installers/ReturnOfModdingInstaller.ts
@@ -33,7 +33,7 @@ export class ReturnOfModdingInstaller implements PackageInstaller {
         for (const fileOrFolder of toCopy) {
             await FileUtils.copyFileOrFolder(
                 path.join(root, fileOrFolder),
-                path.join(profile.getPathOfProfile(), fileOrFolder)
+                profile.joinToProfilePath(fileOrFolder)
             );
         }
     }
@@ -48,7 +48,7 @@ export class ReturnOfModdingInstaller implements PackageInstaller {
                 if (file.toLowerCase() === 'mods.yml') {
                     continue;
                 }
-                const filePath = path.join(profile.getPathOfProfile(), file);
+                const filePath = profile.joinToProfilePath(file);
                 if ((await fs.lstat(filePath)).isFile()) {
                     await fs.unlink(filePath);
                 }
@@ -108,8 +108,8 @@ export class ReturnOfModdingPluginInstaller implements PackageInstaller {
         // Remove the data dir, but keep the cache subdir if it exists.
         // Leave the config dir alone.
         try {
-            const pluginPath = path.join(profile.getPathOfProfile(), this._ROOT, this._PLUGINS, mod.getName())
-            const dataPath = path.join(profile.getPathOfProfile(), this._ROOT, this._DATA, mod.getName());
+            const pluginPath = profile.joinToProfilePath(this._ROOT, this._PLUGINS, mod.getName())
+            const dataPath = profile.joinToProfilePath(this._ROOT, this._DATA, mod.getName());
 
             await FileUtils.recursiveRemoveDirectoryIfExists(pluginPath);
 

--- a/src/installers/ReturnOfModdingInstaller.ts
+++ b/src/installers/ReturnOfModdingInstaller.ts
@@ -44,7 +44,7 @@ export class ReturnOfModdingInstaller implements PackageInstaller {
 
         try {
             // Delete all files except mods.yml from profile root. Ignore directories.
-            for (const file of (await fs.readdir(profile.getPathOfProfile()))) {
+            for (const file of (await fs.readdir(profile.getProfilePath()))) {
                 if (file.toLowerCase() === 'mods.yml') {
                     continue;
                 }

--- a/src/installers/ShimloaderInstaller.ts
+++ b/src/installers/ShimloaderInstaller.ts
@@ -39,7 +39,7 @@ export class ShimloaderInstaller implements PackageInstaller {
 
         for (const targetPath of targets) {
             const absSrc = path.join(packagePath, targetPath[0]);
-            const absDest = path.join(profile.getPathOfProfile(), targetPath[1]);
+            const absDest = profile.joinToProfilePath(targetPath[1]);
 
             await FileUtils.ensureDirectory(path.dirname(absDest));
             await fs.copyFile(absSrc, absDest);
@@ -48,7 +48,7 @@ export class ShimloaderInstaller implements PackageInstaller {
         }
 
         // The config subdir needs to be created for shimloader (it will get cranky if it's not there).
-        const configDir = path.join(profile.getPathOfProfile(), "shimloader", "cfg");
+        const configDir = profile.joinToProfilePath("shimloader", "cfg");
         if (!await fs.exists(configDir)) {
             await fs.mkdirs(configDir);
         }

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -58,6 +58,11 @@ export default class Profile implements ProfileCompatible {
         activeProfile = this;
     }
 
+    // Return a snapshot of the currently active profile.
+    public static getActiveAsImmutableProfile(): ImmutableProfile {
+        return new ImmutableProfile(activeProfile.profileName);
+    }
+
     public static getActiveProfile() {
         return activeProfile;
     }
@@ -69,6 +74,10 @@ export default class Profile implements ProfileCompatible {
      */
     public static getRootDir(): string {
         return path.join(PathResolver.MOD_ROOT, 'profiles');
+    }
+
+    public asImmutableProfile(): ImmutableProfile {
+        return Profile.getActiveAsImmutableProfile();
     }
 
     public getProfileName(): string {

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -5,7 +5,7 @@ import PathResolver from '../r2mm/manager/PathResolver';
 
 interface ProfileCompatible {
     getProfileName: () => string;
-    getPathOfProfile: () => string;
+    getProfilePath: () => string;
     joinToProfilePath: (...paths: [string, ...string[]]) => string;
 }
 
@@ -29,12 +29,12 @@ export class ImmutableProfile implements ProfileCompatible {
         return this.profileName;
     }
 
-    public getPathOfProfile(): string {
+    public getProfilePath(): string {
         return path.join(this.rootDir, this.profileName);
     }
 
     public joinToProfilePath(...paths: [string, ...string[]]): string {
-        return path.join(this.getPathOfProfile(), ...paths);
+        return path.join(this.getProfilePath(), ...paths);
     }
 }
 
@@ -75,11 +75,11 @@ export default class Profile implements ProfileCompatible {
         return this.profileName;
     }
 
-    public getPathOfProfile(): string {
+    public getProfilePath(): string {
         return path.join(Profile.getRootDir(), this.profileName);
     }
 
     public joinToProfilePath(...paths: [string, ...string[]]): string {
-        return path.join(this.getPathOfProfile(), ...paths);
+        return path.join(this.getProfilePath(), ...paths);
     }
 }

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -6,6 +6,7 @@ import PathResolver from '../r2mm/manager/PathResolver';
 interface ProfileCompatible {
     getProfileName: () => string;
     getPathOfProfile: () => string;
+    joinToProfilePath: (...paths: [string, ...string[]]) => string;
 }
 
 /**
@@ -30,6 +31,10 @@ export class ImmutableProfile implements ProfileCompatible {
 
     public getPathOfProfile(): string {
         return path.join(this.rootDir, this.profileName);
+    }
+
+    public joinToProfilePath(...paths: [string, ...string[]]): string {
+        return path.join(this.getPathOfProfile(), ...paths);
     }
 }
 
@@ -72,5 +77,9 @@ export default class Profile implements ProfileCompatible {
 
     public getPathOfProfile(): string {
         return path.join(Profile.getRootDir(), this.profileName);
+    }
+
+    public joinToProfilePath(...paths: [string, ...string[]]): string {
+        return path.join(this.getPathOfProfile(), ...paths);
     }
 }

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -1,42 +1,76 @@
-import * as path from 'path'
-import PathResolver from '../r2mm/manager/PathResolver';
+import * as path from 'path';
+
 import ProfileProvider from '../providers/ror2/model_implementation/ProfileProvider';
+import PathResolver from '../r2mm/manager/PathResolver';
 
-let activeProfile: Profile;
+interface ProfileCompatible {
+    getProfileName: () => string;
+    getPathOfProfile: () => string;
+}
 
-export default class Profile {
-
+/**
+ * ImmutableProfile does not know about the current active profile or
+ * other parts of the app state. It's ideal to be used as a function
+ * argument in cases where the active profile changing during the
+ * execution would cause unwanted behaviour.
+ */
+export class ImmutableProfile implements ProfileCompatible {
     private readonly profileName: string = '';
-    private readonly directory: string = '.';
+    private readonly rootDir: string = '.';
 
     public constructor(name: string) {
         this.profileName = name;
-        this.directory = this.getDirectory();
-        ProfileProvider.instance.ensureProfileDirectory(this.directory, this.profileName);
-        activeProfile = this;
+        this.rootDir = path.join(PathResolver.MOD_ROOT, 'profiles');
+        ProfileProvider.instance.ensureProfileDirectory(this.rootDir, this.profileName);
     }
 
-    // Profile name
     public getProfileName(): string {
         return this.profileName;
     }
 
-    // Directory of profile folder (/mods/profiles/)
-    public getDirectory(): string {
-        return Profile.getDirectory();
-    }
-
-    public static getDirectory(): string {
-        return path.join(PathResolver.MOD_ROOT, 'profiles');
-    }
-
-    // Directory of profile (/mods/profiles/a_profile)
     public getPathOfProfile(): string {
-        return path.join(this.directory, this.profileName);
+        return path.join(this.rootDir, this.profileName);
+    }
+}
+
+let activeProfile: Profile;
+
+/**
+ * Profile updates and provides access to activeProfile singleton.
+ * It's ideal to be used when an operation targets the active profile
+ * but you don't have access to the it in the current scope.
+ *
+ * Note that while changes to the active game are reflected to already
+ * instantiated objects, changes to the active profile are not. To get
+ * guaranteed latest data, access instance methods via
+ * Profile.getActiveProfile().
+ */
+export default class Profile implements ProfileCompatible {
+    private readonly profileName: string = '';
+
+    public constructor(name: string) {
+        this.profileName = name;
+        activeProfile = this;
     }
 
     public static getActiveProfile() {
         return activeProfile;
     }
 
+    /**
+     * Returns the root dir for profiles for the currently active game.
+     * PathResolver.MOD_ROOT is updated when the active game changes.
+     * E.g. DataFolder/[Game.internalFolderName]/profiles
+     */
+    public static getRootDir(): string {
+        return path.join(PathResolver.MOD_ROOT, 'profiles');
+    }
+
+    public getProfileName(): string {
+        return this.profileName;
+    }
+
+    public getPathOfProfile(): string {
+        return path.join(Profile.getRootDir(), this.profileName);
+    }
 }

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -409,7 +409,7 @@ import ModalCard from '../components/ModalCard.vue';
 		}
 
         browseProfileFolder() {
-            LinkProvider.instance.openLink('file://' + this.profile.getPathOfProfile());
+            LinkProvider.instance.openLink('file://' + this.profile.getProfilePath());
 		}
 
 		toggleCardExpanded(expanded: boolean) {
@@ -490,13 +490,13 @@ import ModalCard from '../components/ModalCard.vue';
             let logOutputPath = "";
             switch (this.activeGame.packageLoader) {
                 case PackageLoader.BEPINEX:
-                    logOutputPath = path.join(this.profile.getPathOfProfile(), "BepInEx", "LogOutput.log");
+                    logOutputPath = path.join(this.profile.getProfilePath(), "BepInEx", "LogOutput.log");
                     break;
                 case PackageLoader.MELON_LOADER:
-                    logOutputPath = path.join(this.profile.getPathOfProfile(), "MelonLoader", "Latest.log");
+                    logOutputPath = path.join(this.profile.getProfilePath(), "MelonLoader", "Latest.log");
                     break;
 				case PackageLoader.RETURN_OF_MODDING:
-                    logOutputPath = path.join(this.profile.getPathOfProfile(), "ReturnOfModding", "LogOutput.log");
+                    logOutputPath = path.join(this.profile.getProfilePath(), "ReturnOfModding", "LogOutput.log");
                     break;
             }
             const text = (await fs.readFile(logOutputPath)).toString();

--- a/src/r2mm/data/LogOutput.ts
+++ b/src/r2mm/data/LogOutput.ts
@@ -1,5 +1,4 @@
 import Profile from '../../model/Profile';
-import * as path from 'path';
 import FsProvider from '../../providers/generic/file/FsProvider';
 import GameManager from '../../model/game/GameManager';
 import { PackageLoader } from '../../model/installing/PackageLoader';
@@ -35,16 +34,16 @@ export default class LogOutput {
         const game = GameManager.activeGame;
         switch (game.packageLoader) {
             case PackageLoader.BEPINEX:
-                fs.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), 'BepInEx', 'LogOutput.log'))
+                fs.exists(Profile.getActiveProfile().joinToProfilePath('BepInEx', 'LogOutput.log'))
                     .then(value => this._exists = value);
                 break;
             case PackageLoader.RETURN_OF_MODDING:
-                fs.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), 'ReturnOfModding', 'LogOutput.log'))
+                fs.exists(Profile.getActiveProfile().joinToProfilePath('ReturnOfModding', 'LogOutput.log'))
                     .then(value => this._exists = value);
                 break;
             case PackageLoader.MELON_LOADER:
             case PackageLoader.NORTHSTAR:
-                fs.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), 'MelonLoader', 'Latest.log'))
+                fs.exists(Profile.getActiveProfile().joinToProfilePath('MelonLoader', 'Latest.log'))
                     .then(value => this._exists = value);
                 break;
         }

--- a/src/r2mm/installing/ConflictManagementProviderImpl.ts
+++ b/src/r2mm/installing/ConflictManagementProviderImpl.ts
@@ -14,7 +14,7 @@ export default class ConflictManagementProviderImpl extends ConflictManagementPr
     // TODO: Override files in conflict management state file to say they belong to the following mod.
     async overrideInstalledState(mod: ManifestV2, profile: Profile): Promise<R2Error | void> {
         let stateFileContents: string | undefined;
-        const modStateFilePath = path.join(profile.getPathOfProfile(), "_state", `${mod.getName()}-state.yml`);
+        const modStateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
         if (await FsProvider.instance.exists(modStateFilePath)) {
             stateFileContents = (await FsProvider.instance.readFile(modStateFilePath)).toString();
         }
@@ -31,7 +31,7 @@ export default class ConflictManagementProviderImpl extends ConflictManagementPr
         modState.files.forEach(([key, value]) => {
             modMap.set(value, mod.getName());
         });
-        const totalStateFilePath = path.join(profile.getPathOfProfile(), "_state", "installation_state.yml");
+        const totalStateFilePath = profile.joinToProfilePath("_state", "installation_state.yml");
         await FileUtils.ensureDirectory(path.dirname(totalStateFilePath));
         await FsProvider.instance.writeFile(totalStateFilePath, yaml.stringify({
             currentState: Array.from(modMap.entries())
@@ -45,7 +45,7 @@ export default class ConflictManagementProviderImpl extends ConflictManagementPr
         const modNameToManifestV2 = new Map<string, ManifestV2>();
         for (const mod of mods) {
             let stateFileContents: string | undefined;
-            const modStateFilePath = path.join(profile.getPathOfProfile(), "_state", `${mod.getName()}-state.yml`);
+            const modStateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
             if (await FsProvider.instance.exists(modStateFilePath)) {
                 stateFileContents = (await FsProvider.instance.readFile(modStateFilePath)).toString();
             }
@@ -72,26 +72,26 @@ export default class ConflictManagementProviderImpl extends ConflictManagementPr
                 copyAcross = true;
             } else if (stateMap.get(file) !== overallState.get(file)) {
                 copyAcross = true;
-            } else if (!(await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), file)))) {
+            } else if (!(await FsProvider.instance.exists(profile.joinToProfilePath(file)))) {
                 copyAcross = true;
             }
             if (copyAcross) {
                 const modFiles = modStates.get(overallState.get(file)!)!;
                 for (const [key, value] of modFiles.files) {
                     if (value === file) {
-                        await FileUtils.ensureDirectory(path.dirname(path.join(profile.getPathOfProfile(), file)));
-                        if (await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), file))) {
-                            await FsProvider.instance.unlink(path.join(profile.getPathOfProfile(), file));
+                        await FileUtils.ensureDirectory(path.dirname(profile.joinToProfilePath(file)));
+                        if (await FsProvider.instance.exists(profile.joinToProfilePath(file))) {
+                            await FsProvider.instance.unlink(profile.joinToProfilePath(file));
                         }
                         if (!file.toLowerCase().endsWith(".manager.disabled")) {
-                            await FsProvider.instance.copyFile(key, path.join(profile.getPathOfProfile(), file));
+                            await FsProvider.instance.copyFile(key, profile.joinToProfilePath(file));
                         }
                         break;
                     }
                 }
             }
         }
-        const totalStateFilePath = path.join(profile.getPathOfProfile(), "_state", "installation_state.yml");
+        const totalStateFilePath = profile.joinToProfilePath("_state", "installation_state.yml");
         await FileUtils.ensureDirectory(path.dirname(totalStateFilePath));
         await FsProvider.instance.writeFile(totalStateFilePath, yaml.stringify({
             currentState: Array.from(overallState.entries())
@@ -109,7 +109,7 @@ export default class ConflictManagementProviderImpl extends ConflictManagementPr
     }
 
     private async getTotalState(profile: Profile): Promise<StateTracker> {
-        const totalStateFilePath = path.join(profile.getPathOfProfile(), "_state", "installation_state.yml");
+        const totalStateFilePath = profile.joinToProfilePath("_state", "installation_state.yml");
         let totalState: StateTracker = {
             currentState: []
         };

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -116,11 +116,11 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
     }
 
     async disableMod(mod: ManifestV2, profile: Profile): Promise<R2Error | void> {
-        return this.applyModMode(mod, new FileTree(), profile, profile.getPathOfProfile(), ModMode.DISABLED);
+        return this.applyModMode(mod, new FileTree(), profile, profile.getProfilePath(), ModMode.DISABLED);
     }
 
     async enableMod(mod: ManifestV2, profile: Profile): Promise<R2Error | void> {
-        return this.applyModMode(mod, new FileTree(), profile, profile.getPathOfProfile(), ModMode.ENABLED);
+        return this.applyModMode(mod, new FileTree(), profile, profile.getProfilePath(), ModMode.ENABLED);
     }
 
     async getDescendantFiles(tree: FileTree | null, location: string): Promise<string[]> {
@@ -212,7 +212,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
             }
         }
 
-        await recursiveDelete(profile.getPathOfProfile(), `${mod.getName()}.ts.zip`);
+        await recursiveDelete(profile.getProfilePath(), `${mod.getName()}.ts.zip`);
     }
 
     private async uninstallSubDir(mod: ManifestV2, profile: Profile): Promise<R2Error | null> {
@@ -223,7 +223,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         const modLoaders = MOD_LOADER_VARIANTS[activeGame.internalFolderName];
         if (modLoaders.find(loader => loader.packageName.toLowerCase() === mod.getName().toLowerCase())) {
             try {
-                for (const file of (await fs.readdir(profile.getPathOfProfile()))) {
+                for (const file of (await fs.readdir(profile.getProfilePath()))) {
                     if (file.toLowerCase() === 'mods.yml') {
                         continue;
                     }
@@ -241,7 +241,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
 
         // Uninstallation logic for regular mods.
         // TODO: Move to work through the installer interface
-        const profilePath = profile.getPathOfProfile();
+        const profilePath = profile.getProfilePath();
         const searchLocations = ["BepInEx", "shimloader", "ReturnOfModding"];
         for (const searchLocation of searchLocations) {
             const bepInExLocation: string = path.join(profilePath, searchLocation);

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -61,11 +61,11 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
             .filter(value => ["SUBDIR", "SUBDIR_NO_FLATTEN"].includes(value.trackingMethod));
 
         for (const dir of subDirPaths) {
-            if (await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), dir.route))) {
-                const dirContents = await FsProvider.instance.readdir(path.join(profile.getPathOfProfile(), dir.route));
+            if (await FsProvider.instance.exists(profile.joinToProfilePath(dir.route))) {
+                const dirContents = await FsProvider.instance.readdir(profile.joinToProfilePath(dir.route));
                 for (const namespacedDir of dirContents) {
                     if (namespacedDir === mod.getName()) {
-                        const tree = await FileTree.buildFromLocation(path.join(profile.getPathOfProfile(), dir.route, namespacedDir));
+                        const tree = await FileTree.buildFromLocation(profile.joinToProfilePath(dir.route, namespacedDir));
                         if (tree instanceof R2Error) {
                             return tree;
                         }
@@ -227,7 +227,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
                     if (file.toLowerCase() === 'mods.yml') {
                         continue;
                     }
-                    const filePath = path.join(profile.getPathOfProfile(), file);
+                    const filePath = profile.joinToProfilePath(file);
                     if ((await fs.lstat(filePath)).isFile()) {
                         await fs.unlink(filePath);
                     }
@@ -271,19 +271,19 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
     }
 
     private async uninstallState(mod: ManifestV2, profile: Profile): Promise<R2Error | null> {
-        const stateFilePath = path.join(profile.getPathOfProfile(), "_state", `${mod.getName()}-state.yml`);
+        const stateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
         if (await FsProvider.instance.exists(stateFilePath)) {
             const read = await FsProvider.instance.readFile(stateFilePath);
             const tracker = (yaml.parse(read.toString()) as ModFileTracker);
             for (const [cacheFile, installFile] of tracker.files) {
-                if (await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), installFile))) {
-                    await FsProvider.instance.unlink(path.join(profile.getPathOfProfile(), installFile));
-                    if ((await FsProvider.instance.readdir(path.dirname(path.join(profile.getPathOfProfile(), installFile)))).length === 0) {
-                        await FsProvider.instance.rmdir(path.dirname(path.join(profile.getPathOfProfile(), installFile)));
+                if (await FsProvider.instance.exists(profile.joinToProfilePath(installFile))) {
+                    await FsProvider.instance.unlink(profile.joinToProfilePath(installFile));
+                    if ((await FsProvider.instance.readdir(path.dirname(profile.joinToProfilePath(installFile)))).length === 0) {
+                        await FsProvider.instance.rmdir(path.dirname(profile.joinToProfilePath(installFile)));
                     }
                 }
             }
-            await FsProvider.instance.unlink(path.join(profile.getPathOfProfile(), "_state", `${mod.getName()}-state.yml`));
+            await FsProvider.instance.unlink(profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`));
         }
         return Promise.resolve(null);
     }

--- a/src/r2mm/launching/instructions/GameInstructionParser.ts
+++ b/src/r2mm/launching/instructions/GameInstructionParser.ts
@@ -41,13 +41,13 @@ export default class GameInstructionParser {
         try {
             if (["linux"].includes(process.platform.toLowerCase())) {
                 const isProton = await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).isProtonGame(game);
-                const corePath = await FsProvider.instance.realpath(path.join(profile.getPathOfProfile(), "BepInEx", "core"));
+                const corePath = await FsProvider.instance.realpath(profile.joinToProfilePath("BepInEx", "core"));
                 const preloaderPath = path.join(corePath,
                     (await FsProvider.instance.readdir(corePath))
                         .filter((x: string) => ["BepInEx.Unity.Mono.Preloader.dll", "BepInEx.Unity.IL2CPP.dll", "BepInEx.Preloader.dll", "BepInEx.IL2CPP.dll"].includes(x))[0]);
                 return `${isProton ? 'Z:' : ''}${preloaderPath}`;
             } else {
-                const corePath = path.join(profile.getPathOfProfile(), "BepInEx", "core");
+                const corePath = profile.joinToProfilePath("BepInEx", "core");
                 return path.join(corePath,
                     (await FsProvider.instance.readdir(corePath))
                         .filter((x: string) => ["BepInEx.Unity.Mono.Preloader.dll", "BepInEx.Unity.IL2CPP.dll", "BepInEx.Preloader.dll", "BepInEx.IL2CPP.dll"].includes(x))[0]);
@@ -60,7 +60,7 @@ export default class GameInstructionParser {
 
     private static async bepInExCorelibsPathResolver(game: Game, profile: Profile): Promise<string | R2Error> {
         try {
-            return await FsProvider.instance.realpath(path.join(profile.getPathOfProfile(), "unstripped_corlib"));
+            return await FsProvider.instance.realpath(profile.joinToProfilePath("unstripped_corlib"));
         } catch (e) {
             const err: Error = e as Error;
             return new R2Error("Unable to resolver Corelibs folder", `"unstripped_corlib" folder failed. No such directory exists for path: ${Profile.getActiveProfile().getPathOfProfile()}.\nReason: ${err.message}`, null);
@@ -72,7 +72,7 @@ export default class GameInstructionParser {
     }
 
     private static async northstarDirectoryResolver(game: Game, profile: Profile): Promise<string | R2Error> {
-        return path.join(profile.getPathOfProfile(), "R2Northstar");
+        return profile.joinToProfilePath("R2Northstar");
     }
 
 }

--- a/src/r2mm/launching/instructions/GameInstructionParser.ts
+++ b/src/r2mm/launching/instructions/GameInstructionParser.ts
@@ -34,7 +34,7 @@ export default class GameInstructionParser {
     }
 
     private static async profileDirectoryResolver(game: Game, profile: Profile): Promise<string> {
-        return profile.getPathOfProfile();
+        return profile.getProfilePath();
     }
 
     private static async bepInExPreloaderPathResolver(game: Game, profile: Profile): Promise<string | R2Error> {
@@ -63,7 +63,7 @@ export default class GameInstructionParser {
             return await FsProvider.instance.realpath(profile.joinToProfilePath("unstripped_corlib"));
         } catch (e) {
             const err: Error = e as Error;
-            return new R2Error("Unable to resolver Corelibs folder", `"unstripped_corlib" folder failed. No such directory exists for path: ${Profile.getActiveProfile().getPathOfProfile()}.\nReason: ${err.message}`, null);
+            return new R2Error("Unable to resolver Corelibs folder", `"unstripped_corlib" folder failed. No such directory exists for path: ${Profile.getActiveProfile().getProfilePath()}.\nReason: ${err.message}`, null);
         }
     }
 

--- a/src/r2mm/launching/instructions/instructions/loader/BepInExGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/BepInExGameInstructions.ts
@@ -3,7 +3,6 @@ import { GameInstruction } from '../../GameInstructions';
 import Game from '../../../../../model/game/Game';
 import Profile from '../../../../../model/Profile';
 import FsProvider from '../../../../../providers/generic/file/FsProvider';
-import path from 'path';
 import { DynamicGameInstruction } from '../../DynamicGameInstruction';
 import { GameInstanceType } from '../../../../../model/game/GameInstanceType';
 import { getUnityDoorstopVersion } from '../../../../../utils/UnityDoorstopUtils';
@@ -25,7 +24,7 @@ export default class BepInExGameInstructions extends GameInstructionGenerator {
             if (game.instanceType === GameInstanceType.SERVER) {
                 extraArguments += ` --server`;
             }
-            if (await FsProvider.instance.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), "unstripped_corlib"))) {
+            if (await FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath("unstripped_corlib"))) {
                 extraArguments += ` --doorstop-dll-search-override "${DynamicGameInstruction.BEPINEX_CORLIBS}"`;
             }
         }
@@ -42,7 +41,7 @@ export default class BepInExGameInstructions extends GameInstructionGenerator {
             if (game.instanceType === GameInstanceType.SERVER) {
                 extraArguments += ` --server`;
             }
-            if (await FsProvider.instance.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), "unstripped_corlib"))) {
+            if (await FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath("unstripped_corlib"))) {
                 extraArguments += ` --doorstop-mono-dll-search-path-override "${DynamicGameInstruction.BEPINEX_CORLIBS}"`;
             }
         }

--- a/src/r2mm/launching/instructions/instructions/loader/LovelyGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/LovelyGameInstructions.ts
@@ -2,12 +2,11 @@ import GameInstructionGenerator from '../GameInstructionGenerator';
 import { GameInstruction } from '../../GameInstructions';
 import Game from '../../../../../model/game/Game';
 import Profile from '../../../../../model/Profile';
-import * as path from 'path';
 
 export default class LovelyGameInstructions extends GameInstructionGenerator {
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
-        const modDir = path.join(profile.getPathOfProfile(), "mods");
+        const modDir = profile.joinToProfilePath("mods");
 
         return {
             moddedParameters: `--mod-dir "${modDir}"`,

--- a/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
@@ -4,13 +4,12 @@ import Game from '../../../../../model/game/Game';
 import Profile from '../../../../../model/Profile';
 import { DynamicGameInstruction } from '../../DynamicGameInstruction';
 import FsProvider from '../../../../../providers/generic/file/FsProvider';
-import * as path from 'path';
 
 export default class MelonLoaderGameInstructions extends GameInstructionGenerator {
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
         let moddedParameters = `--melonloader.basedir "${DynamicGameInstruction.PROFILE_DIRECTORY}"`;
-        if (!await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), 'MelonLoader', 'Managed', 'Assembly-CSharp.dll'))) {
+        if (!await FsProvider.instance.exists(profile.joinToProfilePath('MelonLoader', 'Managed', 'Assembly-CSharp.dll'))) {
             console.log("Regenerating AGF")
            moddedParameters += " --melonloader.agfregenerate"
         }

--- a/src/r2mm/launching/instructions/instructions/loader/ReturnOfModdingGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/ReturnOfModdingGameInstructions.ts
@@ -8,7 +8,7 @@ export default class ReturnOfModdingGameInstructions extends GameInstructionGene
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
         return {
-            moddedParameters: `--rom_modding_root_folder "${profile.getPathOfProfile()}"`,
+            moddedParameters: `--rom_modding_root_folder "${profile.getProfilePath()}"`,
             vanillaParameters: "--rom_enabled false"
         };
     }

--- a/src/r2mm/launching/instructions/instructions/loader/ShimloaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/ShimloaderGameInstructions.ts
@@ -2,16 +2,13 @@ import GameInstructionGenerator from '../GameInstructionGenerator';
 import { GameInstruction } from '../../GameInstructions';
 import Game from '../../../../../model/game/Game';
 import Profile from '../../../../../model/Profile';
-import * as path from 'path';
 
 export default class ShimloaderGameInstructions extends GameInstructionGenerator {
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
-        const shimloader = path.join(profile.getPathOfProfile(), "shimloader");
-
-        const luaDir = path.join(shimloader, "mod");
-        const pakDir = path.join(shimloader, "pak");
-        const cfgDir = path.join(shimloader, "cfg");
+        const luaDir = profile.joinToProfilePath("shimloader", "mod");
+        const pakDir = profile.joinToProfilePath("shimloader", "pak");
+        const cfgDir = profile.joinToProfilePath("shimloader", "cfg");
 
         return {
             moddedParameters: `--mod-dir "${luaDir}" --pak-dir "${pakDir}" --cfg-dir "${cfgDir}"`,

--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
@@ -33,12 +33,12 @@ export default class SteamGameRunner_Linux extends GameRunnerProvider {
             }
         } else {
             // If sh files aren't executable then the wrapper will fail.
-            const shFiles = (await FsProvider.instance.readdir(await FsProvider.instance.realpath(path.join(Profile.getActiveProfile().getPathOfProfile()))))
+            const shFiles = (await FsProvider.instance.readdir(await FsProvider.instance.realpath(Profile.getActiveProfile().getPathOfProfile())))
                 .filter(value => value.endsWith(".sh"));
 
             try {
                 for (const shFile of shFiles) {
-                    await FsProvider.instance.chmod(await FsProvider.instance.realpath(path.join(Profile.getActiveProfile().getPathOfProfile(), shFile)), 0o755);
+                    await FsProvider.instance.chmod(await FsProvider.instance.realpath(Profile.getActiveProfile().joinToProfilePath(shFile)), 0o755);
                 }
             } catch (e) {
                 const err: Error = e as Error;

--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
@@ -33,7 +33,7 @@ export default class SteamGameRunner_Linux extends GameRunnerProvider {
             }
         } else {
             // If sh files aren't executable then the wrapper will fail.
-            const shFiles = (await FsProvider.instance.readdir(await FsProvider.instance.realpath(Profile.getActiveProfile().getPathOfProfile())))
+            const shFiles = (await FsProvider.instance.readdir(await FsProvider.instance.realpath(Profile.getActiveProfile().getProfilePath())))
                 .filter(value => value.endsWith(".sh"));
 
             try {

--- a/src/r2mm/launching/runners/multiplatform/EgsGameRunner.ts
+++ b/src/r2mm/launching/runners/multiplatform/EgsGameRunner.ts
@@ -93,7 +93,7 @@ export default class EgsGameRunner extends GameRunnerProvider {
 
     private async updateDoorstopConfigVars(profile: Profile, data: {[section: string]: {[key: string]: string}}): Promise<R2Error | undefined> {
         const fs = FsProvider.instance;
-        const doorstopConfigPath = path.join(profile.getPathOfProfile(), "doorstop_config.ini");
+        const doorstopConfigPath = profile.joinToProfilePath("doorstop_config.ini");
         try {
             if (await fs.exists(doorstopConfigPath)) {
                 const originalConfigText = (await fs.readFile(doorstopConfigPath)).toString();

--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -97,7 +97,7 @@ export default class ModLinker {
         const fs = FsProvider.instance;
         const newLinkedFiles: string[] = [];
         try {
-            const profileFiles = await fs.readdir(profile.getPathOfProfile());
+            const profileFiles = await fs.readdir(profile.getProfilePath());
             try {
                 for (const file of profileFiles) {
                     if ((await fs.lstat(profile.joinToProfilePath(file))).isFile()) {
@@ -138,7 +138,7 @@ export default class ModLinker {
                                     return fileTree;
                                 }
                                 for (const recursiveFileInFolder of fileTree.getRecursiveFiles()) {
-                                    const fileRelativeToProfileFolder = path.relative(profile.getPathOfProfile(), recursiveFileInFolder);
+                                    const fileRelativeToProfileFolder = path.relative(profile.getProfilePath(), recursiveFileInFolder);
                                     const gameDirFile = path.join(installDirectory, fileRelativeToProfileFolder);
                                     if (!(await this.isFileIdentical(recursiveFileInFolder, gameDirFile))) {
                                         await FileUtils.ensureDirectory(path.join(installDirectory, path.dirname(fileRelativeToProfileFolder)));

--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -68,7 +68,7 @@ export default class ModLinker {
                     await fs.rmdir(file);
                 } else {
                     const fileRelative = path.relative(installDirectory, file);
-                    const fileInProfileDir = path.join(profile.getPathOfProfile(), fileRelative);
+                    const fileInProfileDir = profile.joinToProfilePath(fileRelative);
                     if (!(await this.isFileIdentical(fileInProfileDir, file)) && await fs.exists(file)) {
                         await fs.unlink(file);
                     }
@@ -100,13 +100,13 @@ export default class ModLinker {
             const profileFiles = await fs.readdir(profile.getPathOfProfile());
             try {
                 for (const file of profileFiles) {
-                    if ((await fs.lstat(path.join(profile.getPathOfProfile(), file))).isFile()) {
+                    if ((await fs.lstat(profile.joinToProfilePath(file))).isFile()) {
                         try {
                             const targetDir = ModLinker.getRootFilesDestination(game, file, installDirectory);
                             if (targetDir === null) continue;
 
                             const gameDirFilePath = path.join(targetDir, file);
-                            const profileDirFilePath = path.join(profile.getPathOfProfile(), file);
+                            const profileDirFilePath = profile.joinToProfilePath(file);
 
                             if (!(await this.isFileIdentical(profileDirFilePath, gameDirFilePath))) {
                                 await fs.copyFile(profileDirFilePath, gameDirFilePath);
@@ -123,7 +123,7 @@ export default class ModLinker {
                             )
                         }
                     } else {
-                        if ((await fs.lstat(path.join(profile.getPathOfProfile(), file))).isDirectory()) {
+                        if ((await fs.lstat(profile.joinToProfilePath(file))).isDirectory()) {
                             const exclusionsList = [
                                 "bepinex", "bepinex_server", "mods",
                                 "melonloader", "plugins", "userdata",
@@ -132,7 +132,7 @@ export default class ModLinker {
                             ];
 
                             if (!exclusionsList.includes(file.toLowerCase())) {
-                                const fileProfileFolderPath = path.join(profile.getPathOfProfile(), file);
+                                const fileProfileFolderPath = profile.joinToProfilePath(file);
                                 const fileTree = await FileTree.buildFromLocation(fileProfileFolderPath);
                                 if (fileTree instanceof R2Error) {
                                     return fileTree;

--- a/src/r2mm/mods/CacheUtil.ts
+++ b/src/r2mm/mods/CacheUtil.ts
@@ -17,9 +17,9 @@ export default class CacheUtil {
         const fs = FsProvider.instance;
 
         // Store profile name to allow returning back to current profile.
-        fs.readdir(Profile.getDirectory()).then(async dir => {
+        fs.readdir(Profile.getRootDir()).then(async dir => {
             for (const value of dir) {
-                if ((await fs.stat(path.join(Profile.getDirectory(), value))).isDirectory()) {
+                if ((await fs.stat(path.join(Profile.getRootDir(), value))).isDirectory()) {
                     profiles.push(value);
                 }
             }

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -38,12 +38,12 @@ export default class ProfileModList {
     public static async getModList(profile: Profile): Promise<ManifestV2[] | R2Error> {
         const fs = FsProvider.instance;
         await FileUtils.ensureDirectory(profile.getPathOfProfile());
-        if (!await fs.exists(path.join(profile.getPathOfProfile(), 'mods.yml'))) {
-            await fs.writeFile(path.join(profile.getPathOfProfile(), 'mods.yml'), JSON.stringify([]));
+        if (!await fs.exists(profile.joinToProfilePath('mods.yml'))) {
+            await fs.writeFile(profile.joinToProfilePath('mods.yml'), JSON.stringify([]));
         }
         try {
             try {
-                const value = (yaml.parse((await fs.readFile(path.join(profile.getPathOfProfile(), 'mods.yml'))).toString()) || []);
+                const value = (yaml.parse((await fs.readFile(profile.joinToProfilePath('mods.yml'))).toString()) || []);
                 for(let modIndex in value){
                     const mod = new ManifestV2().fromReactive(value[modIndex]);
                     const fallbackPath = path.join(PathResolver.MOD_ROOT, "cache", mod.getName(), mod.getVersionNumber().toString(), "icon.png");
@@ -90,7 +90,7 @@ export default class ProfileModList {
             const yamlModList: string = yaml.stringify(modList);
             try {
                 await fs.writeFile(
-                    path.join(profile.getPathOfProfile(), 'mods.yml'),
+                    profile.joinToProfilePath('mods.yml'),
                     yamlModList
                 );
             } catch(e) {
@@ -193,8 +193,8 @@ export default class ProfileModList {
         const exportFormat = new ExportFormat(profile.getProfileName(), exportModList);
         const builder = ZipProvider.instance.zipBuilder();
         await builder.addBuffer("export.r2x", Buffer.from(yaml.stringify(exportFormat)));
-        if (await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), "BepInEx", "config"))) {
-            await builder.addFolder("config", path.join(profile.getPathOfProfile(), 'BepInEx', 'config'));
+        if (await FsProvider.instance.exists(profile.joinToProfilePath("BepInEx", "config"))) {
+            await builder.addFolder("config", profile.joinToProfilePath('BepInEx', 'config'));
         }
         const tree = await FileTree.buildFromLocation(profile.getPathOfProfile());
         if (tree instanceof R2Error) {
@@ -205,7 +205,7 @@ export default class ProfileModList {
         tree.navigateAndPerform(bepInExDir => {
             bepInExDir.removeDirectories("config");
             bepInExDir.navigateAndPerform(pluginDir => {
-                pluginDir.getDirectories().forEach(value => value.removeFiles(path.join(profile.getPathOfProfile(), "BepInEx", "plugins", value.getDirectoryName(), "manifest.json")));
+                pluginDir.getDirectories().forEach(value => value.removeFiles(profile.joinToProfilePath("BepInEx", "plugins", value.getDirectoryName(), "manifest.json")));
             }, "plugins");
         }, "BepInEx");
         tree.removeDirectories("MelonLoader");
@@ -266,7 +266,7 @@ export default class ProfileModList {
                 const zipSize = FileUtils.humanReadableSize(zipStats.size);
                 const maxSize = FileUtils.humanReadableSize(this.MAX_EXPORT_AS_CODE_SIZE);
                 const fileTypes = this.SUPPORTED_CONFIG_FILE_EXTENSIONS.join(', ');
-                const configFolder = path.join(profile.getPathOfProfile(), 'BepInEx', 'config');
+                const configFolder = profile.joinToProfilePath('BepInEx', 'config');
                 return new R2Error(
                     'The profile is too large to be exported as a code',
                     `Exported profile size is ${zipSize} while the maximum supported size is ${maxSize}.

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -37,7 +37,7 @@ export default class ProfileModList {
 
     public static async getModList(profile: Profile): Promise<ManifestV2[] | R2Error> {
         const fs = FsProvider.instance;
-        await FileUtils.ensureDirectory(profile.getPathOfProfile());
+        await FileUtils.ensureDirectory(profile.getProfilePath());
         if (!await fs.exists(profile.joinToProfilePath('mods.yml'))) {
             await fs.writeFile(profile.joinToProfilePath('mods.yml'), JSON.stringify([]));
         }
@@ -53,9 +53,9 @@ export default class ProfileModList {
                             .find(x => x.packageName === mod.getName()) !== undefined
                     ) {
                         // BepInEx is not a plugin, and so the only place where we can get its icon is from the cache
-                        iconPath = path.resolve(profile.getPathOfProfile(), "BepInEx", "core", "icon.png");
+                        iconPath = path.resolve(profile.getProfilePath(), "BepInEx", "core", "icon.png");
                     } else {
-                        iconPath = path.resolve(profile.getPathOfProfile(), "BepInEx", "plugins", mod.getName(), "icon.png");
+                        iconPath = path.resolve(profile.getProfilePath(), "BepInEx", "plugins", mod.getName(), "icon.png");
                     }
 
                     if (await fs.exists(iconPath)) {
@@ -196,7 +196,7 @@ export default class ProfileModList {
         if (await FsProvider.instance.exists(profile.joinToProfilePath("BepInEx", "config"))) {
             await builder.addFolder("config", profile.joinToProfilePath('BepInEx', 'config'));
         }
-        const tree = await FileTree.buildFromLocation(profile.getPathOfProfile());
+        const tree = await FileTree.buildFromLocation(profile.getProfilePath());
         if (tree instanceof R2Error) {
             return tree;
         }
@@ -213,7 +213,7 @@ export default class ProfileModList {
         for (const file of tree.getRecursiveFiles()) {
             const fileLower = file.toLowerCase();
             if (this.SUPPORTED_CONFIG_FILE_EXTENSIONS.filter(value => fileLower.endsWith(value)).length > 0) {
-                await builder.addBuffer(path.relative(profile.getPathOfProfile(), file), await FsProvider.instance.readFile(file));
+                await builder.addBuffer(path.relative(profile.getProfilePath(), file), await FsProvider.instance.readFile(file));
             }
         }
         return builder;

--- a/src/store/modules/ProfilesModule.ts
+++ b/src/store/modules/ProfilesModule.ts
@@ -39,7 +39,7 @@ export const ProfilesModule = {
 
         async removeSelectedProfile({rootGetters, state, dispatch}) {
             const activeProfile: Profile = rootGetters['profile/activeProfile'];
-            const path = activeProfile.getPathOfProfile();
+            const path = activeProfile.getProfilePath();
             const profileName = activeProfile.getProfileName();
 
             try {

--- a/src/store/modules/ProfilesModule.ts
+++ b/src/store/modules/ProfilesModule.ts
@@ -68,8 +68,8 @@ export const ProfilesModule = {
 
             try {
                 await FsProvider.instance.rename(
-                    path.join(Profile.getDirectory(), oldName),
-                    path.join(Profile.getDirectory(), params.newName)
+                    path.join(Profile.getRootDir(), oldName),
+                    path.join(Profile.getRootDir(), params.newName)
                 );
             } catch (e) {
                 throw R2Error.fromThrownValue(e, 'Error whilst renaming a profile on disk');
@@ -79,7 +79,7 @@ export const ProfilesModule = {
         },
 
         async updateProfileList({commit, rootGetters}) {
-            const profilesDirectory: string = rootGetters['profile/activeProfile'].getDirectory();
+            const profilesDirectory = Profile.getRootDir();
 
             let profilesDirectoryContents = await FsProvider.instance.readdir(profilesDirectory);
             let promises = profilesDirectoryContents.map(async function(file) {

--- a/src/utils/ProfileUtils.ts
+++ b/src/utils/ProfileUtils.ts
@@ -23,7 +23,7 @@ export async function extractZippedProfileFile(file: string, profileName: string
                 file,
                 entry.entryName,
                 path.join(
-                    Profile.getDirectory(),
+                    Profile.getRootDir(),
                     profileName,
                     'BepInEx'
                 )
@@ -33,7 +33,7 @@ export async function extractZippedProfileFile(file: string, profileName: string
                 file,
                 entry.entryName,
                 path.join(
-                    Profile.getDirectory(),
+                    Profile.getRootDir(),
                     profileName
                 )
             )

--- a/src/utils/UnityDoorstopUtils.ts
+++ b/src/utils/UnityDoorstopUtils.ts
@@ -1,10 +1,9 @@
 import Profile from '../model/Profile';
 import FsProvider from '../providers/generic/file/FsProvider';
-import * as path from 'path';
 
 export async function getUnityDoorstopVersion(profile: Profile): Promise<number> {
-    if (await FsProvider.instance.exists(path.join(profile.getPathOfProfile(), ".doorstop_version"))) {
-        const dvContent = (await FsProvider.instance.readFile(path.join(profile.getPathOfProfile(), ".doorstop_version"))).toString();
+    if (await FsProvider.instance.exists(profile.joinToProfilePath(".doorstop_version"))) {
+        const dvContent = (await FsProvider.instance.readFile(profile.joinToProfilePath(".doorstop_version"))).toString();
         const majorVersion = Number(dvContent.split(".")[0]);
         if (majorVersion && majorVersion > 3) {
             return majorVersion;

--- a/test/jest/__tests__/classes/Profile.ts.spec.ts
+++ b/test/jest/__tests__/classes/Profile.ts.spec.ts
@@ -1,0 +1,68 @@
+import * as path from "path";
+
+import InMemoryFsProvider from "../stubs/providers/InMemory.FsProvider";
+import GameManager from "../../../../src/model/game/GameManager";
+import { StorePlatform } from "../../../../src/model/game/StorePlatform";
+import Profile, { ImmutableProfile } from "../../../../src/model/Profile";
+import FsProvider from "../../../../src/providers/generic/file/FsProvider";
+import ProfileProvider from "../../../../src/providers/ror2/model_implementation/ProfileProvider";
+
+
+class ProfileProviderImpl extends ProfileProvider {
+    ensureProfileDirectory(directory: string, profile: string): void {
+        FsProvider.instance.mkdirs(path.join(directory, profile));
+    }
+}
+
+function activateGame(name: string) {
+    const game = GameManager.gameList.find(value => value.internalFolderName === name);
+
+    if (!game) {
+        throw new Error(`Unknown Game "${name}"`);
+    }
+
+    GameManager.activate(game, StorePlatform.STEAM);
+}
+
+describe("ImmutableProfile", () => {
+    beforeAll(async () => {
+        const inMemoryFs = new InMemoryFsProvider();
+        FsProvider.provide(() => inMemoryFs);
+        InMemoryFsProvider.clear();
+
+        ProfileProvider.provide(() => new ProfileProviderImpl());
+    });
+
+    it("Initializing ImmutableProfile doesn't affect Profile", () => {
+        activateGame("RiskOfRain2");
+        new Profile("ActiveProfile");
+        const immutable = new ImmutableProfile("Immutable");
+
+        expect(immutable.getProfileName()).toStrictEqual("Immutable");
+        expect(immutable.getPathOfProfile()).toMatch(/Immutable$/);
+        expect(Profile.getActiveProfile().getProfileName()).toStrictEqual("ActiveProfile");
+        expect(Profile.getActiveProfile().getPathOfProfile()).toMatch(/ActiveProfile$/);
+    });
+});
+
+describe("Profile", () => {
+
+    beforeAll(async () => {
+        const inMemoryFs = new InMemoryFsProvider();
+        FsProvider.provide(() => inMemoryFs);
+        InMemoryFsProvider.clear();
+
+        ProfileProvider.provide(() => new ProfileProviderImpl());
+    });
+
+    it("Initializing Profile doesn't affect ImmutableProfile", () => {
+        activateGame("RiskOfRain2");
+        const immutable = new ImmutableProfile("Immutable");
+        new Profile("ActiveProfile");
+
+        expect(immutable.getProfileName()).toStrictEqual("Immutable");
+        expect(immutable.getPathOfProfile()).toMatch(/Immutable$/);
+        expect(Profile.getActiveProfile().getProfileName()).toStrictEqual("ActiveProfile");
+        expect(Profile.getActiveProfile().getPathOfProfile()).toMatch(/ActiveProfile$/);
+    });
+});

--- a/test/jest/__tests__/classes/Profile.ts.spec.ts
+++ b/test/jest/__tests__/classes/Profile.ts.spec.ts
@@ -40,9 +40,9 @@ describe("ImmutableProfile", () => {
         const immutable = new ImmutableProfile("Immutable");
 
         expect(immutable.getProfileName()).toStrictEqual("Immutable");
-        expect(immutable.getPathOfProfile()).toMatch(/Immutable$/);
+        expect(immutable.getProfilePath()).toMatch(/Immutable$/);
         expect(Profile.getActiveProfile().getProfileName()).toStrictEqual("ActiveProfile");
-        expect(Profile.getActiveProfile().getPathOfProfile()).toMatch(/ActiveProfile$/);
+        expect(Profile.getActiveProfile().getProfilePath()).toMatch(/ActiveProfile$/);
     });
 
     it("joinToProfilePath is immutable if active game changes", () => {
@@ -86,9 +86,9 @@ describe("Profile", () => {
         new Profile("ActiveProfile");
 
         expect(immutable.getProfileName()).toStrictEqual("Immutable");
-        expect(immutable.getPathOfProfile()).toMatch(/Immutable$/);
+        expect(immutable.getProfilePath()).toMatch(/Immutable$/);
         expect(Profile.getActiveProfile().getProfileName()).toStrictEqual("ActiveProfile");
-        expect(Profile.getActiveProfile().getPathOfProfile()).toMatch(/ActiveProfile$/);
+        expect(Profile.getActiveProfile().getProfilePath()).toMatch(/ActiveProfile$/);
     });
 
     // Active game shouldn't change without the active profile resetting but test

--- a/test/jest/__tests__/impl/MelonLoader/state.spec.ts
+++ b/test/jest/__tests__/impl/MelonLoader/state.spec.ts
@@ -49,8 +49,8 @@ describe("State testing", () => {
             const fsStub = sandbox.stub(FsProvider.instance);
             FsProvider.provide(() => fsStub);
 
-            fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), "_state")).returns(Promise.resolve(true));
-            fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), "_state", `${fakeMod.getName()}-state.yml`)).returns(Promise.resolve(false));
+            fsStub.exists.withArgs(profile.joinToProfilePath("_state")).returns(Promise.resolve(true));
+            fsStub.exists.withArgs(profile.joinToProfilePath("_state", `${fakeMod.getName()}-state.yml`)).returns(Promise.resolve(false));
 
             await addToStateFile(
                 fakeMod,
@@ -77,12 +77,12 @@ describe("State testing", () => {
             const fsStub = sandbox.stub(FsProvider.instance);
             FsProvider.provide(() => fsStub);
 
-            fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), "_state", `${fakeMod.getName()}-state.yml`)).returns(Promise.resolve(true));
+            fsStub.exists.withArgs(profile.joinToProfilePath("_state", `${fakeMod.getName()}-state.yml`)).returns(Promise.resolve(true));
             files.forEach(([cached, installed]) => {
-                fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), installed)).returns(Promise.resolve(true));
+                fsStub.exists.withArgs(profile.joinToProfilePath(installed)).returns(Promise.resolve(true));
             });
 
-            fsStub.readFile.withArgs(path.join(profile.getPathOfProfile(), "_state", `${fakeMod.getName()}-state.yml`)).returns(Promise.resolve(Buffer.from(yaml.stringify(
+            fsStub.readFile.withArgs(profile.joinToProfilePath("_state", `${fakeMod.getName()}-state.yml`)).returns(Promise.resolve(Buffer.from(yaml.stringify(
                 {
                     modName: fakeMod.getName(),
                     files: files
@@ -94,9 +94,9 @@ describe("State testing", () => {
             await mlProfileInstaller.uninstallMod(fakeMod, profile);
 
             files.forEach(([cached, installed]) => {
-                expect(fsStub.unlink.withArgs(path.join(profile.getPathOfProfile(), installed)).callCount).toBe(1);
+                expect(fsStub.unlink.withArgs(profile.joinToProfilePath(installed)).callCount).toBe(1);
             });
-            expect(fsStub.unlink.withArgs(path.join(profile.getPathOfProfile(), "_state", `${fakeMod.getName()}-state.yml`)).callCount).toBe(1);
+            expect(fsStub.unlink.withArgs(profile.joinToProfilePath("_state", `${fakeMod.getName()}-state.yml`)).callCount).toBe(1);
 
         });
     });
@@ -223,21 +223,21 @@ let processConflictManagement = async (modA: ManifestV2, modFileTrackerA: ModFil
 
     // Ensure that on state file check; exists returns true.
     [modA, modB].forEach(value => {
-        fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), "_state", `${value.getName()}-state.yml`)).returns(Promise.resolve(true));
+        fsStub.exists.withArgs(profile.joinToProfilePath("_state", `${value.getName()}-state.yml`)).returns(Promise.resolve(true));
     });
 
     // Attach MSTs to readFile.
-    fsStub.readFile.withArgs(path.join(profile.getPathOfProfile(), "_state", `${modA.getName()}-state.yml`))
+    fsStub.readFile.withArgs(profile.joinToProfilePath("_state", `${modA.getName()}-state.yml`))
         .returns(Promise.resolve(Buffer.from(yaml.stringify(modFileTrackerA))));
 
-    fsStub.readFile.withArgs(path.join(profile.getPathOfProfile(), "_state", `${modB.getName()}-state.yml`))
+    fsStub.readFile.withArgs(profile.joinToProfilePath("_state", `${modB.getName()}-state.yml`))
         .returns(Promise.resolve(Buffer.from(yaml.stringify(modFileTrackerB))));
 
     // No need to check if file exists or not.
-    fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), "_state", "installation_state.yml")).returns(Promise.resolve(false));
+    fsStub.exists.withArgs(profile.joinToProfilePath("_state", "installation_state.yml")).returns(Promise.resolve(false));
 
     // No need to create state directory. Ensure no extra stubbing needed.
-    fsStub.exists.withArgs(path.join(profile.getPathOfProfile(), "_state")).returns(Promise.resolve(true));
+    fsStub.exists.withArgs(profile.joinToProfilePath("_state")).returns(Promise.resolve(true));
 
     await conflictManagement.resolveConflicts([modA, modB], profile);
 

--- a/test/jest/__tests__/impl/ModLinker/ModLinker.spec.ts
+++ b/test/jest/__tests__/impl/ModLinker/ModLinker.spec.ts
@@ -30,7 +30,7 @@ const def = () => describe('ModLinker (win32)', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         await GameDirectoryResolverProvider.provide(() => new SettingsRedirectGameDirectoryResolver());
         settings = await ManagerSettings.getSingleton(GameManager.defaultGame);
         await settings.load(true);

--- a/test/jest/__tests__/impl/ModLinker/ModLinker.spec.ts
+++ b/test/jest/__tests__/impl/ModLinker/ModLinker.spec.ts
@@ -48,7 +48,7 @@ const def = () => describe('ModLinker (win32)', () => {
     });
 
     test('Install, no existing files', async () => {
-        const testFile = path.join(Profile.getActiveProfile().getPathOfProfile(), "test_file");
+        const testFile = Profile.getActiveProfile().joinToProfilePath("test_file");
         await FsProvider.instance.writeFile(testFile, "content");
         expect(await FsProvider.instance.exists(path.join(settings.getContext().gameSpecific.gameDirectory!, "test_file"))).toBeFalsy();
         await ModLinker.link(Profile.getActiveProfile(), GameManager.defaultGame);
@@ -56,7 +56,7 @@ const def = () => describe('ModLinker (win32)', () => {
     });
 
     test('Install, file already exists, no overwrite', async () => {
-        const testFile = path.join(Profile.getActiveProfile().getPathOfProfile(), "test_file");
+        const testFile = Profile.getActiveProfile().joinToProfilePath("test_file");
         expect(await FsProvider.instance.exists(testFile)).toBeTruthy();
         const oldStat = await FsProvider.instance.stat(testFile);
         await new Promise(resolve => {
@@ -71,7 +71,7 @@ const def = () => describe('ModLinker (win32)', () => {
     });
 
     test('Install, file already exists, overwritten', async () => {
-        const testFile = path.join(Profile.getActiveProfile().getPathOfProfile(), "test_file");
+        const testFile = Profile.getActiveProfile().joinToProfilePath("test_file");
         expect(await FsProvider.instance.exists(testFile)).toBeTruthy();
         const oldStat = await FsProvider.instance.stat(testFile);
         await FsProvider.instance.writeFile(testFile, "modified");

--- a/test/jest/__tests__/impl/install_logic/Installer.Tests.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/Installer.Tests.spec.ts
@@ -53,9 +53,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "plugins", pkg.getName(), 'loose.dll'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", "plugins", pkg.getName(), 'loose.dll'))
+            ).toBeTruthy();
         });
 
         test("Keep override folder structure", async () => {
@@ -74,9 +74,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "plugins", pkg.getName(), "static_dir", "structured.dll"))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", "plugins", pkg.getName(), "static_dir", "structured.dll")
+            )).toBeTruthy();
         });
 
         test("Flatten non-override structure", async () => {
@@ -95,9 +95,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "plugins", pkg.getName(), "structured.dll"))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", "plugins", pkg.getName(), "structured.dll")
+            )).toBeTruthy();
         });
 
         test('Default file extension', async () => {
@@ -115,9 +115,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "monomod", pkg.getName(), 'loose.mm.dll'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", "monomod", pkg.getName(), 'loose.mm.dll')
+            )).toBeTruthy();
         });
 
     });
@@ -157,9 +157,9 @@ describe('Installer Tests', () => {
                 .find(value => value.isDefaultLocation)!;
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), defaultRuleSubtype.route, 'loose.file'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath(defaultRuleSubtype.route, 'loose.file')
+            )).toBeTruthy();
         });
 
         test('One-level nested', async () => {
@@ -178,9 +178,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "UserData", 'loose.file'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("UserData", 'loose.file')
+            )).toBeTruthy();
         });
 
         test('Two-level nested', async () => {
@@ -199,9 +199,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "UserData", "CustomFolder", 'loose.file'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("UserData", "CustomFolder", 'loose.file')
+            )).toBeTruthy();
         });
 
         // .managed.dll rule points to /MelonLoader/Managed
@@ -220,9 +220,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "MelonLoader", "Managed", 'loose.managed.dll'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("MelonLoader", "Managed", 'loose.managed.dll')
+            )).toBeTruthy();
         });
 
     });
@@ -258,9 +258,9 @@ describe('Installer Tests', () => {
             await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile());
 
             // Expect DLL to be installed as intended
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "config", 'loose.file'))).toBeTruthy();
-
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", "config", 'loose.file')
+            )).toBeTruthy();
         });
 
     });

--- a/test/jest/__tests__/impl/install_logic/Installer.Tests.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/Installer.Tests.spec.ts
@@ -32,7 +32,7 @@ describe('Installer Tests', () => {
             inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
             ProfileProvider.provide(() => new ProfileProviderImpl());
             new Profile('TestProfile');
-            inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+            inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
             GameManager.activeGame = GameManager.gameList.find(value => value.internalFolderName === "RiskOfRain2")!;
             InstallationRuleApplicator.apply();
             InMemoryFsProvider.setMatchMode("CASE_SENSITIVE");
@@ -132,7 +132,7 @@ describe('Installer Tests', () => {
             inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
             ProfileProvider.provide(() => new ProfileProviderImpl());
             new Profile('TestProfile');
-            inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+            inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
             GameManager.activeGame = GameManager.gameList.find(value => value.internalFolderName === "BONEWORKS")!;
             InstallationRuleApplicator.apply();
             ConflictManagementProvider.provide(() => new ConflictManagementProviderImpl());
@@ -237,7 +237,7 @@ describe('Installer Tests', () => {
             inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
             ProfileProvider.provide(() => new ProfileProviderImpl());
             new Profile('TestProfile');
-            inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+            inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
             GameManager.activeGame = GameManager.gameList.find(value => value.internalFolderName === "RiskOfRain2")!;
             InstallationRuleApplicator.apply();
         });

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.BONEWORKS.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.BONEWORKS.spec.ts
@@ -129,9 +129,10 @@ describe('BONEWORKS Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value[0].replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
-            expect(FsProvider.instance.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), "_state", `${pkg.getName()}.yml`)))
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath(value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
+            expect(FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath("_state", `${pkg.getName()}.yml`)))
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.BONEWORKS.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.BONEWORKS.spec.ts
@@ -72,7 +72,7 @@ describe('BONEWORKS Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         ConflictManagementProvider.provide(() => new ConflictManagementProviderImpl());

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.DysonSphereProgram.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.DysonSphereProgram.spec.ts
@@ -10,7 +10,6 @@ import ProfileInstallerProvider from '../../../../../../src/providers/ror2/insta
 import GameManager from 'src/model/game/GameManager';
 import GenericProfileInstaller from 'src/r2mm/installing/profile_installers/GenericProfileInstaller';
 import InstallationRuleApplicator from 'src/r2mm/installing/default_installation_rules/InstallationRuleApplicator';
-import InstallationRules from 'src/r2mm/installing/InstallationRules';
 import NodeFs from 'src/providers/generic/file/NodeFs';
 import FileTree from 'src/model/file/FileTree';
 import R2Error from 'src/model/errors/R2Error';
@@ -110,8 +109,9 @@ describe('Dyson Sphere Program Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +126,9 @@ describe('Dyson Sphere Program Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.DysonSphereProgram.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.DysonSphereProgram.spec.ts
@@ -70,7 +70,7 @@ describe('Dyson Sphere Program Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.GTFO.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.GTFO.spec.ts
@@ -115,8 +115,9 @@ describe('GTFO Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -131,8 +132,9 @@ describe('GTFO Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -148,9 +150,10 @@ describe('GTFO Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value[0].replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
-            expect(FsProvider.instance.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), "_state", `${pkg.getName()}.yml`)))
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath(value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
+            expect(FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath("_state", `${pkg.getName()}.yml`)))
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.GTFO.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.GTFO.spec.ts
@@ -72,7 +72,7 @@ describe('GTFO Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         ConflictManagementProvider.provide(() => new ConflictManagementProviderImpl());

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.H3VR.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.H3VR.spec.ts
@@ -114,8 +114,9 @@ describe('H3VR Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, '_')}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), 'BepInEx', path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath('BepInEx', path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -130,8 +131,9 @@ describe('H3VR Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, '_')}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), 'BepInEx', path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath('BepInEx', path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -146,9 +148,10 @@ describe('H3VR Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value[0].replace(/[\/\\]/g, '_')}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
-            expect(FsProvider.instance.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), '_state', `${pkg.getName()}.yml`)));
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath(value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
+            expect(FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath('_state', `${pkg.getName()}.yml`)));
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.H3VR.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.H3VR.spec.ts
@@ -72,7 +72,7 @@ describe('H3VR Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         ConflictManagementProvider.provide(() => new ConflictManagementProviderImpl());

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Inscryption.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Inscryption.spec.ts
@@ -110,8 +110,9 @@ describe('Inscryption Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('Inscryption Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Inscryption.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Inscryption.spec.ts
@@ -70,7 +70,7 @@ describe('Inscryption Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.LethalLeagueBlaze.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.LethalLeagueBlaze.spec.ts
@@ -110,8 +110,9 @@ describe('Lethal League Blaze Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('Lethal League Blaze Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.LethalLeagueBlaze.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.LethalLeagueBlaze.spec.ts
@@ -70,7 +70,7 @@ describe('Lethal League Blaze Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Mechanica.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Mechanica.spec.ts
@@ -110,8 +110,9 @@ describe('Mechanica Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('Mechanica Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Mechanica.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Mechanica.spec.ts
@@ -70,7 +70,7 @@ describe('Mechanica Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Muck.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Muck.spec.ts
@@ -110,8 +110,9 @@ describe('Muck Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('Muck Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Muck.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Muck.spec.ts
@@ -70,7 +70,7 @@ describe('Muck Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.NASB.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.NASB.spec.ts
@@ -116,8 +116,9 @@ describe('NASB Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -132,8 +133,9 @@ describe('NASB Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -149,9 +151,10 @@ describe('NASB Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value[0].replace(/[\/\\]/g, '_')}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
-            expect(FsProvider.instance.exists(path.join(Profile.getActiveProfile().getPathOfProfile(), '_state', `${pkg.getName()}.yml`)));
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath(value[1], path.basename(value[0]), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
+            expect(FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath('_state', `${pkg.getName()}.yml`)));
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.NASB.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.NASB.spec.ts
@@ -72,7 +72,7 @@ describe('NASB Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         ConflictManagementProvider.provide(() => new ConflictManagementProviderImpl());

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Outward.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Outward.spec.ts
@@ -70,7 +70,7 @@ describe('Outward Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Outward.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Outward.spec.ts
@@ -110,8 +110,9 @@ describe('Outward Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('Outward Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.ROUNDS.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.ROUNDS.spec.ts
@@ -70,7 +70,7 @@ describe('ROUNDS Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.ROUNDS.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.ROUNDS.spec.ts
@@ -110,8 +110,9 @@ describe('ROUNDS Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('ROUNDS Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.RiskOfRain2.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.RiskOfRain2.spec.ts
@@ -10,7 +10,6 @@ import ProfileInstallerProvider from '../../../../../../src/providers/ror2/insta
 import GameManager from 'src/model/game/GameManager';
 import GenericProfileInstaller from 'src/r2mm/installing/profile_installers/GenericProfileInstaller';
 import InstallationRuleApplicator from 'src/r2mm/installing/default_installation_rules/InstallationRuleApplicator';
-import InstallationRules from 'src/r2mm/installing/InstallationRules';
 import NodeFs from 'src/providers/generic/file/NodeFs';
 import FileTree from 'src/model/file/FileTree';
 import R2Error from 'src/model/errors/R2Error';
@@ -111,8 +110,9 @@ describe('Risk of Rain 2 Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -127,8 +127,9 @@ describe('Risk of Rain 2 Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.RiskOfRain2.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.RiskOfRain2.spec.ts
@@ -70,7 +70,7 @@ describe('Risk of Rain 2 Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Starsand.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Starsand.spec.ts
@@ -70,7 +70,7 @@ describe('Starsand Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Starsand.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Starsand.spec.ts
@@ -110,8 +110,9 @@ describe('Starsand Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('Starsand Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.TaleSpire.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.TaleSpire.spec.ts
@@ -70,7 +70,7 @@ describe('TaleSpire Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.TaleSpire.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.TaleSpire.spec.ts
@@ -110,8 +110,9 @@ describe('TaleSpire Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('TaleSpire Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Timberborn.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Timberborn.spec.ts
@@ -70,7 +70,7 @@ describe('Timberborn Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Timberborn.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Timberborn.spec.ts
@@ -111,8 +111,9 @@ describe('Timberborn Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -127,8 +128,9 @@ describe('Timberborn Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.TotallyAccurateBattleSimulator.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.TotallyAccurateBattleSimulator.spec.ts
@@ -70,7 +70,7 @@ describe('TABS Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.TotallyAccurateBattleSimulator.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.TotallyAccurateBattleSimulator.spec.ts
@@ -110,8 +110,9 @@ describe('TABS Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -126,8 +127,9 @@ describe('TABS Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.TsDev.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.TsDev.spec.ts
@@ -107,7 +107,7 @@ describe('TS Dev No Flatten Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            const noFlattenDir = path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "NoFlatten");
+            const noFlattenDir = Profile.getActiveProfile().joinToProfilePath("BepInEx", "NoFlatten");
             // Add one to remove trailing path separator.
             const subdirPathAfterNoFlatten = value.substring(path.join("BIE", "GameSpecific", "ThunderstoreDev", "NoFlatten").length + 1);
             expect(await FsProvider.instance.exists(path.join(
@@ -123,7 +123,7 @@ describe('TS Dev No Flatten Install Logic', () => {
         ]
 
         for (const value of subdirPaths) {
-            const noFlattenDir = path.join(Profile.getActiveProfile().getPathOfProfile(), "BepInEx", "NoFlatten");
+            const noFlattenDir = Profile.getActiveProfile().joinToProfilePath("BepInEx", "NoFlatten");
             const convertedName = value.replace(/[\/\\]/g, "_");
 
             expect(await FsProvider.instance.exists(path.join(

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.TsDev.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.TsDev.spec.ts
@@ -70,7 +70,7 @@ describe('TS Dev No Flatten Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Valheim.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Valheim.spec.ts
@@ -70,7 +70,7 @@ describe('Valheim Install Logic', () => {
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         new Profile('TestProfile');
-        await inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+        await inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
         InstallationRuleApplicator.apply();
 
         pkg = packageBuilder('test_mod', 'author', new VersionNumber('1.0.0'));

--- a/test/jest/__tests__/impl/install_logic/game_specific/Install.Valheim.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/game_specific/Install.Valheim.spec.ts
@@ -111,8 +111,9 @@ describe('Valheim Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), pkg.getName(), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 
@@ -127,8 +128,9 @@ describe('Valheim Install Logic', () => {
 
         for (const value of subdirPaths) {
             const convertedName = `${value.replace(/[\/\\]/g, "_")}`;
-            expect(await FsProvider.instance.exists(path.join(
-                Profile.getActiveProfile().getPathOfProfile(), "BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`))).toBeTruthy();
+            expect(await FsProvider.instance.exists(
+                Profile.getActiveProfile().joinToProfilePath("BepInEx", path.basename(value), `${convertedName}_Files`, `${convertedName}_file.txt`)
+            )).toBeTruthy();
         }
     });
 

--- a/test/jest/__utils__/InstallLogicUtils.ts
+++ b/test/jest/__utils__/InstallLogicUtils.ts
@@ -41,7 +41,7 @@ export async function installLogicBeforeEach(internalFolderName: string) {
 
     ProfileProvider.provide(() => new ProfileProviderImpl());
     new Profile('TestProfile');
-    inMemoryFs.mkdirs(Profile.getActiveProfile().getPathOfProfile());
+    inMemoryFs.mkdirs(Profile.getActiveProfile().getProfilePath());
 
     ProfileInstallerProvider.provide(() => new GenericProfileInstaller());
     InstallationRuleApplicator.apply();
@@ -106,7 +106,7 @@ async function getTree(target: string) {
  */
 export async function expectFilesToBeCopied(sourceToExpectedDestination: Record<string, string>) {
     const fs = FsProvider.instance;
-    const profilePath = Profile.getActiveProfile().getPathOfProfile();
+    const profilePath = Profile.getActiveProfile().getProfilePath();
 
     for (const destPath of Object.values(sourceToExpectedDestination)) {
         const fullPath = path.join(profilePath, destPath);
@@ -128,7 +128,7 @@ export async function expectFilesToBeRemoved(
     expectedAfterUninstall: string[]
 ) {
     const fs = FsProvider.instance;
-    const profilePath = Profile.getActiveProfile().getPathOfProfile();
+    const profilePath = Profile.getActiveProfile().getProfilePath();
 
     for (const destPath of Object.values(sourceToExpectedDestination)) {
         const fullPath = path.join(profilePath, destPath);
@@ -149,7 +149,7 @@ export async function expectFilesToBeRemoved(
 
 export async function createFilesIntoProfile(filePaths: string[]) {
     const fs = FsProvider.instance;
-    const profilePath = Profile.getActiveProfile().getPathOfProfile();
+    const profilePath = Profile.getActiveProfile().getProfilePath();
 
     for (const filePath of filePaths) {
         const destPath = path.join(profilePath, ...filePath.split('/'));
@@ -161,7 +161,7 @@ export async function createFilesIntoProfile(filePaths: string[]) {
 
 export async function expectFilesToExistInProfile(filePaths: string[]) {
     const fs = FsProvider.instance;
-    const profilePath = Profile.getActiveProfile().getPathOfProfile();
+    const profilePath = Profile.getActiveProfile().getProfilePath();
 
     for (const filePath of filePaths) {
         const fullPath = path.join(profilePath, filePath);


### PR DESCRIPTION
This is part of a larger refactoring effort aiming to remove the
business logic from components so it can eventually be exported to be
a responsibility of a CLI tool.