### PR TITLE
Update Thunderstore ecosystem schema and data

### DIFF
--- a/src/assets/data/ecosystem.json
+++ b/src/assets/data/ecosystem.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.2.2",
+  "schemaVersion": "0.2.3",
   "games": {
     "20-minutes-till-dawn": {
       "uuid": "57ae7cc1-b21a-4592-8415-73512a91b180",
@@ -10247,63 +10247,8 @@
             "pvr"
           ],
           "packageLoader": "recursive-melonloader",
-          "installRules": [
-            {
-              "route": "Mods",
-              "defaultFileExtensions": [
-                ".dll"
-              ],
-              "trackingMethod": "state",
-              "subRoutes": [],
-              "isDefaultLocation": false
-            },
-            {
-              "route": "UserData/ModManager",
-              "defaultFileExtensions": [],
-              "trackingMethod": "subdir-no-flatten",
-              "subRoutes": [],
-              "isDefaultLocation": true
-            },
-            {
-              "route": "UserLibs",
-              "defaultFileExtensions": [
-                ".lib.dll"
-              ],
-              "trackingMethod": "state",
-              "subRoutes": [],
-              "isDefaultLocation": false
-            },
-            {
-              "route": "MelonLoader",
-              "defaultFileExtensions": [],
-              "trackingMethod": "state",
-              "subRoutes": [
-                {
-                  "route": "Managed",
-                  "defaultFileExtensions": [
-                    ".managed.dll"
-                  ],
-                  "trackingMethod": "state",
-                  "subRoutes": [],
-                  "isDefaultLocation": false
-                },
-                {
-                  "route": "Libs",
-                  "defaultFileExtensions": [],
-                  "trackingMethod": "state",
-                  "subRoutes": [],
-                  "isDefaultLocation": false
-                }
-              ],
-              "isDefaultLocation": false
-            }
-          ],
-          "relativeFileExclusions": [
-            "manifest.json",
-            "icon.png",
-            "README.md",
-            "LICENCE"
-          ]
+          "installRules": [],
+          "relativeFileExclusions": null
         }
       ],
       "thunderstore": {
@@ -10891,10 +10836,8 @@
             ]
           }
         },
-        "discordUrl": "https://discord.gg/peakgame",
-        "autolistPackageIds": [
-          "BepInEx-BepInExPack"
-        ]
+        "discordUrl": "https://discord.gg/SAw86z24rB",
+        "wikiUrl": "https://peakmodding.github.io"
       }
     },
     "peaks-of-yore": {
@@ -22363,10 +22306,8 @@
           ]
         }
       },
-      "discordUrl": "https://discord.gg/peakgame",
-      "autolistPackageIds": [
-        "BepInEx-BepInExPack"
-      ]
+      "discordUrl": "https://discord.gg/SAw86z24rB",
+      "wikiUrl": "https://peakmodding.github.io"
     },
     "peaks-of-yore": {
       "displayName": "Peaks of Yore",
@@ -25449,6 +25390,11 @@
       "packageId": "LavaGang-MelonLoader",
       "rootFolder": "",
       "loader": "recursive-melonloader"
+    },
+    {
+      "packageId": "BepInEx-BepInExPack_PEAK",
+      "rootFolder": "BepInExPack_PEAK",
+      "loader": "bepinex"
     }
   ]
 }

--- a/src/assets/data/ecosystemJsonSchema.json
+++ b/src/assets/data/ecosystemJsonSchema.json
@@ -145,6 +145,9 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "shortDescription": {
+                    "type": "string"
                   }
                 },
                 "required": [

--- a/src/assets/data/ecosystemTypes.ts
+++ b/src/assets/data/ecosystemTypes.ts
@@ -17,6 +17,7 @@ export interface ThunderstoreEcosyste {
     discordUrl?:         string;
     displayName:         string;
     sections:            { [key: string]: Section };
+    shortDescription?:   string;
     wikiUrl?:            string;
 }
 
@@ -305,6 +306,7 @@ const typeMap: any = {
         { json: "discordUrl", js: "discordUrl", typ: u(undefined, "") },
         { json: "displayName", js: "displayName", typ: "" },
         { json: "sections", js: "sections", typ: m(r("Section")) },
+        { json: "shortDescription", js: "shortDescription", typ: u(undefined, "") },
         { json: "wikiUrl", js: "wikiUrl", typ: u(undefined, "") },
     ], false),
     "Category": o([


### PR DESCRIPTION
- Schema change: add optional shortDescription field to community data. This field is not currently used in the mod managers
- Remove InstallRules and RelativeFileExclusions from Painting VR. The game uses recursive MelonLoader, and neither of these fields are used with it. How the fields got populated in the first place is a mystery to me, but as the extraction code is no longer used, spending time debugging the issue makes no sense either
- Update PEAK links
- Add new mod loader package for PEAK