### PR TITLE
Reduce time spent on the splash screen

### DIFF
--- a/src/pages/Splash.vue
+++ b/src/pages/Splash.vue
@@ -5,7 +5,6 @@
             <p>Game updates may break mods. If a new update has been released, please be patient.</p>
         </div>
         <progress-bar
-            v-if="!isOffline"
             :max='requests.length * 100'
             :value='reduceRequests().getProgress() > 0 ? reduceRequests().getProgress() : undefined'
             :className='[reduceRequests().getProgress() > 0 ? "is-info" : ""]' />
@@ -25,16 +24,6 @@
                 </aside>
             </div>
             <div class='column is-three-quarters'>
-                <div class='container'>
-                    <br />
-                    <nav class='level' v-if='isOffline'>
-                        <div class='level-item'>
-                            <a class='button is-info margin-right margin-right--half-width' @click='continueOffline()'>Continue offline</a>
-                            <a class='button' @click='retryConnection()'>Try to reconnect</a>
-                        </div>
-                        <br /><br />
-                    </nav>
-                </div>
                 <div>
                     <article class='media'>
                         <div class='media-content'>
@@ -195,12 +184,6 @@ export default class Splash extends mixins(SplashMixin) {
             return;
         }
         this.$router.push({name: 'profiles'});
-    }
-
-    retryConnection() {
-        this.resetRequestProgresses();
-        this.isOffline = false;
-        this.checkForUpdates();
     }
 
     private async ensureWrapperInGameFolder() {

--- a/src/store/modules/TsModsModule.ts
+++ b/src/store/modules/TsModsModule.ts
@@ -212,6 +212,11 @@ export const TsModsModule = {
             return chunks;
         },
 
+        async gameHasCachedModList({rootState}): Promise<boolean> {
+            const updated = await PackageDb.getLastPackageListUpdateTime(rootState.activeGame.internalFolderName);
+            return updated !== undefined;
+        },
+
         async prewarmCache({getters, rootGetters}) {
             const profileMods: ManifestV2[] = rootGetters['profile/modList'];
             profileMods.forEach(getters['cachedMod']);


### PR DESCRIPTION
Users may want to get to the manager screen quickly so they can just launch the game with existing mods. Having to wait for the latest mod list update can be frustrating.

Splash screen now only checks the API for a fresh list if no local cache is found at all. Handling different error scenarios is also omitted, and user is moved to profile selection screen even if no mod list can be loaded. Error screen offering a chance to retry loading the mod list is dropped. The idea is that the background update or a manually triggered mod list update will handle the mod list eventually.

Note that the changes only affect the splash screen. Background updates still work the same way they did before.

In the future the splash screen can be hastened even further e.g. by handling the loading of the exclusion list in the background and reducing the timeouts/retry attempts of the API calls.