### PR TITLE
Discard profile if importing fails midway through the process

### DIFF
--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -177,6 +177,7 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
             await ThunderstoreDownloaderProvider.instance.downloadImportedMods(comboList, ignoreCache, progressCallback);
             await ProfileUtils.populateImportedProfile(comboList, mods, targetProfileName, isUpdate, zipPath, progressCallback);
         } catch (e) {
+            await this.$store.dispatch('profiles/ensureProfileExists');
             this.closeModal();
             this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
             return;

--- a/src/store/modules/ProfilesModule.ts
+++ b/src/store/modules/ProfilesModule.ts
@@ -37,6 +37,18 @@ export const ProfilesModule = {
             }
         },
 
+        async ensureProfileExists({commit, dispatch, rootGetters, state}) {
+            const activeProfile: Profile = rootGetters['profile/activeProfile'];
+
+            if (!(await FsProvider.instance.exists(activeProfile.getProfilePath()))) {
+                await dispatch('profile/updateActiveProfile', 'Default', { root: true });
+                commit(
+                    'setProfileList',
+                    state.profileList.filter((p) => p !== activeProfile.getProfileName())
+                );
+            }
+        },
+
         async removeSelectedProfile({rootGetters, state, dispatch}) {
             const activeProfile: Profile = rootGetters['profile/activeProfile'];
             const path = activeProfile.getProfilePath();

--- a/src/utils/ProfileUtils.ts
+++ b/src/utils/ProfileUtils.ts
@@ -146,8 +146,13 @@ export async function populateImportedProfile(
         await FileUtils.recursiveRemoveDirectoryIfExists(profile.getProfilePath());
     }
 
-    await installModsToImportedProfile(comboList, exportModList, profile, progressCallback);
-    await extractConfigsToImportedProfile(zipPath, profile.getProfileName(), progressCallback);
+    try {
+        await installModsToImportedProfile(comboList, exportModList, profile, progressCallback);
+        await extractConfigsToImportedProfile(zipPath, profile.getProfileName(), progressCallback);
+    } catch (e) {
+        await FileUtils.recursiveRemoveDirectoryIfExists(profile.getProfilePath());
+        throw e;
+    }
 
     if (isUpdate) {
         progressCallback('Applying changes to updated profile...');


### PR DESCRIPTION
If importing a profile fails while copying files, the resulting profile is unlikely to be what the user expects it to be, so delete the profile folder. The process can't be resumed, so any retry will do all the work (besides downloading the mods) again anyway.

When creating a new profile, it's the newly created profile folder. When updating an existing profile, it's the temporary work folder.

On the UI/state management side, we need to check if the profile exists or not, and update the profile list accordingly.