### PR TITLE
Ensure manifest.json is present in all locally imported mods

### DIFF
--- a/src/r2mm/installing/LocalModInstaller.ts
+++ b/src/r2mm/installing/LocalModInstaller.ts
@@ -42,9 +42,32 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
         await FsProvider.instance.writeFile(manifestPath, JSON.stringify(manifest));
     }
 
+    /**
+     * Write Thunderstore compatible manifest.json to cache if one wasn't provided
+     * with the upload. This is done to have consistency between all installed
+     * mods, regardless of how they were installed. Having the manifest present
+     * allows e.g. other mods to sniff out what other mods are installed.
+     */
+    private async writeManifestToCache(cacheDirectory: string, manifest: ManifestV2) {
+        const manifestPath: string = path.join(cacheDirectory, 'manifest.json');
+
+        if (!(await FsProvider.instance.exists(manifestPath))) {
+            const content = {
+                'name': manifest.getDisplayName(),  // getName() returns "author-modname" here
+                'description': manifest.getDescription(),
+                'version_number': manifest.getVersionNumber().toString(),
+                'dependencies': manifest.getDependencies(),
+                'website_url': ''
+            };
+
+            await FsProvider.instance.writeFile(manifestPath, JSON.stringify(content, null, 4));
+        }
+    }
+
     public async extractToCacheWithManifestData(profile: ImmutableProfile, zipFile: string, manifest: ManifestV2) {
         const cacheDirectory: string = await this.initialiseCacheDirectory(manifest);
         await ZipExtract.extractOnly(zipFile, cacheDirectory);
+        await this.writeManifestToCache(cacheDirectory, manifest);
         await this.writeCustomManifestToCache(cacheDirectory, manifest);
         await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
         throwForR2Error(await ProfileInstallerProvider.instance.installMod(manifest, profile));
@@ -56,6 +79,7 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
             const cacheDirectory: string = await this.initialiseCacheDirectory(manifest);
             const fileSafe = file.split("\\").join("/");
             await FsProvider.instance.copyFile(fileSafe, path.join(cacheDirectory, path.basename(fileSafe)));
+            await this.writeManifestToCache(cacheDirectory, manifest);
             await this.writeCustomManifestToCache(cacheDirectory, manifest);
         } catch (e) {
             throw R2Error.fromThrownValue(e, "Error moving file to cache");

--- a/src/r2mm/installing/LocalModInstaller.ts
+++ b/src/r2mm/installing/LocalModInstaller.ts
@@ -28,7 +28,7 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
      * be used in troubleshooting, telling us that the version of the mod isn't
      * necessarily the same that's available via Thunderstore API.
      */
-    private async writeManifestToCache(cacheDirectory: string, manifest: ManifestV2) {
+    private async writeCustomManifestToCache(cacheDirectory: string, manifest: ManifestV2) {
         const manifestPath: string = path.join(cacheDirectory, 'mm_v2_manifest.json');
 
         if (await FsProvider.instance.exists(manifestPath)) {
@@ -45,7 +45,7 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
     public async extractToCacheWithManifestData(profile: ImmutableProfile, zipFile: string, manifest: ManifestV2) {
         const cacheDirectory: string = await this.initialiseCacheDirectory(manifest);
         await ZipExtract.extractOnly(zipFile, cacheDirectory);
-        await this.writeManifestToCache(cacheDirectory, manifest);
+        await this.writeCustomManifestToCache(cacheDirectory, manifest);
         await ProfileInstallerProvider.instance.uninstallMod(manifest, profile);
         throwForR2Error(await ProfileInstallerProvider.instance.installMod(manifest, profile));
         throwForR2Error(await ProfileModList.addMod(manifest, profile));
@@ -56,7 +56,7 @@ export default class LocalModInstaller extends LocalModInstallerProvider {
             const cacheDirectory: string = await this.initialiseCacheDirectory(manifest);
             const fileSafe = file.split("\\").join("/");
             await FsProvider.instance.copyFile(fileSafe, path.join(cacheDirectory, path.basename(fileSafe)));
-            await this.writeManifestToCache(cacheDirectory, manifest);
+            await this.writeCustomManifestToCache(cacheDirectory, manifest);
         } catch (e) {
             throw R2Error.fromThrownValue(e, "Error moving file to cache");
         }


### PR DESCRIPTION
Create a manifest.json file into cache folder if one wasn't provided by
the uploaded zip, or if a .dll file was uploaded. For consistency we
want all installed mods to have this file regardless of the
installation method.

Locally installed mods will still have the separate mm_v2_manifest.json
file so they can be told apart from the files downloaded from
Thunderstore.