### PR TITLE
Always track changes to mods.yml when installing mods to a profile

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -107,7 +107,7 @@ import ConflictManagementProvider from '../../providers/generic/installing/Confl
 import { MOD_LOADER_VARIANTS } from '../../r2mm/installing/profile_installers/ModLoaderVariantRecord';
 import ModalCard from '../ModalCard.vue';
 import * as PackageDb from '../../r2mm/manager/PackageDexieStore';
-import { installModsAfterDownload } from '../../utils/ProfileUtils';
+import { installModsToProfile } from '../../utils/ProfileUtils';
 
 interface DownloadProgress {
     assignId: number;
@@ -374,7 +374,7 @@ let assignId = 0;
                 const profile = this.profile.asImmutableProfile();
 
                 try {
-                    const modList = await installModsAfterDownload(downloadedMods, profile);
+                    const modList = await installModsToProfile(downloadedMods, profile);
                     await this.$store.dispatch('profile/updateModList', modList);
 
                     const err = await ConflictManagementProvider.instance.resolveConflicts(modList, this.profile);

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -194,7 +194,10 @@ export default class ProfileModList {
         // Add all tree contents to buffer.
         for (const file of tree.getRecursiveFiles()) {
             const fileLower = file.toLowerCase();
-            if (this.SUPPORTED_CONFIG_FILE_EXTENSIONS.filter(value => fileLower.endsWith(value)).length > 0) {
+            if (
+                this.SUPPORTED_CONFIG_FILE_EXTENSIONS.some(value => fileLower.endsWith(value)) &&
+                !fileLower.endsWith('mods.yml')
+            ) {
                 await builder.addBuffer(path.relative(profile.getProfilePath(), file), await FsProvider.instance.readFile(file));
             }
         }


### PR DESCRIPTION
Both regular installation and importing a profile now use the same helper function. Effectively this means that import now tracks installed mods to profile's mods.yml file instead of copying the file as-is from the exported zip. This restores compatibility with profiles exported with Gale, and closes one potential attack vector.

Profile exporting no longer includes the mods.yml in the zip files. Profile import ignores the file even if it exists to accommodate older profiles.