### PR TITLE
Add no-wrap to DownloadMonitor's item

### DIFF
--- a/src/pages/DownloadMonitor.vue
+++ b/src/pages/DownloadMonitor.vue
@@ -23,7 +23,7 @@
             </div>
             <div v-for="(downloadObject, index) of $store.getters['download/newestFirst']" :key="`download-progress-${index}`">
                 <div class="container">
-                    <div class="row border-at-bottom pad pad--sides">
+                    <div class="row no-wrap border-at-bottom pad pad--sides">
                         <div class="is-flex-grow-1 margin-right card is-shadowless">
                             <p><strong>{{ downloadObject.initialMods.join(", ") }}</strong></p>
 


### PR DESCRIPTION
* Long titles made the buttons wrap to the next row, which looked bad.