### PR TITLE
Fix state drift of ignoreCache setting

### DIFF
--- a/src/components/mixins/DownloadMixin.vue
+++ b/src/components/mixins/DownloadMixin.vue
@@ -33,11 +33,6 @@ export default class DownloadMixin extends Vue {
         return this.$store.state.modals.isDownloadModModalOpen;
     }
 
-    get ignoreCache(): boolean {
-        const settings = this.$store.getters['settings'];
-        return settings.getContext().global.ignoreCache;
-    }
-
     get thunderstoreMod(): ThunderstoreMod | null {
         return this.$store.state.modals.downloadModModalMod;
     }

--- a/src/components/profiles-modals/ImportProfileModal.vue
+++ b/src/components/profiles-modals/ImportProfileModal.vue
@@ -246,8 +246,7 @@ export default class ImportProfileModal extends mixins(ProfilesMixin) {
         const progressCallback = (progress: number|string) => typeof progress === "number"
             ? this.importPhaseDescription = `Downloading mods: ${Math.floor(progress)}%`
             : this.importPhaseDescription = progress;
-        const settings = this.$store.getters['settings'];
-        const ignoreCache = settings.getContext().global.ignoreCache;
+        const ignoreCache = this.$store.state.download.ignoreCache;
         const isUpdate = this.importUpdateSelection === 'UPDATE';
 
         try {

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -170,7 +170,7 @@ import CdnProvider from '../../providers/generic/connection/CdnProvider';
                 'Toggle download cache',
                 'Downloading a mod will ignore mods stored in the cache. Mods will still be placed in the cache.',
                 async () => {
-                    return this.settings.getContext().global.ignoreCache
+                    return this.$store.state.download.ignoreCache
                         ? 'Current: cache is disabled'
                         : 'Current: cache is enabled (recommended)';
                 },

--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -78,7 +78,6 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
         public static async downloadSpecific(
             profile: Profile,
             combo: ThunderstoreCombo,
-            ignoreCache: boolean,
             store: Store<any>
         ): Promise<void> {
             return new Promise(async (resolve, reject) => {
@@ -94,7 +93,7 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                         downloadedMods = await ThunderstoreDownloaderProvider.instance.download(
                             profile.asImmutableProfile(),
                             combo,
-                            ignoreCache,
+                            store.state.download.ignoreCache,
                             (downloadProgress: number, modName: string, status: number, err: R2Error | null) => {
                                 try {
                                     DownloadMixin.downloadProgressCallback(store, assignId, downloadProgress, modName, status, err);
@@ -150,7 +149,7 @@ import ProfileModList from '../../r2mm/mods/ProfileModList';
                     downloadedMods = await ThunderstoreDownloaderProvider.instance.download(
                         this.profile.asImmutableProfile(),
                         tsCombo,
-                        this.ignoreCache,
+                        this.$store.state.download.ignoreCache,
                         (downloadProgress, modName, status, err) => {
                             DownloadMixin.downloadProgressCallback(
                                 this.$store,

--- a/src/components/views/UpdateAllInstalledModsModal.vue
+++ b/src/components/views/UpdateAllInstalledModsModal.vue
@@ -48,8 +48,9 @@ export default class UpdateAllInstalledModsModal extends mixins(DownloadMixin)  
             modsWithUpdates.map(value => `${value.getMod().getName()} (${value.getVersion().getVersionNumber().toString()})`)
         );
 
+        const ignoreCache = this.$store.state.download.ignoreCache;
         this.setIsModProgressModalOpen(true);
-        ThunderstoreDownloaderProvider.instance.downloadLatestOfAll(modsWithUpdates, this.ignoreCache, (downloadProgress: number, modName: string, status: number, err: R2Error | null) => {
+        ThunderstoreDownloaderProvider.instance.downloadLatestOfAll(modsWithUpdates, ignoreCache, (downloadProgress: number, modName: string, status: number, err: R2Error | null) => {
             try {
                 if (status === StatusEnum.FAILURE) {
                     this.setIsModProgressModalOpen(false);

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -484,10 +484,6 @@ import ModalCard from '../components/ModalCard.vue';
 			this.showLaunchParameterModal = false;
 		}
 
-		toggleIgnoreCache() {
-			this.settings.setIgnoreCache(!this.settings.getContext().global.ignoreCache);
-		}
-
 		async copyLogToClipboard() {
             const fs = FsProvider.instance;
             let logOutputPath = "";
@@ -560,7 +556,7 @@ import ModalCard from '../components/ModalCard.vue';
                     this.copyTroubleshootingInfoToClipboard();
                     break;
                 case "ToggleDownloadCache":
-                    this.toggleIgnoreCache();
+                    await this.$store.dispatch('download/toggleIgnoreCache');
                     break;
                 case "ValidateSteamInstallation":
                     this.validateSteamInstallation();
@@ -631,7 +627,6 @@ import ModalCard from '../components/ModalCard.vue';
 
 		async created() {
 			this.launchParametersModel = this.settings.getContext().gameSpecific.launchParameters;
-			const ignoreCache = this.settings.getContext().global.ignoreCache;
 
             InteractionProvider.instance.hookModInstallProtocol(async (protocolUrl) => {
                 const game = this.$store.state.activeGame;
@@ -643,7 +638,7 @@ import ModalCard from '../components/ModalCard.vue';
                     });
                     return;
                 }
-                DownloadModModal.downloadSpecific(this.profile, combo, ignoreCache, this.$store)
+                DownloadModModal.downloadSpecific(this.profile, combo, this.$store)
                     .then(async value => {
                         const modList = await ProfileModList.getModList(this.profile.asImmutableProfile());
                         if (!(modList instanceof R2Error)) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,18 +59,20 @@ export const store = {
             return await dispatch('setActiveGame', GameManager.defaultGame);
         },
 
-        async setActiveGame({commit}: Context, game: Game): Promise<ManagerSettings> {
+        async setActiveGame({commit, dispatch}: Context, game: Game): Promise<ManagerSettings> {
             // Some parts of the code base reads the active game from
             // this static class attribute for now. Ideally we wouldn't
             // need to track it on two separate places.
             GameManager.activeGame = game;
             commit('setActiveGame', game);
 
+            const settings = await ManagerSettings.getSingleton(game);
+            commit('setSettings', settings);
+            commit('download/setIgnoreCacheVuexOnly', settings.getContext().global.ignoreCache);
+
             // Return settings for the new active game. This comes handy
             // when accessing settings before user has selected the game
             // as the settings-getter might throw a sanity check error.
-            const settings = await ManagerSettings.getSingleton(game);
-            commit('setSettings', settings);
             return settings;
         },
 

--- a/src/store/modules/DownloadModule.ts
+++ b/src/store/modules/DownloadModule.ts
@@ -1,5 +1,6 @@
 import { ActionTree, GetterTree } from "vuex";
 
+import ManagerSettings from "../../r2mm/manager/ManagerSettings";
 import { State as RootState } from "../../store";
 
 interface DownloadProgress {
@@ -21,6 +22,7 @@ interface UpdateObject {
 
 interface State {
     allDownloads: DownloadProgress[],
+    ignoreCache: boolean,
     isModProgressModalOpen: boolean,
 }
 
@@ -32,6 +34,7 @@ export const DownloadModule = {
 
     state: (): State => ({
         allDownloads: [],
+        ignoreCache: false,
         isModProgressModalOpen: false,
     }),
 
@@ -48,6 +51,11 @@ export const DownloadModule = {
             };
             state.allDownloads = [...state.allDownloads, downloadObject];
             return assignId;
+        },
+        async toggleIgnoreCache({commit, rootGetters}) {
+            const settings: ManagerSettings = rootGetters['settings'];
+            settings.setIgnoreCache(!settings.getContext().global.ignoreCache);
+            commit('setIgnoreCacheVuexOnly', settings.getContext().global.ignoreCache);
         },
     },
 
@@ -103,6 +111,10 @@ export const DownloadModule = {
 
             newDownloads[index] = {...newDownloads[index], ...update};
             state.allDownloads = newDownloads;
+        },
+        // Use actions.toggleIngoreCache to store the setting persistently.
+        setIgnoreCacheVuexOnly(state: State, ignoreCache: boolean) {
+            state.ignoreCache = ignoreCache;
         },
         setIsModProgressModalOpen(state: State, isModProgressModalOpen: boolean) {
             state.isModProgressModalOpen = isModProgressModalOpen;


### PR DESCRIPTION
Toggling the setting didn't take place immediately everywhere. Assumedly this is due to Vuex not detecting changes in a class based object.

To fix this, the setting is encapsulated completely in Vuex: the value is initialized when settings are loaded, it's changed only through a Vuex action, and it's always read from Vuex state. The only exception to this is the ManagerSettingsMigration but I assume this is such a niche case it's not worth addressing.