### PR TITLE
Remove default value definition to avoid causing rerendering

### DIFF
--- a/src/components/buttons/DonateIconButton.vue
+++ b/src/components/buttons/DonateIconButton.vue
@@ -23,7 +23,7 @@ export default class DonateIconButton extends Vue {
     mod: ThunderstoreMod | undefined;
 
     @Prop({default: true})
-    extraRenderCondition: boolean = true;
+    extraRenderCondition!: boolean;
 
 }
 


### PR DESCRIPTION
A warning was logged when the actual prop passed to the component overwrote the default value.