### PR TITLE
Fix method argument

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -408,7 +408,7 @@ let assignId = 0;
                     const resolvedAuthorModNameString = `${manifestMod.getAuthorName()}-${manifestMod.getDisplayName()}`;
                     const olderInstallOfMod = profileModList.find(value => `${value.getAuthorName()}-${value.getDisplayName()}` === resolvedAuthorModNameString);
                     if (manifestMod.getName().toLowerCase() !== 'bbepis-bepinexpack') {
-                        const result = await ProfileInstallerProvider.instance.uninstallMod(manifestMod, profile);
+                        const result = await ProfileInstallerProvider.instance.uninstallMod(manifestMod, profile.asImmutableProfile());
                         if (result instanceof R2Error) {
                             return reject(result);
                         }


### PR DESCRIPTION
uninstallMod method was recently changed to accept ImmutableProfile instead of a profile, but this file wasn't included in the PR since I had stashed the file due to other simultaneous changes.