### PR TITLE
Moved import local mod functionality into ProfileManagementModal

### DIFF
--- a/src/components/importing/LocalFileImportModal.vue
+++ b/src/components/importing/LocalFileImportModal.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <ModalCard id="import-mod-from-file-modal" :can-close="true" @close-modal="emitClose" :is-active="isOpen">
+        <ModalCard id="import-mod-from-file-modal" :can-close="true" @close-modal="closeModal" :is-active="isOpen">
             <template v-slot:header>
                 <h2 class='modal-title'>Import mod from file</h2>
             </template>
@@ -98,7 +98,7 @@ import { ImmutableProfile } from '../../model/Profile';
 import ProfileModList from '../../r2mm/mods/ProfileModList';
 import LocalModInstallerProvider from '../../providers/ror2/installing/LocalModInstallerProvider';
 import ModalCard from '../ModalCard.vue';
-import { ref, defineProps, watch, computed } from 'vue';
+import { ref, defineProps, computed } from 'vue';
 import useStore from '../../store';
 
 const store = useStore();
@@ -124,12 +124,6 @@ const modVersionPatch = ref<number>(0);
 
 let resultingManifest = new ManifestV2();
 
-watch(() => props.visible, () => {
-    fileToImport.value = null;
-    waitingForSelection.value = false;
-    validationMessage.value = null;
-});
-
 async function selectFile() {
     waitingForSelection.value = true;
     InteractionProvider.instance.selectFile({
@@ -145,6 +139,18 @@ async function selectFile() {
             fileToImport.value = null;
         }
     })
+}
+
+async function resetValues() {
+    modName.value = "";
+    modAuthor.value = "Unknown";
+    modDescription.value = "";
+    modVersionMajor.value = 0;
+    modVersionMinor.value = 0;
+    modVersionPatch.value = 0;
+    fileToImport.value = null;
+    waitingForSelection.value = false;
+    validationMessage.value = null;
 }
 
 async function assumeDefaults() {
@@ -265,7 +271,8 @@ function versionPartToNumber(input: string | undefined) {
         .shift() || "0";
 }
 
-function emitClose() {
+async function closeModal() {
+    await resetValues();
     store.commit("closeLocalFileImportModal");
 }
 
@@ -335,7 +342,7 @@ async function importFile() {
         store.commit('error/handleError', R2Error.fromThrownValue(updatedModListResult));
     } else {
         await store.dispatch("profile/updateModList", updatedModListResult);
-        emitClose();
+        closeModal();
     }
 }
 

--- a/src/components/modals/ProfileManagementModal.vue
+++ b/src/components/modals/ProfileManagementModal.vue
@@ -41,6 +41,11 @@ async function exportProfileAsCode() {
     }
     store.commit("closeProfileManagementModal");
 }
+
+async function importLocalMod() {
+    store.commit("openLocalFileImportModal");
+    store.commit("closeProfileManagementModal");
+}
 </script>
 
 <template>
@@ -68,6 +73,13 @@ async function exportProfileAsCode() {
                 icon="fa-cloud-upload-alt"
                 :value="async () => undefined"
                 @click="exportProfileAsCode"
+            />
+            <SettingsItem
+                action="Import local mod"
+                description="Install a mod offline from your files"
+                icon="fa-file-import"
+                :value="async () => 'Not all mods can be installed locally'"
+                @click="importLocalMod"
             />
         </template>
         <template v-slot:footer>

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -237,14 +237,6 @@ import CdnProvider from '../../providers/generic/connection/CdnProvider';
             ),
             new SettingsRow(
                 'Profile',
-                'Import local mod',
-                'Install a mod offline from your files.',
-                async () => 'Not all mods can be installed locally',
-                'fa-file-import',
-                () => this.emitInvoke('ImportLocalMod')
-            ),
-            new SettingsRow(
-                'Profile',
                 'Update all mods',
                 'Quickly update every installed mod to their latest versions.',
                 async () => {

--- a/src/store/modules/ModalsModule.ts
+++ b/src/store/modules/ModalsModule.ts
@@ -18,6 +18,7 @@ interface State {
     uninstallModModalMod: ManifestV2 | null;
     isProfileManagementModalOpen: boolean;
     isProfileCodeExportModalOpen: boolean;
+    isLocalFileImportModalOpen: boolean;
 }
 
 export default {
@@ -38,6 +39,7 @@ export default {
         uninstallModModalMod: null,
         isProfileManagementModalOpen: false,
         isProfileCodeExportModalOpen: false,
+        isLocalFileImportModalOpen: false,
     }),
 
     mutations: {
@@ -91,6 +93,10 @@ export default {
 
         closeProfileCodeExportModal: function(state: State): void {
             state.isProfileCodeExportModalOpen = false;
+        },
+
+        closeLocalFileImportModal: function(state: State): void {
+            state.isLocalFileImportModalOpen = false;
         },
 
         openAssociatedModsModal: function(state: State, mod: ManifestV2): void {
@@ -148,6 +154,10 @@ export default {
 
         openProfileCodeExportModal: function(state: State): void {
             state.isProfileCodeExportModalOpen = true;
+        },
+
+        openLocalFileImportModal: function(state: State): void {
+            state.isLocalFileImportModalOpen = true;
         },
     }
 }


### PR DESCRIPTION
The bulk of the changes of this PR are porting the modal to the composition API. Should be okay to mostly ignore that file, and loop back to changes to that file as part of the second commit.