### PR TITLE
Clean up the download state management Vuex store and it's usages

### DIFF
--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -155,7 +155,7 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                         this.$store.commit('download/updateDownload', {assignId, progress, modName});
                     }
                 } catch (e) {
-                    this.$store.commit('error/handleError', e);
+                    this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
                 }
             }, async (downloadedMods) => {
                 await this.downloadCompletedCallback(downloadedMods);
@@ -186,7 +186,7 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                             this.$store.commit('download/updateDownload', {assignId, progress, modName});
                         }
                     } catch (e) {
-                        this.$store.commit('error/handleError', e);
+                        this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
                     }
                 }, async (downloadedMods) => {
                     await this.downloadCompletedCallback(downloadedMods);

--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -105,9 +105,7 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                                 store.commit('download/updateDownload', {assignId, progress, modName});
                             }
                         } catch (e) {
-                            if (e instanceof R2Error) {
-                                store.commit('error/handleError', e);
-                            }
+                            return reject(e);
                         }
                     }, async (downloadedMods: ThunderstoreCombo[]) => {
                         ProfileModList.requestLock(async () => {
@@ -151,15 +149,13 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                         this.$store.commit('download/updateDownload', {assignId, failed: true});
                         if (err !== null) {
                             DownloadModModal.addSolutionsToError(err);
-                            this.$store.commit('error/handleError', err);
+                            throw err;
                         }
                     } else if (status === StatusEnum.PENDING) {
                         this.$store.commit('download/updateDownload', {assignId, progress, modName});
                     }
                 } catch (e) {
-                    if (e instanceof R2Error) {
-                        this.$store.commit('error/handleError', e);
-                    }
+                    this.$store.commit('error/handleError', e);
                 }
             }, async (downloadedMods) => {
                 await this.downloadCompletedCallback(downloadedMods);
@@ -184,15 +180,13 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                             this.$store.commit('download/updateDownload', {assignId, failed: true});
                             if (err !== null) {
                                 DownloadModModal.addSolutionsToError(err);
-                                this.$store.commit('error/handleError', err);
+                                throw err;
                             }
                         } else if (status === StatusEnum.PENDING) {
                             this.$store.commit('download/updateDownload', {assignId, progress, modName});
                         }
                     } catch (e) {
-                        if (e instanceof R2Error) {
-                            this.$store.commit('error/handleError', e);
-                        }
+                        this.$store.commit('error/handleError', e);
                     }
                 }, async (downloadedMods) => {
                     await this.downloadCompletedCallback(downloadedMods);

--- a/src/pages/DownloadMonitor.vue
+++ b/src/pages/DownloadMonitor.vue
@@ -13,7 +13,7 @@
             </div>
         </template>
         <template v-else>
-            <div v-for="([assignId, downloadObject], index) of activeDownloads" :key="`download-progress-${index}`">
+            <div v-for="(downloadObject, index) of activeDownloads" :key="`download-progress-${index}`">
                 <div>
                     <div class="container margin-right">
                         <div class="border-at-bottom pad pad--sides">
@@ -42,10 +42,12 @@
 
 <script lang="ts">
 
+import Timeout = NodeJS.Timeout;
 import { Component, Vue } from 'vue-property-decorator';
+
 import { Hero } from '../components/all';
 import Progress from '../components/Progress.vue';
-import Timeout = NodeJS.Timeout;
+import { DownloadProgress } from "../store/modules/DownloadModule";
 
 @Component({
     components: {
@@ -55,12 +57,12 @@ import Timeout = NodeJS.Timeout;
 })
 export default class DownloadMonitor extends Vue {
     private refreshInterval!: Timeout;
-    private activeDownloads: [number, any][] = [];
+    private activeDownloads: DownloadProgress[] = [];
 
     created() {
-        this.activeDownloads = [...this.$store.state.download.allVersions].reverse();
+        this.activeDownloads = [...this.$store.state.download.allDownloads].reverse();
         this.refreshInterval = setInterval(() => {
-            this.activeDownloads = [...this.$store.state.download.allVersions].reverse();
+            this.activeDownloads = [...this.$store.state.download.allDownloads].reverse();
         }, 100);
     }
 

--- a/src/store/modules/DownloadModule.ts
+++ b/src/store/modules/DownloadModule.ts
@@ -62,13 +62,30 @@ export const DownloadModule = {
     mutations: {
         updateDownload(state: State, update: UpdateObject) {
             const newDownloads = [...state.allDownloads];
-            if (newDownloads[update.assignId].assignId !== update.assignId) {
-                throw new R2Error(
+            const index = newDownloads.findIndex((old: DownloadProgress) => {
+                return old.assignId === update.assignId;
+            });
+
+            if (index === -1) {
+                // The DownloadProgress by the ID from the update wasn't found at all.
+                const err = new R2Error(
                     'Failed to update download status.',
-                    `DownloadProgress with id of ${update.assignId} didn't have the correct assignId.`,
+                    `DownloadProgress with assign id of ${update.assignId} wasn't found.`,
                     'Try initiating the download again or restarting the app.'
                 );
+                // Only throw if the download failed, otherwise just console.log() it.
+                if (update.failed) {
+                    throw err;
+                }
+                console.warn(err);
+                return;
             }
+
+            if (index !== update.assignId) {
+                // Just as a bonus, log if the DownloadProgress by the ID was located at the corresponding index of the array.
+                console.log(`There was a mismatch between download update\'s assign ID (${update.assignId}) and the index it was found at (${index}).`);
+            }
+
             newDownloads[update.assignId] = {...newDownloads[update.assignId], ...update};
             state.allDownloads = newDownloads;
         },

--- a/src/store/modules/DownloadModule.ts
+++ b/src/store/modules/DownloadModule.ts
@@ -68,10 +68,9 @@ export const DownloadModule = {
                     `DownloadProgress with id of ${update.assignId} didn't have the correct assignId.`,
                     'Try initiating the download again or restarting the app.'
                 );
-            } else {
-                newDownloads[update.assignId] = {...newDownloads[update.assignId], ...update};
-                state.allDownloads = newDownloads;
             }
+            newDownloads[update.assignId] = {...newDownloads[update.assignId], ...update};
+            state.allDownloads = newDownloads;
         },
     },
 }


### PR DESCRIPTION
- Remove assignId field
- Remove downloadObject field
- Rename some fields and functions to be more descriptive
- assignId is no longer passed unnecessarily when calling vuex store functions