### PR TITLE
Fix crash issue on Linux for games using platform: other

### DIFF
--- a/src/pages/Splash.vue
+++ b/src/pages/Splash.vue
@@ -166,17 +166,26 @@ export default class Splash extends mixins(SplashMixin) {
     async moveToNextScreen() {
         if (process.platform === 'linux') {
             const activeGame: Game = this.$store.state.activeGame;
+            const gdrp : GameDirectoryResolverProvider = GameDirectoryResolverProvider.instance;
 
-            if (!await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).isProtonGame(activeGame)) {
-                console.log('Not proton game');
-                await this.ensureWrapperInGameFolder();
-                const launchArgs = await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).getLaunchArgs(activeGame);
-                console.log(`Launch arguments for this game:`, launchArgs);
-                if (typeof launchArgs === 'string' && !launchArgs.startsWith(path.join(PathResolver.MOD_ROOT, 'linux_wrapper.sh'))) {
-                    this.$router.push({name: 'linux'});
-                    return;
+            if (gdrp instanceof LinuxGameDirectoryResolver)
+            {
+                if (!await (gdrp as LinuxGameDirectoryResolver).isProtonGame(activeGame)) {
+                    console.log('Not proton game');
+                    await this.ensureWrapperInGameFolder();
+                    const launchArgs = await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).getLaunchArgs(activeGame);
+                    console.log(`Launch arguments for this game:`, launchArgs);
+                    if (typeof launchArgs === 'string' && !launchArgs.startsWith(path.join(PathResolver.MOD_ROOT, 'linux_wrapper.sh'))) {
+                        this.$router.push({name: 'linux'});
+                        return;
+                    }
                 }
             }
+            else
+            {
+                // no idea what we need to do
+            }
+
         } else if (process.platform === 'darwin') {
             await this.ensureWrapperInGameFolder();
             this.$router.push({name: 'linux'});


### PR DESCRIPTION
Disclaimer: I'm not a TypeScript main, but I think I've found a fix for the crash issue in the following reports: #1577, #1458.

Basically what's going on is that the moveToNextScreen() function assumes that if a game is on Linux, then the GameDirectoryResolver for it will have Linux-specific functions available (isProtonGame and getLaunchArgs), but this isn't the case for DRMFreeDirectoryResolver, which is what is used if the platform is set to OTHER. I've worked around this by simply bypassing whatever's happening in Splash.vue. This seems to let r2modman boot up okay, although I have no idea what this code is supposed to be doing, so I've set this to draft for now so someone can take a look at it.