### PR TITLE
Add setting for resetting online mod list stored in IndexedDB

### DIFF
--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -187,6 +187,14 @@ import CdnProvider from '../../providers/generic/connection/CdnProvider';
             ),
             new SettingsRow(
                 'Debugging',
+                'Clean online mod list',
+                'Deletes local copy of mod list, forcing the next refresh to fetch a new one.',
+                async () => this.$store.dispatch('tsMods/getActiveGameCacheStatus'),
+                'fa-trash',
+                () => this.$store.dispatch('tsMods/resetActiveGameCache')
+            ),
+            new SettingsRow(
+                'Debugging',
                 'Toggle preferred Thunderstore CDN',
                 'Switch the CDN until app is restarted. This might bypass issues with downloading mods.',
                 async () => `Current: ${CdnProvider.current.label} (${CdnProvider.current.url})`,


### PR DESCRIPTION
This debug option can be used if the mod list stored in IndexedDB is corrupted, preventing it from being loaded into Vuex. Otherwise user would have to wait for a new version of the mod list to be available on Thunderstore API and hoping the update fixes the issue.