### PR TITLE
Fix online mod list reactivity

### DIFF
--- a/src/components/views/OnlineModView.vue
+++ b/src/components/views/OnlineModView.vue
@@ -220,7 +220,7 @@ watch(() => [
 watch(() => [
     store.state.modFilters.sortDirection,
     store.state.modFilters.sortBehaviour,
-    thunderstoreModList,
+    thunderstoreModList.value,
 ], () => {
     sortThunderstoreModList();
 })


### PR DESCRIPTION
When watch() is passed a single computed or ref, Vue automatically unwraps the .value of the ref and triggers watch function when it changes. However, if a function that returns an array of refs are passed instead, the wrapping is not done automatically.