### PR TITLE
Add a background color to the buttons' sticky toolbar on DownloadMonitor

### DIFF
--- a/src/pages/DownloadMonitor.vue
+++ b/src/pages/DownloadMonitor.vue
@@ -131,6 +131,7 @@ import { DownloadStatusEnum } from '../model/enums/DownloadStatusEnum';
     z-index: 100;
     padding: 0.5rem;
     text-align: right;
+    background-color: var(--background);
 }
 
 // icons are different sizes, so we need to compensate for that


### PR DESCRIPTION
* The background was transparent, thus showing the download list through itself when scrolling