### PR TITLE
Fix profile import silently leaving some mods uninstalled

### DIFF
--- a/src/model/ThunderstoreCombo.ts
+++ b/src/model/ThunderstoreCombo.ts
@@ -44,4 +44,7 @@ export default class ThunderstoreCombo {
         this.version = version;
     }
 
+    public getDependencyString(): string {
+        return `${this.mod.getFullName()}-${this.version.getVersionNumber().toString()}`;
+    }
 }

--- a/src/store/modules/TsModsModule.ts
+++ b/src/store/modules/TsModsModule.ts
@@ -1,7 +1,6 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex';
 
 import { State as RootState } from '../index';
-import ExportMod from '../../model/exports/ExportMod';
 import ManifestV2 from '../../model/ManifestV2';
 import ThunderstoreMod from '../../model/ThunderstoreMod';
 import VersionNumber from '../../model/VersionNumber';
@@ -81,7 +80,7 @@ export const TsModsModule = {
          *  time this happens slows down the LocalModList, cache the
          *  data in a Map.
          */
-        cachedMod: (state) => (mod: ExportMod|ManifestV2): CachedMod => {
+        cachedMod: (state) => (mod: ManifestV2): CachedMod => {
             const cacheKey = `${mod.getName()}-${mod.getVersionNumber()}`;
 
             if (state.cache.get(cacheKey) === undefined) {
@@ -119,7 +118,7 @@ export const TsModsModule = {
         },
 
         /*** Return ThunderstoreMod representation of a ManifestV2 */
-        tsMod: (_state, getters) => (mod: ExportMod|ManifestV2): ThunderstoreMod | undefined => {
+        tsMod: (_state, getters) => (mod: ManifestV2): ThunderstoreMod | undefined => {
             return getters.cachedMod(mod).tsMod;
         },
 


### PR DESCRIPTION
To reduce time spent on the splash screen, recent changes skip refreshing the online mod list if older version is found in IndexedDB cache. This means the user might have outdated mod list when importing a profile, and the manager can't import mods it doesn't know about. To mitigate the issue, a warning was added to profile preview step with an option for the user to update the mod list.

However, the warning uses the mod list in Vuex to check if a mod is available, which is a mistake since that only checks if the mod itself is known, and not whether the mod version in the profile is known. This caused recently updated mods to not always trigger the warning. The download part uses IndexedDB as its source of truth, and silently ignored the unknown mods/versions, since user has explicitly decided to import a partial profile.

To fix the issue, both parts now use IndexedDB as the source of truth.

The implementation in ImportProfileModal now somewhat akwardly handles the mod information as ExportMods (read from mods.yml and required to know which mods are disabled), ThunderstoreMods (required to use existing UI components), and ThunderstoreCombos (required to download a specific version of the mod). This could potentially be simplified but is outside the scope of this PR.

ExportMod support was dropped from TsModsModule functions to remove the footgun that caused this whole problem.