### PR TITLE
Fix sorting online mod list by download counts

### DIFF
--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -46,7 +46,7 @@
                 <DonateButton :mod="key"/>
             </template>
             <div class='card-footer-item non-selectable'>
-                <span><i class='fas fa-download'/> {{key.getTotalDownloads()}}</span>
+                <span><i class='fas fa-download'/> {{key.getDownloadCount()}}</span>
             </div>
             <div class='card-footer-item non-selectable'>
                 <span><i class='fas fa-thumbs-up'/> {{key.getRating()}}</span>

--- a/src/model/ThunderstoreMod.ts
+++ b/src/model/ThunderstoreMod.ts
@@ -9,7 +9,6 @@ export default class ThunderstoreMod extends ThunderstoreVersion {
     private uuid4: string = '';
     private pinned: boolean = false;
     private deprecated: boolean = false;
-    private totalDownloads: number = 0;
     private categories: string[] = [];
     private hasNsfwContent: boolean = false;
     private donationLink: string | undefined;
@@ -25,7 +24,7 @@ export default class ThunderstoreMod extends ThunderstoreVersion {
         mod.setDeprecatedStatus(data.is_deprecated);
         mod.setPinnedStatus(data.is_pinned);
         mod.setRating(data.rating_score);
-        mod.setTotalDownloads(
+        mod.setDownloadCount(
             data.versions.reduce(
                 (x: number, y: {downloads: number}) => x + y.downloads,
                 0
@@ -115,14 +114,6 @@ export default class ThunderstoreMod extends ThunderstoreVersion {
 
     public setDeprecatedStatus(deprecated: boolean) {
         this.deprecated = deprecated;
-    }
-
-    public getTotalDownloads(): number {
-        return this.totalDownloads;
-    }
-
-    public setTotalDownloads(total: number) {
-        this.totalDownloads = total;
     }
 
     public getCategories(): string[] {


### PR DESCRIPTION
This had broken when ThunderstoreMod object dropped a reference to a list of ThunderstoreVersions to reduce memory usage. ThunderstoreMod defined a separate getter for package's total download count, but the sorting method kept using the getter inherited by ThunderstoreMod from ThunderstoreVersion, always returning 0. TypeScript didn't catch the error, since due to inheritance, it was a valid getter to call.

Rather than rename the sorting method to use the correct getter, drop the duplicate getter to ensure similar errors don't occur in the future. Both ThunderstoreMod and ThunderstoreVersion now have the same getter, while former just returns the combined download counts of all the versions.