### PR TITLE
Make package list processing more serial

### DIFF
--- a/src/components/ModListUpdateBanner.vue
+++ b/src/components/ModListUpdateBanner.vue
@@ -16,7 +16,7 @@ export default class ModListUpdateBanner extends Vue {
     }
 
     async updateModList() {
-        await this.$store.dispatch('tsMods/fetchAndProcessPackageList');
+        await this.$store.dispatch('tsMods/syncPackageList');
     }
 }
 </script>

--- a/src/components/mixins/SplashMixin.vue
+++ b/src/components/mixins/SplashMixin.vue
@@ -107,7 +107,7 @@ export default class SplashMixin extends Vue {
 
         try {
             return await this.$store.dispatch(
-                'tsMods/fetchPackageListChunks',
+                'tsMods/fetchAndCachePackageListChunks',
                 {packageListIndex, progressCallback}
             );
         } catch (e) {
@@ -135,7 +135,7 @@ export default class SplashMixin extends Vue {
         this.loadingText = 'Pruning removed mods from local cache';
 
         try {
-            await this.$store.dispatch('tsMods/pruneRemovedMods', packageListIndex.dateFetched);
+            await this.$store.dispatch('tsMods/pruneRemovedModsFromCache', packageListIndex.dateFetched);
         } catch (e) {
             console.error('SplashMixin failed to delete outdated mods from local cache.', e);
         }

--- a/src/components/mixins/UtilityMixin.vue
+++ b/src/components/mixins/UtilityMixin.vue
@@ -32,7 +32,7 @@ export default class UtilityMixin extends Vue {
             return;
         }
 
-        await this.$store.dispatch("tsMods/fetchAndProcessPackageList");
+        await this.$store.dispatch("tsMods/syncPackageList");
 
         if (this.$store.state.tsMods.thunderstoreModListUpdateError.length > 0) {
             if (this.tsBackgroundRefreshFailed) {

--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -339,11 +339,11 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
                     <span v-else-if="$store.state.tsMods.thunderstoreModListUpdateError">
                         Error updating the mod list:
                         {{ $store.state.tsMods.thunderstoreModListUpdateError }}.
-                        <a @click="$store.dispatch('tsMods/fetchAndProcessPackageList')">Retry</a>?
+                        <a @click="$store.dispatch('tsMods/syncPackageList')">Retry</a>?
                     </span>
                     <span v-else>
                         Would you like to
-                        <a @click="$store.dispatch('tsMods/fetchAndProcessPackageList')">update now</a>?
+                        <a @click="$store.dispatch('tsMods/syncPackageList')">update now</a>?
                     </span>
                 </p>
             </div>

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -310,7 +310,7 @@ import CdnProvider from '../../providers/generic/connection/CdnProvider';
                         return "No API information available";
                     },
                 'fa-exchange-alt',
-                async () => await this.$store.dispatch("tsMods/fetchAndProcessPackageList")
+                async () => await this.$store.dispatch("tsMods/syncPackageList")
             ),
             new SettingsRow(
               'Other',

--- a/src/model/ThunderstoreMod.ts
+++ b/src/model/ThunderstoreMod.ts
@@ -14,6 +14,22 @@ export default class ThunderstoreMod extends ThunderstoreVersion {
     private donationLink: string | undefined;
     private latestVersion: string = '';
 
+    // Imitate the order where mods are returned from Thunderstore package listing API.
+    public static defaultOrderComparer(a: ThunderstoreMod, b: ThunderstoreMod): number {
+        // Pinned mods first.
+        if (a.isPinned() !== b.isPinned()) {
+            return a.isPinned() ? -1 : 1;
+        }
+
+        // Deprecated mods last.
+        if (a.isDeprecated() !== b.isDeprecated()) {
+            return a.isDeprecated() ? 1 : -1;
+        }
+
+        // Sort mods with same boolean flags by update date.
+        return a.getDateUpdated() >= b.getDateUpdated() ? -1 : 1;
+    }
+
     public static parseFromThunderstoreData(data: any): ThunderstoreMod {
         const mod = new ThunderstoreMod();
         mod.setName(data.name);

--- a/src/pages/Splash.vue
+++ b/src/pages/Splash.vue
@@ -148,8 +148,9 @@ export default class Splash extends mixins(SplashMixin) {
 
     requests = [
         new RequestItem('UpdateCheck', 0),
-        new RequestItem('ThunderstoreDownload', 0),
-        new RequestItem('CacheOperations', 0)
+        new RequestItem('PackageListIndex', 0),
+        new RequestItem('PackageListChunks', 0),
+        new RequestItem('Vuex', 0)
     ];
 
     // Ensure that r2modman isn't outdated.

--- a/src/r2mm/manager/PackageDexieStore.ts
+++ b/src/r2mm/manager/PackageDexieStore.ts
@@ -41,7 +41,6 @@ interface DexiePackage {
     // Extra fields not included in the API response
     community: string;
     date_fetched: Date; // When the entry was fetched from the API
-    default_order: number; // Entry's index when received from the API
 }
 
 // For keeping track of seen package list index files so we can
@@ -70,53 +69,10 @@ class PackageDexieStore extends Dexie {
 
 const db = new PackageDexieStore();
 
-// TODO: user type guards to validate (part of) the data before operations?
-export async function updateFromApiResponse(community: string, packageChunks: any[][]) {
-    let default_order = 0;
-    const extra = {community, date_fetched: new Date()};
-    const newPackageChunks: DexiePackage[][] = packageChunks.map((chunk) =>
-        chunk.map((pkg) => ({
-            ...pkg,
-            ...extra,
-            default_order: default_order++
-        }))
-    );
-
-    // Since we need to do these operations in a single transaction we can't
-    // process the chunks one by one as they are downloaded.
-    await db.transaction(
-        'rw',
-        db.packages,
-        async () => {
-            // UPSERT with fresh data from API.
-            // Fetching ids for community's packages and deleting them all using
-            // .bulkDelete would be a bit faster on small package lists due to
-            // .bulkAdd (INSERT) being faster than .bulkPut (UPSERT). It starts
-            // to lose its advantage when the package list grows since fetching
-            // the ids and calling .bulkDelete gets slower. We should optimize
-            // for big lists since the small ones are fast enough anyway, and
-            // this approach also works better with the plans to use pagination
-            // when fetching the package list in the future.
-            await Promise.all(
-                newPackageChunks.map((chunk) => db.packages.bulkPut(chunk))
-            );
-
-            // Find packages that were no longer returned by the API and delete them.
-            // .bulkDelete is faster than calling .delete() on the Collection
-            // directly. Using the odd looking .where(compoundIndex).between(values)
-            // is faster than .where(community).and(filterByDateFetched).
-            const oldIds = await db.packages
-                .where('[community+date_fetched]')
-                .between([community, 0], [community, extra.date_fetched])
-                .primaryKeys();
-            await db.packages.bulkDelete(oldIds);
-        }
-    );
-}
-
 export async function getPackagesAsThunderstoreMods(community: string) {
-    const packages = await db.packages.where({community}).sortBy('default_order');
-    return packages.map(ThunderstoreMod.parseFromThunderstoreData);
+    const packages = await db.packages.where({community}).toArray();
+    return packages.map(ThunderstoreMod.parseFromThunderstoreData)
+                   .sort(ThunderstoreMod.defaultOrderComparer);
 }
 
 export async function getPackagesByNames(community: string, packageNames: string[]) {
@@ -189,6 +145,24 @@ export async function isLatestPackageListIndex(community: string, hash: string) 
     return Boolean(
         await db.indexHashes.where({community, hash}).count()
     );
+}
+
+export async function pruneRemovedMods(community: string, cutoff: Date) {
+    // Find packages that were no longer returned by the API and delete them.
+    // .bulkDelete is faster than calling .delete() on the Collection
+    // directly. Using the odd looking .where(compoundIndex).between(values)
+    // is faster than .where(community).and(filterByDateFetched).
+    const oldIds = await db.packages
+        .where('[community+date_fetched]')
+        .between([community, 0], [community, cutoff])
+        .primaryKeys();
+    await db.packages.bulkDelete(oldIds);
+}
+
+export async function upsertPackageListChunk(community: string, packageChunk: any[]) {
+    const extra = {community, date_fetched: new Date()};
+    const newPackages: DexiePackage[] = packageChunk.map((pkg) => ({...pkg, ...extra}));
+    await db.packages.bulkPut(newPackages);
 }
 
 export async function setLatestPackageListIndex(community: string, hash: string) {

--- a/src/utils/HttpUtils.ts
+++ b/src/utils/HttpUtils.ts
@@ -109,12 +109,13 @@ export const makeLongRunningGetRequest = async (
  * all users and can be cached heavily on CDN level.
  */
 export const fetchAndProcessBlobFile = async (url: string) => {
+    const dateFetched = new Date();
     const response = await makeLongRunningGetRequest(url, {axiosConfig: {responseType: 'arraybuffer'}});
     const buffer = Buffer.from(response.data);
     const hash = await getSha256Hash(buffer);
     const jsonString = await decompressArrayBuffer(buffer);
     const content = JSON.parse(jsonString);
-    return {content, hash};
+    return {content, hash, dateFetched};
 }
 
 async function getSha256Hash(arrayBuffer: ArrayBuffer): Promise<string> {


### PR DESCRIPTION
- Old implementation first downloaded all chunks and only then stored
  them into IndexedDB. The new implementation downloads a chunk and
  stores it before downloading the next chunk. This will hopefully
  reduce memory usage and IndexedDB related errors.
- Packages are upserted into IndexedDB and failures are silently
  ignored. This means the package list may be in inconsistent state
  where some of the packages are updated based on most recent API
  response while others aren't.
- Packages no longer present in the API response are removed from
  IndexedDB only if all chunks were processed successfully.
- Since the state consistency is no longer guaranteed, we can't depend
  on the order of packages in the API response as the default ordering.
  Instead, packages are ordered when loaded from IndexedDB using the
  same rules the API currently uses to sort the packages.
  - Consequently the default_order field could be dropped from the DB.
- As the progress indicator steps on splash screen didn't make sense
  anymore after the changes, there are now three steps: checking for
  updates, downloading & storing the chunks, and loading the mods into
  Vuex. First of these steps is quicker than the others for larger
  communities, which skews the overall progress, but the percentage
  wasn't really bound to remaining time earlier either.
- Unify action names in TsModModule Vuex store