### PR TITLE
Remove last uses of Profile from ProfileInstallerProvider

### DIFF
--- a/src/providers/ror2/installing/ProfileInstallerProvider.ts
+++ b/src/providers/ror2/installing/ProfileInstallerProvider.ts
@@ -1,7 +1,7 @@
 import ProviderUtils from '../../generic/ProviderUtils';
 import ManifestV2 from '../../../model/ManifestV2';
 import R2Error from '../../../model/errors/R2Error';
-import Profile, { ImmutableProfile } from '../../../model/Profile';
+import { ImmutableProfile } from '../../../model/Profile';
 
 export default abstract class ProfileInstallerProvider {
 
@@ -21,7 +21,7 @@ export default abstract class ProfileInstallerProvider {
      * Removes a mod from the profile. Does not affect the mod list display.
      * @param mod
      */
-    public abstract uninstallMod(mod: ManifestV2, profile: Profile): Promise<R2Error | null>;
+    public abstract uninstallMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null>;
 
     /**
      * Disable files to prevent the mod from loading.

--- a/src/r2mm/installing/LocalModInstaller.ts
+++ b/src/r2mm/installing/LocalModInstaller.ts
@@ -60,7 +60,7 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
                         }
                     }
                     await FsProvider.instance.writeFile(path.join(cacheDirectory, manifest.getName(), manifest.getVersionNumber().toString(), "mm_v2_manifest.json"), JSON.stringify(manifest));
-                    await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
+                    await ProfileInstallerProvider.instance.uninstallMod(manifest, profile.asImmutableProfile());
                     const profileInstallResult = await ProfileInstallerProvider.instance.installMod(manifest, profile.asImmutableProfile());
                     if (profileInstallResult instanceof R2Error) {
                         callback(false, profileInstallResult);
@@ -86,7 +86,7 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
             const fileSafe = file.split("\\").join("/");
             await FsProvider.instance.copyFile(fileSafe, path.join(modCacheDirectory, path.basename(fileSafe)));
             await FsProvider.instance.writeFile(path.join(modCacheDirectory, "mm_v2_manifest.json"), JSON.stringify(manifest));
-            await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
+            await ProfileInstallerProvider.instance.uninstallMod(manifest, profile.asImmutableProfile());
             const profileInstallResult = await ProfileInstallerProvider.instance.installMod(manifest, profile.asImmutableProfile());
             if (profileInstallResult instanceof R2Error) {
                 callback(false, profileInstallResult);

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -1,6 +1,6 @@
 import ProfileInstallerProvider from '../../../providers/ror2/installing/ProfileInstallerProvider';
 import ManifestV2 from '../../../model/ManifestV2';
-import Profile, { ImmutableProfile } from '../../../model/Profile';
+import { ImmutableProfile } from '../../../model/Profile';
 import FileTree from '../../../model/file/FileTree';
 import R2Error from '../../../model/errors/R2Error';
 import ModLoaderPackageMapping from '../../../model/installing/ModLoaderPackageMapping';
@@ -157,11 +157,10 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         return this.installForManifestV2(args);
     }
 
-    private getInstallArgs(mod: ManifestV2, profile: Profile|ImmutableProfile): InstallArgs {
-        const immutable = profile instanceof Profile ? profile.asImmutableProfile() : profile;
+    private getInstallArgs(mod: ManifestV2, profile: ImmutableProfile): InstallArgs {
         const cacheDirectory = path.join(PathResolver.MOD_ROOT, 'cache');
         const packagePath = path.join(cacheDirectory, mod.getName(), mod.getVersionNumber().toString());
-        return {mod, profile: immutable, packagePath};
+        return {mod, profile, packagePath};
     }
 
     private getModLoader(mod: ManifestV2): ModLoaderPackageMapping|undefined {
@@ -182,7 +181,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         }
     }
 
-    private async uninstallPackageZip(mod: ManifestV2, profile: Profile) {
+    private async uninstallPackageZip(mod: ManifestV2, profile: ImmutableProfile) {
         const fs = FsProvider.instance;
 
         const recursiveDelete = async (mainPath: string, match: string) => {
@@ -200,7 +199,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         await recursiveDelete(profile.getProfilePath(), `${mod.getName()}.ts.zip`);
     }
 
-    private async uninstallSubDir(mod: ManifestV2, profile: Profile): Promise<R2Error | null> {
+    private async uninstallSubDir(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null> {
         const activeGame = GameManager.activeGame;
         const fs = FsProvider.instance;
 
@@ -255,7 +254,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         return Promise.resolve(null);
     }
 
-    private async uninstallState(mod: ManifestV2, profile: Profile): Promise<R2Error | null> {
+    private async uninstallState(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null> {
         const stateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
         if (await FsProvider.instance.exists(stateFilePath)) {
             const read = await FsProvider.instance.readFile(stateFilePath);
@@ -273,7 +272,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         return Promise.resolve(null);
     }
 
-    async uninstallMod(mod: ManifestV2, profile: Profile): Promise<R2Error | null> {
+    async uninstallMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null> {
         // Support for installer specific uninstall methods are rolled out
         // gradually and therefore might not be defined yet.
         try {
@@ -309,7 +308,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
      * implements a custom uninstallation method.
      * @return true if mod loader was uninstalled
      */
-    async uninstallModLoaderWithInstaller(mod: ManifestV2, profile: Profile): Promise<boolean> {
+    async uninstallModLoaderWithInstaller(mod: ManifestV2, profile: ImmutableProfile): Promise<boolean> {
         const modLoader = this.getModLoader(mod);
         const installerId = modLoader ? GetInstallerIdForLoader(modLoader.loaderType) : null;
         return this.uninstallWithInstaller(installerId, mod, profile);
@@ -320,7 +319,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
      * uninstallation method.
      * @return true if mod was uninstalled
      */
-    async uninstallModWithInstaller(mod: ManifestV2, profile: Profile): Promise<boolean> {
+    async uninstallModWithInstaller(mod: ManifestV2, profile: ImmutableProfile): Promise<boolean> {
         const installerId = GetInstallerIdForPlugin(GameManager.activeGame.packageLoader);
         return this.uninstallWithInstaller(installerId, mod, profile);
     }
@@ -328,7 +327,7 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
     private async uninstallWithInstaller(
         installerId: PackageInstallerId | null,
         mod: ManifestV2,
-        profile: Profile
+        profile: ImmutableProfile
     ): Promise<boolean> {
         const installer = installerId ? PackageInstallers[installerId] : undefined;
 

--- a/src/store/modules/ProfileModule.ts
+++ b/src/store/modules/ProfileModule.ts
@@ -383,7 +383,7 @@ export default {
                 onProgress?: (mod: ManifestV2) => void,
             }
         ) {
-            const profile = getters.activeProfileOrThrow;
+            const profile = getters.activeProfileOrThrow.asImmutableProfile();
             await dispatch('uninstallModsFromProfile', {...params, profile});
         },
 
@@ -391,7 +391,7 @@ export default {
             {dispatch},
             params: {
                 mods: ManifestV2[],
-                profile: Profile,
+                profile: ImmutableProfile,
                 onProgress?: (mod: ManifestV2) => void,
             }
         ) {
@@ -411,7 +411,7 @@ export default {
                     // Update mod list status to mods.yml.
                     // TODO: can performance be improved by implementing
                     // a .removeMods(mods, profile) and calling it once outside the loop?
-                    const updatedList = await ProfileModList.removeMod(mod, profile.asImmutableProfile());
+                    const updatedList = await ProfileModList.removeMod(mod, profile);
                     if (updatedList instanceof R2Error) {
                         throw updatedList;
                     } else {

--- a/test/jest/__tests__/impl/MelonLoader/state.spec.ts
+++ b/test/jest/__tests__/impl/MelonLoader/state.spec.ts
@@ -71,7 +71,7 @@ describe("State testing", () => {
             const files: [string, string][] = [["cachedFileA", "fileInstallLocationA"], ["cachedFileB", "fileInstallLocationB"]];
 
             sandbox.stub(ProfileProvider.instance);
-            const profile = new Profile("stub");
+            const profile = new ImmutableProfile("stub");
 
             const fsStub = sandbox.stub(FsProvider.instance);
             FsProvider.provide(() => fsStub);

--- a/test/jest/__tests__/impl/install_logic/ReturnOfModding.Tests.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/ReturnOfModding.Tests.spec.ts
@@ -29,7 +29,7 @@ describe('ReturnOfModding Installer Tests', () => {
         await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         await expectFilesToBeCopied(sourceToExpectedDestination);
 
-        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile());
+        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         expect(result instanceof R2Error).toBeFalsy();
         await expectFilesToBeRemoved(sourceToExpectedDestination, expectedAfterUninstall);
     });
@@ -70,7 +70,7 @@ describe('ReturnOfModding Installer Tests', () => {
         await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         await expectFilesToBeCopied(sourceToExpectedDestination);
 
-        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile());
+        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         expect(result instanceof R2Error).toBeFalsy();
         await expectFilesToBeRemoved(sourceToExpectedDestination, expectedAfterUninstall);
     });
@@ -89,7 +89,7 @@ describe('ReturnOfModding Installer Tests', () => {
         await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         await expectFilesToBeCopied(sourceToExpectedDestination);
 
-        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile());
+        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         expect(result instanceof R2Error).toBeFalsy();
         await expectFilesToBeRemoved(sourceToExpectedDestination, expectedAfterUninstall);
     });

--- a/test/jest/__tests__/impl/install_logic/Shimloader.Tests.spec.ts
+++ b/test/jest/__tests__/impl/install_logic/Shimloader.Tests.spec.ts
@@ -38,7 +38,7 @@ describe('Shimloader Installer Tests', () => {
         await ProfileInstallerProvider.instance.installMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         await expectFilesToBeCopied(sourceToExpectedDestination);
 
-        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile());
+        const result = await ProfileInstallerProvider.instance.uninstallMod(pkg, Profile.getActiveProfile().asImmutableProfile());
         expect(result instanceof R2Error).toBeFalsy();
         expectFilesToBeRemoved(sourceToExpectedDestination, expectedAfterUninstall)
     });


### PR DESCRIPTION
ImmutableProfile objects will now be used with uninstallation operations, as changing the target profile in the middle of the operation would result in disaster.