### PR TITLE
Add a button to remove an inactive download from the list in DownloadMonitor

### DIFF
--- a/src/pages/DownloadMonitor.vue
+++ b/src/pages/DownloadMonitor.vue
@@ -20,22 +20,40 @@
                             <div class="card is-shadowless">
                                 <p><strong>{{ downloadObject.initialMods.join(", ") }}</strong></p>
 
-                                <div v-if="downloadObject.failed">
-                                    <p>Download failed</p>
-                                    <Progress
-                                        :max='100'
-                                        :value='100'
-                                        :className="['is-danger']"
-                                    />
+                                <div class="row" v-if="downloadObject.failed">
+                                    <div class="col">
+                                        <p>Download failed</p>
+                                        <Progress
+                                            :max='100'
+                                            :value='100'
+                                            :className="['is-danger']"
+                                        />
+                                    </div>
+                                    <button
+                                        class="button ghost"
+                                        v-tooltip.left="'Remove'"
+                                        @click="$store.commit('download/remove', downloadObject)"
+                                    >
+                                        <i class="fas fa-times" />
+                                    </button>
                                 </div>
 
-                                <div v-else-if="downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100">
-                                    <p>Download complete</p>
-                                    <Progress
-                                        :max='100'
-                                        :value='100'
-                                        :className="['is-success']"
-                                    />
+                                <div class="row" v-else-if="downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100">
+                                    <div class="col">
+                                        <p>Download complete</p>
+                                        <Progress
+                                            :max='100'
+                                            :value='100'
+                                            :className="['is-success']"
+                                        />
+                                    </div>
+                                    <button
+                                        class="button ghost"
+                                        v-tooltip.left="'Remove'"
+                                        @click="$store.commit('download/removeDownload', downloadObject.assignId)"
+                                    >
+                                        <i class="fas fa-times" />
+                                    </button>
                                 </div>
 
                                 <div v-else class="row">

--- a/src/pages/DownloadMonitor.vue
+++ b/src/pages/DownloadMonitor.vue
@@ -14,83 +14,75 @@
         </template>
         <template v-else>
             <div v-for="(downloadObject, index) of $store.getters['download/newestFirst']" :key="`download-progress-${index}`">
-                <div>
-                    <div class="container margin-right">
-                        <div class="border-at-bottom pad pad--sides">
-                            <div class="card is-shadowless">
-                                <p><strong>{{ downloadObject.initialMods.join(", ") }}</strong></p>
+                <div class="container">
+                    <div class="row border-at-bottom pad pad--sides">
+                        <div class="is-flex-grow-1 margin-right card is-shadowless">
+                            <p><strong>{{ downloadObject.initialMods.join(", ") }}</strong></p>
 
-                                <div class="row" v-if="downloadObject.failed">
-                                    <div class="col">
-                                        <p>Download failed</p>
-                                        <Progress
-                                            :max='100'
-                                            :value='100'
-                                            :className="['is-danger']"
-                                        />
-                                    </div>
-                                    <button
-                                        class="button ghost"
-                                        v-tooltip.left="'Remove'"
-                                        @click="$store.commit('download/remove', downloadObject)"
-                                    >
-                                        <i class="fas fa-times" />
-                                    </button>
-                                </div>
-
-                                <div class="row" v-else-if="downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100">
-                                    <div class="col">
-                                        <p>Download complete</p>
-                                        <Progress
-                                            :max='100'
-                                            :value='100'
-                                            :className="['is-success']"
-                                        />
-                                    </div>
-                                    <button
-                                        class="button ghost"
-                                        v-tooltip.left="'Remove'"
-                                        @click="$store.commit('download/removeDownload', downloadObject.assignId)"
-                                    >
-                                        <i class="fas fa-times" />
-                                    </button>
-                                </div>
-
-                                <div v-else class="row">
-
-                                    <div class="col">
-                                        <p v-if="downloadObject.downloadProgress < 100">Downloading: {{ downloadObject.modName }}</p>
-                                        <p v-else>Downloading:</p>
-                                        <p>{{Math.min(Math.floor(downloadObject.downloadProgress), 100)}}% complete</p>
-                                        <Progress
-                                            :max='100'
-                                            :value='downloadObject.downloadProgress'
-                                            :className="['is-info']"
-                                        />
-                                    </div>
-
-                                    <div v-if="downloadObject.downloadProgress < 100" class="col">
-                                        <p>Installing:</p>
-                                        <p>Waiting for download to finish</p>
-                                        <Progress
-                                            :max='100'
-                                            :value='0'
-                                            :className="['is-info']"
-                                        />
-                                    </div>
-                                    <div v-else class="col">
-                                        <p>Installing: {{ downloadObject.modName }}</p>
-                                        <p>{{Math.min(Math.floor(downloadObject.installProgress), 100)}}% complete</p>
-                                        <Progress
-                                            :max='100'
-                                            :value='downloadObject.installProgress'
-                                            :className="['is-info']"
-                                        />
-                                    </div>
-
+                            <div class="row" v-if="downloadObject.failed">
+                                <div class="col">
+                                    <p>Download failed</p>
+                                    <Progress
+                                        :max='100'
+                                        :value='100'
+                                        :className="['is-danger']"
+                                    />
                                 </div>
                             </div>
+
+                            <div class="row" v-else-if="downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100">
+                                <div class="col">
+                                    <p>Download complete</p>
+                                    <Progress
+                                        :max='100'
+                                        :value='100'
+                                        :className="['is-success']"
+                                    />
+                                </div>
+                            </div>
+
+                            <div v-else class="row">
+
+                                <div class="col">
+                                    <p v-if="downloadObject.downloadProgress < 100">Downloading: {{ downloadObject.modName }}</p>
+                                    <p v-else>Downloading:</p>
+                                    <p>{{Math.min(Math.floor(downloadObject.downloadProgress), 100)}}% complete</p>
+                                    <Progress
+                                        :max='100'
+                                        :value='downloadObject.downloadProgress'
+                                        :className="['is-info']"
+                                    />
+                                </div>
+
+                                <div v-if="downloadObject.downloadProgress < 100" class="col">
+                                    <p>Installing:</p>
+                                    <p>Waiting for download to finish</p>
+                                    <Progress
+                                        :max='100'
+                                        :value='0'
+                                        :className="['is-info']"
+                                    />
+                                </div>
+                                <div v-else class="col">
+                                    <p>Installing: {{ downloadObject.modName }}</p>
+                                    <p>{{Math.min(Math.floor(downloadObject.installProgress), 100)}}% complete</p>
+                                    <Progress
+                                        :max='100'
+                                        :value='downloadObject.installProgress'
+                                        :className="['is-info']"
+                                    />
+                                </div>
+
+                            </div>
                         </div>
+                        <button
+                            v-if="downloadObject.failed || (downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100)"
+                            class="button download-item-action-button"
+                            v-tooltip.left="'Remove'"
+                            @click="$store.commit('download/removeDownload', downloadObject)"
+                        >
+                            <i class="fas fa-times" />
+                        </button>
                     </div>
                 </div>
             </div>
@@ -115,3 +107,13 @@ export default class DownloadMonitor extends Vue {
 }
 
 </script>
+
+<style lang="scss" scoped>
+.download-item-action-button {
+    font-size: 1.5rem;
+    padding: 0;
+    height: 1em;
+    margin: auto 1rem;
+    border: none;
+}
+</style>

--- a/src/store/modules/DownloadModule.ts
+++ b/src/store/modules/DownloadModule.ts
@@ -93,24 +93,19 @@ export const DownloadModule = {
     },
 
     mutations: {
+        removeDownload(state: State, download: UpdateObject) {
+            const index = getIndexOfDownloadProgress(state.allDownloads, download.assignId);
+            if (index > -1) {
+                state.allDownloads.splice(index, 1);
+            }
+        },
         updateDownload(state: State, update: UpdateObject) {
-            const newDownloads = [...state.allDownloads];
-            const index = newDownloads.findIndex((old: DownloadProgress) => {
-                return old.assignId === update.assignId;
-            });
-
-            if (index === -1) {
-                // The DownloadProgress by the ID from the update wasn't found at all.
-                console.warn(`Couldn\'t find DownloadProgress object with assignId ${update.assignId}.`);
-                return;
+            const index: number = getIndexOfDownloadProgress(state.allDownloads, update.assignId);
+            if (index > -1) {
+                const newDownloads = [...state.allDownloads];
+                newDownloads[index] = {...newDownloads[index], ...update};
+                state.allDownloads = newDownloads;
             }
-
-            if (index !== update.assignId) {
-                console.log(`There was a mismatch between download update\'s assign ID (${update.assignId}) and the index it was found at (${index}).`);
-            }
-
-            newDownloads[index] = {...newDownloads[index], ...update};
-            state.allDownloads = newDownloads;
         },
         // Use actions.toggleIngoreCache to store the setting persistently.
         setIgnoreCacheVuexOnly(state: State, ignoreCache: boolean) {
@@ -120,4 +115,14 @@ export const DownloadModule = {
             state.isModProgressModalOpen = isModProgressModalOpen;
         }
     },
+}
+
+function getIndexOfDownloadProgress(allDownloads: DownloadProgress[], assignId: number): number {
+    const index = [...allDownloads].findIndex((downloadProgress) => downloadProgress.assignId === assignId);
+
+    if (index === -1) {
+        console.warn(`Couldn't find DownloadProgress object with assignId ${assignId}.`);
+    }
+
+    return index;
 }


### PR DESCRIPTION
- Added a corresponding vuex mutation
- Separated indexOfDownloadProgress function
- Removed the "There was a mismatch between download update's assign ID" check as that is now expected behavciour when a download is removed from the list.