### PR TITLE
Add DownloadStatusEnum and use it when tracking download/install status

### DIFF
--- a/src/components/mixins/DownloadMixin.vue
+++ b/src/components/mixins/DownloadMixin.vue
@@ -2,6 +2,7 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
+import { DownloadStatusEnum } from '../../model/enums/DownloadStatusEnum';
 import R2Error, { throwForR2Error } from "../../model/errors/R2Error";
 import Game from "../../model/game/Game";
 import Profile, { ImmutableProfile } from "../../model/Profile";
@@ -41,9 +42,11 @@ export default class DownloadMixin extends Vue {
 
     async downloadCompletedCallback(downloadedMods: ThunderstoreCombo[], downloadId: number): Promise<void> {
         try {
+            this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.INSTALLING});
             await this.installModsAndResolveConflicts(downloadedMods, this.profile.asImmutableProfile(), downloadId);
+            this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.DONE});
         } catch (e) {
-            this.$store.commit('download/updateDownload', {downloadId, failed: true});
+            this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.FAILED});
             this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
         }
     }

--- a/src/components/mixins/DownloadMixin.vue
+++ b/src/components/mixins/DownloadMixin.vue
@@ -2,7 +2,6 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
-import { DownloadStatusEnum } from '../../model/enums/DownloadStatusEnum';
 import R2Error, { throwForR2Error } from "../../model/errors/R2Error";
 import Game from "../../model/game/Game";
 import Profile, { ImmutableProfile } from "../../model/Profile";
@@ -42,11 +41,11 @@ export default class DownloadMixin extends Vue {
 
     async downloadCompletedCallback(downloadedMods: ThunderstoreCombo[], downloadId: number): Promise<void> {
         try {
-            this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.INSTALLING});
+            this.$store.commit('download/setInstalling', downloadId);
             await this.installModsAndResolveConflicts(downloadedMods, this.profile.asImmutableProfile(), downloadId);
-            this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.DONE});
+            this.$store.commit('download/setDone', downloadId);
         } catch (e) {
-            this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.FAILED});
+            this.$store.commit('download/setFailed', downloadId);
             this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
         }
     }

--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -53,7 +53,6 @@ import ModalCard from '../ModalCard.vue';
 import DownloadModVersionSelectModal from "../../components/views/DownloadModVersionSelectModal.vue";
 import UpdateAllInstalledModsModal from "../../components/views/UpdateAllInstalledModsModal.vue";
 import DownloadMixin from "../mixins/DownloadMixin.vue";
-import { DownloadStatusEnum } from "../../model/enums/DownloadStatusEnum";
 import R2Error from '../../model/errors/R2Error';
 import ThunderstoreMod from '../../model/ThunderstoreMod';
 import ThunderstoreVersion from '../../model/ThunderstoreVersion';
@@ -97,7 +96,7 @@ import ThunderstoreDownloaderProvider from '../../providers/ror2/downloading/Thu
                     );
                 } catch (e) {
                     this.setIsModProgressModalOpen(false);
-                    this.$store.commit('download/updateDownload', { downloadId, status: DownloadStatusEnum.FAILED });
+                    this.$store.commit('download/setFailed', downloadId);
                     this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
                     return;
                 }

--- a/src/components/views/DownloadModModal.vue
+++ b/src/components/views/DownloadModModal.vue
@@ -53,6 +53,7 @@ import ModalCard from '../ModalCard.vue';
 import DownloadModVersionSelectModal from "../../components/views/DownloadModVersionSelectModal.vue";
 import UpdateAllInstalledModsModal from "../../components/views/UpdateAllInstalledModsModal.vue";
 import DownloadMixin from "../mixins/DownloadMixin.vue";
+import { DownloadStatusEnum } from "../../model/enums/DownloadStatusEnum";
 import R2Error from '../../model/errors/R2Error';
 import ThunderstoreMod from '../../model/ThunderstoreMod';
 import ThunderstoreVersion from '../../model/ThunderstoreVersion';
@@ -96,7 +97,7 @@ import ThunderstoreDownloaderProvider from '../../providers/ror2/downloading/Thu
                     );
                 } catch (e) {
                     this.setIsModProgressModalOpen(false);
-                    this.$store.commit('download/updateDownload', { downloadId, failed: true });
+                    this.$store.commit('download/updateDownload', { downloadId, status: DownloadStatusEnum.FAILED });
                     this.$store.commit('error/handleError', R2Error.fromThrownValue(e));
                     return;
                 }

--- a/src/components/views/UpdateAllInstalledModsModal.vue
+++ b/src/components/views/UpdateAllInstalledModsModal.vue
@@ -1,3 +1,4 @@
+
 <template>
     <ModalCard id="update-all-installed-mods-modal" :is-active="isOpen" :can-close="true" v-if="thunderstoreMod === null" @close-modal="closeModal()">
         <template v-slot:header>
@@ -29,6 +30,7 @@ import ModalCard from "../ModalCard.vue";
 import DownloadMixin from "../mixins/DownloadMixin.vue";
 import * as DownloadUtils from "../../utils/DownloadUtils";
 import DownloadModVersionSelectModal from "../views/DownloadModVersionSelectModal.vue";
+import { DownloadStatusEnum } from "../../model/enums/DownloadStatusEnum";
 import ThunderstoreCombo from "../../model/ThunderstoreCombo";
 import StatusEnum from "../../model/enums/StatusEnum";
 import R2Error from "../../model/errors/R2Error";
@@ -55,7 +57,7 @@ export default class UpdateAllInstalledModsModal extends mixins(DownloadMixin)  
             try {
                 if (status === StatusEnum.FAILURE) {
                     this.setIsModProgressModalOpen(false);
-                    this.$store.commit('download/updateDownload', {downloadId, failed: true});
+                    this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.FAILED});
                     if (err !== null) {
                         DownloadUtils.addSolutionsToError(err);
                         throw err;

--- a/src/components/views/UpdateAllInstalledModsModal.vue
+++ b/src/components/views/UpdateAllInstalledModsModal.vue
@@ -30,7 +30,6 @@ import ModalCard from "../ModalCard.vue";
 import DownloadMixin from "../mixins/DownloadMixin.vue";
 import * as DownloadUtils from "../../utils/DownloadUtils";
 import DownloadModVersionSelectModal from "../views/DownloadModVersionSelectModal.vue";
-import { DownloadStatusEnum } from "../../model/enums/DownloadStatusEnum";
 import ThunderstoreCombo from "../../model/ThunderstoreCombo";
 import StatusEnum from "../../model/enums/StatusEnum";
 import R2Error from "../../model/errors/R2Error";
@@ -57,7 +56,7 @@ export default class UpdateAllInstalledModsModal extends mixins(DownloadMixin)  
             try {
                 if (status === StatusEnum.FAILURE) {
                     this.setIsModProgressModalOpen(false);
-                    this.$store.commit('download/updateDownload', {downloadId, status: DownloadStatusEnum.FAILED});
+                    this.$store.commit('download/setFailed', downloadId);
                     if (err !== null) {
                         DownloadUtils.addSolutionsToError(err);
                         throw err;

--- a/src/model/enums/DownloadStatusEnum.ts
+++ b/src/model/enums/DownloadStatusEnum.ts
@@ -1,0 +1,6 @@
+export enum DownloadStatusEnum {
+    DOWNLOADING = 0,
+    INSTALLING = 1,
+    DONE = 2,
+    FAILED = 3
+}

--- a/src/pages/DownloadMonitor.vue
+++ b/src/pages/DownloadMonitor.vue
@@ -27,7 +27,7 @@
                         <div class="is-flex-grow-1 margin-right card is-shadowless">
                             <p><strong>{{ downloadObject.initialMods.join(", ") }}</strong></p>
 
-                            <div class="row" v-if="downloadObject.failed">
+                            <div class="row" v-if="downloadObject.status === DownloadStatusEnum.FAILED">
                                 <div class="col">
                                     <p>Download failed</p>
                                     <Progress
@@ -38,7 +38,7 @@
                                 </div>
                             </div>
 
-                            <div class="row" v-else-if="downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100">
+                            <div class="row" v-else-if="downloadObject.status === DownloadStatusEnum.DONE">
                                 <div class="col">
                                     <p>Download complete</p>
                                     <Progress
@@ -52,7 +52,7 @@
                             <div v-else class="row">
 
                                 <div class="col">
-                                    <p v-if="downloadObject.downloadProgress < 100">Downloading: {{ downloadObject.modName }}</p>
+                                    <p v-if="downloadObject.status === DownloadStatusEnum.DOWNLOADING">Downloading: {{ downloadObject.modName }}</p>
                                     <p v-else>Downloading:</p>
                                     <p>{{Math.min(Math.floor(downloadObject.downloadProgress), 100)}}% complete</p>
                                     <Progress
@@ -62,7 +62,7 @@
                                     />
                                 </div>
 
-                                <div v-if="downloadObject.downloadProgress < 100" class="col">
+                                <div v-if="downloadObject.status === DownloadStatusEnum.DOWNLOADING" class="col">
                                     <p>Installing:</p>
                                     <p>Waiting for download to finish</p>
                                     <Progress
@@ -84,7 +84,7 @@
                             </div>
                         </div>
                         <button
-                            v-if="downloadObject.failed || (downloadObject.downloadProgress === 100 && downloadObject.installProgress === 100)"
+                            v-if="downloadObject.status === DownloadStatusEnum.FAILED || downloadObject.status === DownloadStatusEnum.DONE"
                             class="button download-item-action-button"
                             v-tooltip.left="'Remove'"
                             @click="$store.commit('download/removeDownload', downloadObject)"
@@ -104,6 +104,7 @@ import { Component, Vue } from 'vue-property-decorator';
 
 import { Hero } from '../components/all';
 import Progress from '../components/Progress.vue';
+import { DownloadStatusEnum } from '../model/enums/DownloadStatusEnum';
 
 @Component({
     components: {
@@ -112,6 +113,7 @@ import Progress from '../components/Progress.vue';
     }
 })
 export default class DownloadMonitor extends Vue {
+    DownloadStatusEnum = DownloadStatusEnum;
 }
 
 </script>

--- a/src/store/modules/DownloadModule.ts
+++ b/src/store/modules/DownloadModule.ts
@@ -4,6 +4,7 @@ import UUID from 'uuid-js';
 import R2Error, { throwForR2Error } from "../../model/errors/R2Error";
 import ManifestV2 from "../../model/ManifestV2";
 import { ImmutableProfile } from "../../model/Profile";
+import { DownloadStatusEnum } from "../../model/enums/DownloadStatusEnum";
 import StatusEnum from "../../model/enums/StatusEnum";
 import ThunderstoreCombo from "../../model/ThunderstoreCombo";
 import ConflictManagementProvider from "../../providers/generic/installing/ConflictManagementProvider";
@@ -20,7 +21,7 @@ interface DownloadProgress {
     modName: string;
     downloadProgress: number;
     installProgress: number;
-    failed: boolean;
+    status: DownloadStatusEnum;
 }
 
 interface UpdateObject {
@@ -28,7 +29,7 @@ interface UpdateObject {
     downloadProgress?: number;
     installProgress?: number;
     modName?: string;
-    failed?: boolean;
+    status?: DownloadStatusEnum;
 }
 
 interface State {
@@ -58,7 +59,7 @@ export const DownloadModule = {
                 modName: '',
                 downloadProgress: 0,
                 installProgress: 0,
-                failed: false,
+                status: DownloadStatusEnum.DOWNLOADING
             };
             state.allDownloads = [...state.allDownloads, downloadObject];
             return downloadId;
@@ -140,9 +141,12 @@ export const DownloadModule = {
                         dispatch('downloadProgressCallback', { downloadId, downloadProgress, modName, status, err });
                     }
                 );
+
+                commit('updateDownload', { downloadId, status: DownloadStatusEnum.INSTALLING });
                 await dispatch('installMods', {downloadedMods, downloadId, profile: params.profile});
+                commit('updateDownload', { downloadId, status: DownloadStatusEnum.DONE });
             } catch (e) {
-                commit('updateDownload', { downloadId, failed: true });
+                commit('updateDownload', { downloadId, status: DownloadStatusEnum.FAILED });
                 throw e;
             }
         },
@@ -156,7 +160,7 @@ export const DownloadModule = {
         }) {
             if (params.status === StatusEnum.FAILURE) {
                 commit('setIsModProgressModalOpen', false);
-                commit('updateDownload', {downloadId: params.downloadId, failed: true});
+                commit('updateDownload', {downloadId: params.downloadId, status: DownloadStatusEnum.FAILED});
                 if (params.err !== null) {
                     DownloadUtils.addSolutionsToError(params.err);
                     throw params.err;
@@ -236,8 +240,6 @@ function getIndexOfDownloadProgress(allDownloads: DownloadProgress[], downloadId
 }
 
 function getOnlyActiveDownloads(downloads: DownloadProgress[]): DownloadProgress[] {
-    return downloads.filter(dl =>
-        !dl.failed &&
-        !(dl.downloadProgress >= 100 && dl.installProgress >= 100)
-    );
+    const active = [DownloadStatusEnum.DOWNLOADING, DownloadStatusEnum.INSTALLING];
+    return downloads.filter(dl => active.includes(dl.status));
 }


### PR DESCRIPTION
* Instead of a boolean type field "failed", set status to DownloadStatusEnum.FAILED
* Update status accordingly when download is initiated, when installation starts and when installation finishes.