### PR TITLE
Remove MSStore from Bomb Rush Cyberfunk

### DIFF
--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -494,7 +494,6 @@ export default class GameManager {
             "https://thunderstore.io/c/bomb-rush-cyberfunk/api/v1/package-listing-index/", EXCLUSIONS,
             [
                 new StorePlatformMetadata(StorePlatform.STEAM, "1353230"),
-                new StorePlatformMetadata(StorePlatform.XBOX_GAME_PASS, "TeamReptile.BombRushCyberfunk"),
                 new StorePlatformMetadata(StorePlatform.OTHER)
             ], "BombRushCyberfunk.jpg", GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, ["brc"]),
 


### PR DESCRIPTION
Effectively reverts #1259

At the time, nobody with the technical ability to verify if it would work had the MS Store copy, so we enabled it.  Since then, someone was able to get the MS Store version and verify that it is IL2CPP, so is incompatible with all our modding.  So now we know the MSStore / GamePass option should be removed from r2modman.