### PR TITLE
Lock both source and destination files when copying or renaming files

### DIFF
--- a/src/providers/generic/file/NodeFs.ts
+++ b/src/providers/generic/file/NodeFs.ts
@@ -93,7 +93,7 @@ export default class NodeFs extends FsProvider {
 
     async rename(path: string, newPath: string): Promise<void> {
         return new Promise((resolve, reject) => {
-            NodeFs.lock.acquire(path, async () => {
+            NodeFs.lock.acquire([path, newPath], async () => {
                 try {
                     await fs.promises.rename(path, newPath);
                     resolve();
@@ -110,7 +110,7 @@ export default class NodeFs extends FsProvider {
 
     async copyFile(from: string, to: string): Promise<void> {
         return new Promise((resolve, reject) => {
-            NodeFs.lock.acquire(from, async () => {
+            NodeFs.lock.acquire([from, to], async () => {
                 try {
                     await fs.promises.copyFile(from, to);
                     resolve();


### PR DESCRIPTION
This seems to resolve a race condition issue where a disabled mod was imported as a part of a profile. Before the fix, renaming the file with ".old" extension when disabling the mod after copying it into profile caused an EBUSY error.