### PR TITLE
MelonLoader Improvements

### DIFF
--- a/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
+++ b/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
@@ -124,7 +124,7 @@ const VARIANTS = {
     Aloft: MODLOADER_PACKAGES,
     COTL: MODLOADER_PACKAGES,
     ChronoArk: MODLOADER_PACKAGES,
-    BONELAB: [new ModLoaderPackageMapping("LavaGang-MelonLoader", "", PackageLoader.MELON_LOADER, new VersionNumber("0.5.7"))],
+    BONELAB: [new ModLoaderPackageMapping("LavaGang-MelonLoader", "", PackageLoader.MELON_LOADER)],
     TromboneChamp: MODLOADER_PACKAGES,
     RogueGenesia: MODLOADER_PACKAGES,
     AcrossTheObelisk: MODLOADER_PACKAGES,

--- a/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
@@ -14,7 +14,6 @@ export default class MelonLoaderGameInstructions extends GameInstructionGenerato
         const mlZeroPointSixAssemblyExists = await FsProvider.instance.exists(profile.joinToProfilePath('MelonLoader', 'Il2CppAssemblies', 'Assembly-CSharp.dll'));
 
         if (!mlZeroPointFiveAssemblyExists && !mlZeroPointSixAssemblyExists) {
-            console.log('Regenerating AGF');
             moddedParameters += ' --melonloader.agfregenerate';
         }
         return {

--- a/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/MelonLoaderGameInstructions.ts
@@ -9,9 +9,13 @@ export default class MelonLoaderGameInstructions extends GameInstructionGenerato
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
         let moddedParameters = `--melonloader.basedir "${DynamicGameInstruction.PROFILE_DIRECTORY}"`;
-        if (!await FsProvider.instance.exists(profile.joinToProfilePath('MelonLoader', 'Managed', 'Assembly-CSharp.dll'))) {
-            console.log("Regenerating AGF")
-           moddedParameters += " --melonloader.agfregenerate"
+
+        const mlZeroPointFiveAssemblyExists = await FsProvider.instance.exists(profile.joinToProfilePath('MelonLoader', 'Managed', 'Assembly-CSharp.dll'));
+        const mlZeroPointSixAssemblyExists = await FsProvider.instance.exists(profile.joinToProfilePath('MelonLoader', 'Il2CppAssemblies', 'Assembly-CSharp.dll'));
+
+        if (!mlZeroPointFiveAssemblyExists && !mlZeroPointSixAssemblyExists) {
+            console.log('Regenerating AGF');
+            moddedParameters += ' --melonloader.agfregenerate';
         }
         return {
             moddedParameters: moddedParameters,


### PR DESCRIPTION
This PR fixes how we handle MelonLoader to prevent always passing `--agfregenerate` on MelonLoader 0.6.x.
Additionally we remove the "recommended" version for BONELAB as that should always be using the latest 0.6.x.

This functionality is pending a release of MelonLoader 0.6.6 (the next version) to work correctly. Once this has been released, we should expect to see correct behaviour with MelonLoader and BONELAB.