### PR TITLE
Refactor ModLinker to use ImmutableProfile

### DIFF
--- a/src/components/navigation/NavigationMenu.vue
+++ b/src/components/navigation/NavigationMenu.vue
@@ -107,7 +107,7 @@ export default class NavigationMenu extends Vue {
             await throwIfNoGameDir(this.activeGame);
 
             if (mode === LaunchMode.MODDED) {
-                await linkProfileFiles(this.activeGame, this.profile);
+                await linkProfileFiles(this.activeGame, this.profile.asImmutableProfile());
             }
 
             this.$store.commit("openGameRunningModal");

--- a/src/r2mm/manager/ModLinker.ts
+++ b/src/r2mm/manager/ModLinker.ts
@@ -1,5 +1,5 @@
 import R2Error from '../../model/errors/R2Error';
-import Profile from '../../model/Profile';
+import { ImmutableProfile } from '../../model/Profile';
 import FileWriteError from '../../model/errors/FileWriteError';
 
 import * as path from 'path';
@@ -15,7 +15,7 @@ import { PackageLoader } from "../../model/installing/PackageLoader";
 
 export default class ModLinker {
 
-    public static async link(profile: Profile, game: Game): Promise<string[] | R2Error> {
+    public static async link(profile: ImmutableProfile, game: Game): Promise<string[] | R2Error> {
         if (game.packageLoader == PackageLoader.BEPINEX) {
             if (process.platform === 'linux') {
                 const isProton = await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).isProtonGame(game);
@@ -56,7 +56,7 @@ export default class ModLinker {
     // Is this 100% needed?
     // Could move to a setting at a later date?
     // TBD: Only apply when starting vanilla?
-    private static async cleanupLinkedFiles(profile: Profile, installDirectory: string, previouslyLinkedFiles: string[]) {
+    private static async cleanupLinkedFiles(profile: ImmutableProfile, installDirectory: string, previouslyLinkedFiles: string[]) {
         const fs = FsProvider.instance;
         await LoggerProvider.instance.Log(LogSeverity.INFO, `Files to remove: \n-> ${previouslyLinkedFiles.join('\n-> ')}`);
         for (const file of previouslyLinkedFiles) {
@@ -93,7 +93,7 @@ export default class ModLinker {
         }
     }
 
-    private static async performLink(profile: Profile, game: Game, installDirectory: string): Promise<string[] | R2Error> {
+    private static async performLink(profile: ImmutableProfile, game: Game, installDirectory: string): Promise<string[] | R2Error> {
         const fs = FsProvider.instance;
         const newLinkedFiles: string[] = [];
         try {

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -1,4 +1,4 @@
-import Profile from "../model/Profile";
+import Profile, { ImmutableProfile } from "../model/Profile";
 import R2Error from "../model/errors/R2Error";
 import Game from "../model/game/Game";
 import FsProvider from "../providers/generic/file/FsProvider";
@@ -19,7 +19,7 @@ export const launch = async (game: Game, profile: Profile, mode: LaunchMode): Pr
     }
 };
 
-export const linkProfileFiles = async (game: Game, profile: Profile): Promise<void> => {
+export const linkProfileFiles = async (game: Game, profile: ImmutableProfile): Promise<void> => {
     const settings = await ManagerSettings.getSingleton(game);
 
     const newLinkedFiles = await ModLinker.link(profile, game);

--- a/test/jest/__tests__/impl/ModLinker/ModLinker.spec.ts
+++ b/test/jest/__tests__/impl/ModLinker/ModLinker.spec.ts
@@ -51,7 +51,7 @@ const def = () => describe('ModLinker (win32)', () => {
         const testFile = Profile.getActiveProfile().joinToProfilePath("test_file");
         await FsProvider.instance.writeFile(testFile, "content");
         expect(await FsProvider.instance.exists(path.join(settings.getContext().gameSpecific.gameDirectory!, "test_file"))).toBeFalsy();
-        await ModLinker.link(Profile.getActiveProfile(), GameManager.defaultGame);
+        await ModLinker.link(Profile.getActiveAsImmutableProfile(), GameManager.defaultGame);
         expect(await FsProvider.instance.exists(path.join(settings.getContext().gameSpecific.gameDirectory!, "test_file"))).toBeTruthy();
     });
 
@@ -61,7 +61,7 @@ const def = () => describe('ModLinker (win32)', () => {
         const oldStat = await FsProvider.instance.stat(testFile);
         await new Promise(resolve => {
             setTimeout(async () => {
-                await ModLinker.link(Profile.getActiveProfile(), GameManager.defaultGame);
+                await ModLinker.link(Profile.getActiveAsImmutableProfile(), GameManager.defaultGame);
                 expect(await FsProvider.instance.exists(path.join(settings.getContext().gameSpecific.gameDirectory!, "test_file"))).toBeTruthy();
                 const newStat = await FsProvider.instance.stat(testFile);
                 expect(newStat.mtime).toEqual(oldStat.mtime);
@@ -77,7 +77,7 @@ const def = () => describe('ModLinker (win32)', () => {
         await FsProvider.instance.writeFile(testFile, "modified");
         await new Promise(resolve => {
             setTimeout(async () => {
-                await ModLinker.link(Profile.getActiveProfile(), GameManager.defaultGame);
+                await ModLinker.link(Profile.getActiveAsImmutableProfile(), GameManager.defaultGame);
                 expect(await FsProvider.instance.exists(path.join(settings.getContext().gameSpecific.gameDirectory!, "test_file"))).toBeTruthy();
                 const newStat = await FsProvider.instance.stat(testFile);
                 expect(newStat.mtime).not.toEqual(oldStat.mtime);


### PR DESCRIPTION
Once started, the outcome of mod linking operation shouldn't change if the active profile is changed for whatever reason.