### PR TITLE
Use getCombosByDependencyStrings in ProfileUtils

### DIFF
--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -167,13 +167,13 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
         const progressCallback = (progress: number|string) => typeof progress === "number"
             ? this.importPhaseDescription = `Downloading mods: ${Math.floor(progress)}%`
             : this.importPhaseDescription = progress;
-        const community = this.$store.state.activeGame.internalFolderName;
+        const game = this.$store.state.activeGame;
         const settings = this.$store.getters['settings'];
         const ignoreCache = settings.getContext().global.ignoreCache;
         const isUpdate = this.importUpdateSelection === 'UPDATE';
 
         try {
-            const comboList = await ProfileUtils.exportModsToCombos(mods, community);
+            const comboList = await ProfileUtils.exportModsToCombos(mods, game);
             await ThunderstoreDownloaderProvider.instance.downloadImportedMods(comboList, ignoreCache, progressCallback);
             await ProfileUtils.populateImportedProfile(comboList, mods, targetProfileName, isUpdate, zipPath, progressCallback);
         } catch (e) {

--- a/src/model/exports/ExportMod.ts
+++ b/src/model/exports/ExportMod.ts
@@ -43,6 +43,10 @@ export default class ExportMod {
         return this.version;
     }
 
+    public getDependencyString(): string {
+        return `${this.name}-${this.version}`;
+    }
+
     public isEnabled(): boolean {
         return this.enabled;
     }


### PR DESCRIPTION
The recently added helper is more suitable for the use case. This also means the implementation doesn't depend on ThunderstoreMod containing references to all related ThunderstoreVersions anymore - a change we want to introduce to reduce the apps memory footprint.