### PR TITLE
Prevent unhandled errors from happening when log file doesn't exist

### DIFF
--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -95,9 +95,13 @@ let settingsList = [
         'Debugging',
         'Copy log file contents to clipboard',
         'Copy the text inside the LogOutput.log file to the clipboard, with Discord formatting.',
-        async () => doesLogFileExist(),
+        async () => logOutput.value.exists ? 'Log file exists' : 'Log file does not exist',
         'fa-clipboard',
-        () => emitInvoke('CopyLogToClipboard')
+        () => {
+            if (logOutput.value.exists) {
+                emitInvoke('CopyLogToClipboard')
+            }
+        }
     ),
     new SettingsRow(
         'Debugging',
@@ -361,9 +365,6 @@ function emitInvoke(invoked: string) {
     emits('setting-invoked', invoked);
 }
 
-function doesLogFileExist() {
-    return logOutput.value.exists ? 'Log file exists' : 'Log file does not exist';
-}
 </script>
 
 <template>


### PR DESCRIPTION
* Unhandled errors were generated when the user was trying to copy the contents of a non-existent log file.