### PR TITLE
Turn off autocomplete for text inputs

### DIFF
--- a/src/components/config-components/ConfigEditLayout.vue
+++ b/src/components/config-components/ConfigEditLayout.vue
@@ -54,7 +54,13 @@
                                     </option>
                                 </select>
                             </template>
-                            <input class="input" v-model="line.value" v-else/>
+                            <input
+                                v-else
+                                v-model="line.value"
+                                :id="`${key.toString().replace(/\s+/g, '-')}-${variable.toString().replace(/\s+/g, '-')}`"
+                                class="input"
+                                autocomplete="off"
+                            />
                         </div>
                     </div>
                 </div>

--- a/src/components/config-components/ConfigSelectionLayout.vue
+++ b/src/components/config-components/ConfigSelectionLayout.vue
@@ -16,8 +16,15 @@
             <div class='no-padding-left card-header-title'>
 
                 <div class="input-group input-group--flex margin-right">
-                    <label for="local-search" class="non-selectable">Search</label>
-                    <input id="local-search" v-model='filterText' class="input margin-right" type="text" placeholder="Search for config files"/>
+                    <label for="config-search" class="non-selectable">Search</label>
+                    <input
+                        v-model="filterText"
+                        id="config-search"
+                        class="input margin-right"
+                        type="text"
+                        placeholder="Search for config files"
+                        autocomplete="off"
+                    />
                 </div>
 
                 <div class="input-group margin-right">

--- a/src/components/importing/LocalFileImportModal.vue
+++ b/src/components/importing/LocalFileImportModal.vue
@@ -27,17 +27,41 @@
                 </div>
                 <div class="input-group input-group--flex margin-right">
                     <label for="mod-name" class="non-selectable">Mod name</label>
-                    <input id="mod-name" ref="mod-name" class="input margin-right" type="text" v-model="modName" placeholder="Enter the name of the mod"/>
+                    <input
+                        v-model="modName"
+                        id="mod-name"
+                        class="input margin-right"
+                        ref="mod-name"
+                        type="text"
+                        placeholder="Enter the name of the mod"
+                        autocomplete="off"
+                    />
                 </div>
                 <br/>
                 <div class="input-group input-group--flex margin-right">
                     <label for="mod-author" class="non-selectable">Author</label>
-                    <input id="mod-author" ref="mod-author" class="input margin-right" type="text" v-model="modAuthor" placeholder="Enter the author name"/>
+                    <input
+                        v-model="modAuthor"
+                        id="mod-author"
+                        class="input margin-right"
+                        ref="mod-author"
+                        type="text"
+                        placeholder="Enter the author name"
+                        autocomplete="off"
+                    />
                 </div>
                 <br/>
                 <div class="input-group input-group--flex margin-right">
                     <label for="mod-author" class="non-selectable">Description (optional)</label>
-                    <input id="mod-description" ref="mod-description" class="input margin-right" type="text" v-model="modDescription" placeholder="Enter a description"/>
+                    <input
+                        v-model="modDescription"
+                        id="mod-description"
+                        class="input margin-right"
+                        ref="mod-description"
+                        type="text"
+                        placeholder="Enter a description"
+                        autocomplete="off"
+                    />
                 </div>
                 <hr/>
                 <h3 class="title is-6">Version</h3>

--- a/src/components/profiles-modals/CreateProfileModal.vue
+++ b/src/components/profiles-modals/CreateProfileModal.vue
@@ -54,11 +54,12 @@ export default class CreateProfileModal extends ProfilesMixin {
             <p>This profile will store its own mods independently from other profiles.</p>
             <br/>
             <input
-                class="input"
                 v-model="newProfileName"
                 @keyup.enter="!doesProfileExist(newProfileName) && createProfile()"
                 id="create-profile-modal-new-profile-name"
+                class="input"
                 ref="nameInput"
+                autocomplete="off"
             />
             <br/><br/>
             <span class="tag is-dark" v-if="newProfileName === '' || makeProfileNameSafe(newProfileName) === ''">

--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -276,11 +276,13 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
         </template>
         <template v-slot:body>
             <input
-                type="text"
-                class="input"
                 v-model="profileImportCode"
-                ref="profileCodeInput"
                 @keyup.enter="isProfileCodeValid(profileImportCode) && onProfileCodeEntered()"
+                id="import-profile-modal-profile-code"
+                class="input"
+                type="text"
+                ref="profileCodeInput"
+                autocomplete="off"
             />
             <br />
             <br />
@@ -354,7 +356,14 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
         <template v-slot:body v-if="importUpdateSelection === 'CREATE'">
             <p>This profile will store its own mods independently from other profiles.</p>
             <br/>
-            <input class="input" v-model="targetProfileName" ref="profileNameInput" />
+            <input
+                v-model="targetProfileName"
+                id="import-profile-modal-new-profile-name"
+                class="input"
+                type="text"
+                ref="profileNameInput"
+                autocomplete="off"
+            />
             <br/><br/>
             <span class="tag is-dark" v-if="makeProfileNameSafe(targetProfileName) === ''">
                 Profile name required

--- a/src/components/profiles-modals/RenameProfileModal.vue
+++ b/src/components/profiles-modals/RenameProfileModal.vue
@@ -73,10 +73,12 @@ export default class RenameProfileModal extends ProfilesMixin {
             <p>This profile will store its own mods independently from other profiles.</p>
 
             <input
-                class="input"
                 v-model="newProfileName"
                 @keyup.enter="!doesProfileExist(newProfileName) && performRename()"
+                id="rename-profile-modal-new-profile-name"
+                class="input"
                 ref="nameInput"
+                autocomplete="off"
             />
 
             <span class="tag is-dark" v-if="newProfileName === '' || makeProfileNameSafe(newProfileName) === ''">

--- a/src/components/views/LocalModList/SearchAndSort.vue
+++ b/src/components/views/LocalModList/SearchAndSort.vue
@@ -67,13 +67,14 @@ export default class SearchAndSort extends Vue {
             <div class="no-padding-left card-header-title">
 
                 <div class="input-group input-group--flex margin-right">
-                    <label for="local-search" class="non-selectable">Search</label>
+                    <label for="installed-search" class="non-selectable">Search</label>
                     <DeferredInput
                         v-model="search"
-                        id="local-search"
+                        id="installed-search"
                         class="input margin-right"
                         type="text"
                         placeholder="Search for an installed mod"
+                        autocomplete="off"
                     />
                 </div>
 

--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -4,13 +4,14 @@
             <div class="is-shadowless is-square">
                 <div class="no-padding-left card-header-title">
                     <div class="input-group input-group--flex margin-right">
-                        <label for="thunderstore-search-filter">Search</label>
+                        <label for="online-search">Search</label>
                         <DeferredInput
                             v-model="thunderstoreSearchFilter"
-                            id="thunderstore-search-filter"
+                            id="online-search"
                             class="input"
                             type="text"
                             placeholder="Search for a mod"
+                            autocomplete="off"
                         />
                     </div>
                     <div class="input-group margin-right">

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -41,7 +41,14 @@
                             <div class="level-item">
                                 <div class="card-header-title">
                                     <div class="input-group input-group--flex margin-right">
-                                        <input id="local-search" v-model='filterText' class="input margin-right" type="text" placeholder="Search for a game"/>
+                                        <input
+                                            v-model="filterText"
+                                            id="game-selection-list-search"
+                                            class="input margin-right"
+                                            type="text"
+                                            placeholder="Search for a game"
+                                            autocomplete="off"
+                                        />
                                     </div>
                                 </div>
                             </div>
@@ -62,7 +69,14 @@
                             <div class="level-item">
                                 <div class="card-header-title">
                                     <div class="input-group input-group--flex margin-right">
-                                        <input id="local-search" v-model='filterText' class="input margin-right" type="text" placeholder="Search for a game"/>
+                                        <input
+                                            v-model="filterText"
+                                            id="game-selection-cards-search"
+                                            class="input margin-right"
+                                            type="text"
+                                            placeholder="Search for a game"
+                                            autocomplete="off"
+                                        />
                                     </div>
                                 </div>
                             </div>

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -107,7 +107,13 @@
 						entering custom launch parameters.</strong>
 				</p>
 				<br/>
-				<input class='input' v-model='launchParametersModel' placeholder='Enter parameters'/>
+				<input
+					v-model='launchParametersModel'
+					id='launch-parameters-modal-input'
+					class='input'
+					placeholder='Enter parameters'
+					autocomplete='off'
+				/>
 			</template>
 			<template v-slot:footer>
 				<button class='button is-info' @click='updateLaunchParameters()'>


### PR DESCRIPTION
TSMM updates to use Chrome v131, which causes awkward autocomplete popups to be shown for text inputs. This seemed to affect only inputs with ids, but not all of them. To avoid regressions if ids would be added later, they were added now, paired with the autocomplete="off" attribute. As an additional benefit, this makes it easier to interpret errors TSMM logs into Sentry.