### PR TITLE
Aloft fix

### DIFF
--- a/src/assets/data/games.json
+++ b/src/assets/data/games.json
@@ -203,7 +203,7 @@
       "distributions": [
         {
           "platform": "steam",
-          "identifier": "2051980"
+          "identifier": "1660080"
         }
       ],
       "r2modman": {

--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -301,7 +301,7 @@ export default class GameManager {
         new Game("Aloft", "Aloft", "Aloft",
             "Aloft Demo", ["Aloft.exe"], "Aloft_Data",
             "https://thunderstore.io/c/aloft/api/v1/package-listing-index/",
-            [new StorePlatformMetadata(StorePlatform.STEAM, "2051980")], "Aloft.png",
+            [new StorePlatformMetadata(StorePlatform.STEAM, "1660080")], "Aloft.png",
             GameSelectionDisplayMode.VISIBLE, GameInstanceType.GAME, PackageLoader.BEPINEX, []),
 
         new Game("Cult of the Lamb", "COTL", "COTL",


### PR DESCRIPTION
Use the correct Steam App ID for Aloft (the old one is for the demo)