### PR TITLE
Re-added removed settings to aid transition to new profile management modal

### DIFF
--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -237,6 +237,30 @@ import CdnProvider from '../../providers/generic/connection/CdnProvider';
             ),
             new SettingsRow(
                 'Profile',
+                'Import local mod',
+                'Install a mod offline from your files.',
+                async () => 'Not all mods can be installed locally',
+                'fa-file-import',
+                () => this.$store.commit("openLocalFileImportModal")
+            ),
+            new SettingsRow(
+                'Profile',
+                'Export profile as a file',
+                'Export your mod list and configs as a file.',
+                async () => 'The exported file can be shared with friends to get an identical profile quickly and easily',
+                'fa-file-export',
+                () => this.$store.dispatch("profileExport/exportProfileAsFile")
+            ),
+            new SettingsRow(
+                'Profile',
+                'Export profile as a code',
+                'Export your mod list and configs as a code.',
+                async () => 'The exported code can be shared with friends to get an identical profile quickly and easily',
+                'fa-file-export',
+                () => this.$store.dispatch("profileExport/exportProfileAsCode")
+            ),
+            new SettingsRow(
+                'Profile',
                 'Update all mods',
                 'Quickly update every installed mod to their latest versions.',
                 async () => {


### PR DESCRIPTION
It'll be quite a workflow jump to remove all of these settings and so it'll likely receive less backlash should these be removed gradually instead. 

We don't currently have a nice way to indicate that something like this has happened.