### PR TITLE
Prevent disabling/enabling mod loaders

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,6 +100,8 @@ export default class App extends mixins(UtilityMixin) {
         this.$watch('$q.dark.isActive', () => {
             document.documentElement.classList.toggle('html--dark', this.$q.dark.isActive);
         });
+
+        this.$store.commit('updateModLoaderPackageNames');
     }
 
     beforeCreate() {

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -25,6 +25,12 @@ export default class LocalModCard extends Vue {
     missingDependencies: string[] = [];
     disableChangePending = false;
 
+    get canBeDisabled(): boolean {
+        // Mod loader packages can't be disabled as it's hard to define
+        // what that should even do in all cases.
+        return !this.$store.getters['isModLoader'](this.mod.getName());
+    }
+
     get donationLink() {
         return this.tsMod ? this.tsMod.getDonationLink() : undefined;
     }
@@ -246,7 +252,8 @@ function dependencyStringToModName(x: string) {
                     class='fas fa-exclamation-circle'
                 ></i>
             </span>
-            <span @click.prevent.stop="() => mod.isEnabled() ? disableMod() : enableMod(mod)"
+            <span v-if="canBeDisabled"
+                @click.prevent.stop="() => mod.isEnabled() ? disableMod() : enableMod(mod)"
                 class='card-header-icon'>
                 <div class="field">
                     <input :id="`switch-${mod.getName()}`"
@@ -264,10 +271,10 @@ function dependencyStringToModName(x: string) {
             Uninstall
         </a>
 
-        <a v-if="mod.isEnabled()" @click="disableMod()" class='card-footer-item'>
+        <a v-if="canBeDisabled && mod.isEnabled()" @click="disableMod()" class='card-footer-item'>
             Disable
         </a>
-        <a v-else @click="enableMod(mod)" class='card-footer-item' >
+        <a v-else-if="canBeDisabled && !mod.isEnabled()" @click="enableMod(mod)" class='card-footer-item' >
             Enable
         </a>
 

--- a/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
+++ b/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
@@ -212,3 +212,14 @@ const VARIANTS = {
 // Casting is done here to ensure the values are ModLoaderPackageMapping[]
 export type GAME_NAME = keyof typeof VARIANTS;
 export const MOD_LOADER_VARIANTS: {[key in GAME_NAME]: ModLoaderPackageMapping[]} = VARIANTS;
+
+export function getModLoaderPackageNames() {
+    const names = MODLOADER_PACKAGES.map((mapping) => mapping.packageName);
+
+    // Hard code MelonLoader to avoid having to iterate over MODLOADER_PACKAGES
+    // for each game separately. Hopefully we'll get rid of this once ML v0.6.6
+    // is released, as it's supposed to fix a bug that forces some games to
+    // currently use the older versions.
+    names.push("LavaGang-MelonLoader");
+    return names;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,7 @@ import { FolderMigration } from '../migrations/FolderMigration';
 import Game from '../model/game/Game';
 import GameManager from '../model/game/GameManager';
 import R2Error from '../model/errors/R2Error';
+import { getModLoaderPackageNames } from '../r2mm/installing/profile_installers/ModLoaderVariantRecord';
 import ManagerSettings from '../r2mm/manager/ManagerSettings';
 
 Vue.use(Vuex);
@@ -18,6 +19,7 @@ Vue.use(Vuex);
 export interface State {
     activeGame: Game;
     isMigrationChecked: boolean;
+    modLoaderPackageNames: string[];
     _settings: ManagerSettings | null;
 }
 
@@ -32,6 +34,7 @@ export const store = {
     state: {
         activeGame: GameManager.defaultGame,
         isMigrationChecked: false,
+        modLoaderPackageNames: [],
 
         // Access through getters to ensure the settings are loaded.
         _settings: null,
@@ -87,9 +90,19 @@ export const store = {
         },
         setSettings(state: State, settings: ManagerSettings) {
             state._settings = settings;
+        },
+        updateModLoaderPackageNames(state: State) {
+            // The list is static and doesn't change during runtime.
+            if (!state.modLoaderPackageNames.length) {
+                state.modLoaderPackageNames = getModLoaderPackageNames();
+            }
         }
     },
     getters: {
+        isModLoader: (state: State) => (packageName: string): boolean => {
+            return state.modLoaderPackageNames.includes(packageName);
+        },
+
         settings(state: State): ManagerSettings {
             if (state._settings === null) {
                 throw new R2Error(


### PR DESCRIPTION
Before the changes, mod loaders could be disabled, but in most cases it didn't really do anything. Disabling e.g. BepInEx and running the game modded still loaded the mods.

Defining how each mod loader should be actually disabled isn't trivial, and the need to actually disable them is low, as user can always just choose to run the vanilla game. Therefore it was decided that just hiding the disable option for package loaders was the best approach.

This adds 0-0.1ms rendering delay for each mod. While not ideal, it doesn't affect even the bigger profiles too badly.