### PR TITLE
Fix posix scripts to preserve arguments with spaces

### DIFF
--- a/public/linux_wrapper.sh
+++ b/public/linux_wrapper.sh
@@ -3,48 +3,43 @@
 # Linux wrapper script for r2modman
 # Written by Naomi Calabretta (blame her if something does not work)
 
-a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BASEDIR=$(cd "$a"; pwd -P)
+a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BASEDIR=$(cd "$a" || exit; pwd -P)
 
 R2PROFILE=""
 R2STARTSERVER=""
-args=""
 
-while :; do
+i=0; max=$#
+while [ $i -lt $max ]; do
     case $1 in
         --r2profile)
             if [ -n "$2" ]; then
                 R2PROFILE="$2"
                 shift
+                i=$((i+1))
             else
                 echo "[R2MODMAN LINUX WRAPPER] Warning: --r2profile value is empty!"
             fi
-            ;;
+        ;;
         --server)
             R2STARTSERVER="true"
-            ;;
+        ;;
         *)
-            if [ -z "$1" ]; then
-                break
-            fi
-            if [ -z "$args" ]; then
-                args="$1"
-            else
-                args="$args $1"
-            fi
-            ;;
+            set -- "$@" "$1"
+        ;;
     esac
     shift
+    i=$((i+1))
 done
 
 if [ -z "$R2PROFILE" ]; then
     echo "[R2MODMAN LINUX WRAPPER] Launching vanilla!"
-    exec $args
+    exec "$@"
 fi
 
-[ -n "$R2STARTSERVER" ] && exec "$BASEDIR/profiles/$R2PROFILE/start_server_bepinex.sh" $args || true
+[ -n "$R2STARTSERVER" ] && exec "$BASEDIR/profiles/$R2PROFILE/start_server_bepinex.sh" "$@" || true
 
 if test -f "$BASEDIR/profiles/$R2PROFILE/run_bepinex.sh"; then
-    exec "$BASEDIR/profiles/$R2PROFILE/run_bepinex.sh" $args
+    exec "$BASEDIR/profiles/$R2PROFILE/run_bepinex.sh" "$@"
 else
-   exec "$BASEDIR/profiles/$R2PROFILE/start_game_bepinex.sh" $args
+   exec "$BASEDIR/profiles/$R2PROFILE/start_game_bepinex.sh" "$@"
 fi

--- a/public/macos_wrapper.sh
+++ b/public/macos_wrapper.sh
@@ -3,44 +3,43 @@
 # Linux wrapper script for r2modman
 # Written by Naomi Calabretta (blame her if something does not work)
 
-a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BASEDIR=$(cd "$a"; pwd -P)
+a="/$0"; a=${a%/*}; a=${a#/}; a=${a:-.}; BASEDIR=$(cd "$a" || exit; pwd -P)
 
 R2PROFILE=""
 R2STARTSERVER=""
-args=""
 
-while :; do
+i=0; max=$#
+while [ $i -lt $max ]; do
     case $1 in
         --r2profile)
             if [ -n "$2" ]; then
                 R2PROFILE="$2"
                 shift
+                i=$((i+1))
             else
                 echo "[R2MODMAN LINUX WRAPPER] Warning: --r2profile value is empty!"
             fi
-            ;;
+        ;;
         --server)
             R2STARTSERVER="true"
-            ;;
+        ;;
         *)
-            if [ -z "$1" ]; then
-                break
-            fi
-            if [ -z "$args" ]; then
-                args="$1"
-            else
-                args="$args $1"
-            fi
-            ;;
+            set -- "$@" "$1"
+        ;;
     esac
     shift
+    i=$((i+1))
 done
 
 if [ -z "$R2PROFILE" ]; then
     echo "[R2MODMAN LINUX WRAPPER] Launching vanilla!"
-    exec $args
+    exec "$@"
 fi
 
-[ -n "$R2STARTSERVER" ] && exec "$BASEDIR/profiles/$R2PROFILE/start_server_bepinex.sh" $args || true
+[ -n "$R2STARTSERVER" ] && exec "$BASEDIR/profiles/$R2PROFILE/start_server_bepinex.sh" "$@" || true
 
-exec "$BASEDIR/profiles/$R2PROFILE/start_game_bepinex.sh" $args
+if test -f "$BASEDIR/profiles/$R2PROFILE/run_bepinex.sh"; then
+    exec "$BASEDIR/profiles/$R2PROFILE/run_bepinex.sh" "$@"
+else
+   exec "$BASEDIR/profiles/$R2PROFILE/start_game_bepinex.sh" "$@"
+fi


### PR DESCRIPTION
The wrapper scripts are mangling any arguments with spaces and passing them on as multiple arguments. This is known to cause any game installed to a path with a space in it to fail to launch. Improper argument parsing can be a serious issue and this could cause additional bugs in the future if not fixed.

This preserves the arguments while only striping out the options the wrapper script is checking for. The start_game_bepinex.sh script may also need to be updated and I'm working with the BepInExPack for Valheim team on this. I don't know what other games use a start_game_bepinex.sh script and if they would need updated too.