### PR TITLE
Improve performance of installing mods with multiple dependencies

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -107,6 +107,7 @@ import ConflictManagementProvider from '../../providers/generic/installing/Confl
 import { MOD_LOADER_VARIANTS } from '../../r2mm/installing/profile_installers/ModLoaderVariantRecord';
 import ModalCard from '../ModalCard.vue';
 import * as PackageDb from '../../r2mm/manager/PackageDexieStore';
+import { installModsAfterDownload } from '../../utils/ProfileUtils';
 
 interface DownloadProgress {
     assignId: number;
@@ -370,24 +371,20 @@ let assignId = 0;
 
         async downloadCompletedCallback(downloadedMods: ThunderstoreCombo[]) {
             ProfileModList.requestLock(async () => {
-                for (const combo of downloadedMods) {
-                    try {
-                        await DownloadModModal.installModAfterDownload(this.profile, combo.getMod(), combo.getVersion());
-                    } catch (e) {
-                        this.downloadingMod = false;
-                        const err = R2Error.fromThrownValue(e, `Failed to install mod [${combo.getMod().getFullName()}]`);
-                        this.$store.commit('error/handleError', err);
-                        return;
-                    }
-                }
-                this.downloadingMod = false;
-                const modList = await ProfileModList.getModList(this.profile.asImmutableProfile());
-                if (!(modList instanceof R2Error)) {
+                const profile = this.profile.asImmutableProfile();
+
+                try {
+                    const modList = await installModsAfterDownload(downloadedMods, profile);
                     await this.$store.dispatch('profile/updateModList', modList);
+
                     const err = await ConflictManagementProvider.instance.resolveConflicts(modList, this.profile);
                     if (err instanceof R2Error) {
-                        this.$store.commit('error/handleError', err);
+                        throw err;
                     }
+                } catch (e) {
+                    this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
+                } finally {
+                    this.downloadingMod = false;
                 }
             });
         }

--- a/src/model/ManifestV2.ts
+++ b/src/model/ManifestV2.ts
@@ -282,4 +282,8 @@ export default class ManifestV2 implements ReactiveObjectConverterInterface {
     public setInstalledAtTime(installedAtTime: number) {
         this.installedAtTime = installedAtTime;
     }
+
+    public getDependencyString(): string {
+        return `${this.getName()}-${this.getVersionNumber().toString()}`;
+    }
 }


### PR DESCRIPTION
After the downloads are completed, the download modal hangs at 100% for
a moment while mods are copied to the profile folder and the mods.yml
file is updated.

The old implementation called ProfileModList.addMod() for each mod,
which meant that for each mod:

- The mods.yml was read six times, including checking if the file
  exists, reading it, parsing the yaml into ManifestV2[], and checking
  if *each* mod in the profile has icon file inside the profile folder
- The mods.yml was written twice, serializing the ManifestV2[] into
  yaml.
- For a modpack with 69 mods, all already in the cache, this took 25
  seconds

The new implementation tracks the contents of the ManifestV2[] in
memory. As a result mods.yml is read twice and saved once regardless
of the number of processed mods. For the aforementioned modpack this
takes four seconds.

It's worth noting that the implementations aren't completely identical
in other things. The new implementation doesn't necessarily define
which mod caused the error, whereas the old one did. The new
implementation doesn't give special treatment to bbepis-BepInExCack
anymore - it's now uninstalled like all the other files are.

Unfortunately this doesn't allow us to use the new implementation
with the static DownloadModModal.downloadSpecific(), nor clean up
the old implementation. That would require more refactoring, which
doesn't need to block these changes.