### PR TITLE
Fix directory name for Gladio Mori

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -659,7 +659,7 @@ export default class GameManager {
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["act"]),
 
         new Game("Gladio Mori", "GladioMori", "GladioMori",
-            "Gladio Mori Demo", ["Gladio Mori.exe"], "Gladio Mori_Data",
+            "Gladio Mori", ["Gladio Mori.exe"], "Gladio Mori_Data",
             "https://thunderstore.io/c/gladio-mori/api/v1/package-listing-index/", EXCLUSIONS,
             [new StorePlatformMetadata(StorePlatform.STEAM, "2908480")], "GladioMori.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["gm"]),


### PR DESCRIPTION
Gladio Mori is releasing on [November 26th](https://store.steampowered.com/app/2689120/Gladio_Mori/) and the demo app has been [delisted/made unplayable.](https://store.steampowered.com/news/app/2689120/view/4453592104064518366?l=english)

The actual game app's directory name is `Gladio Mori`, not `Gladio Mori Demo`. There are no other changes to be made.