### PR TITLE
Proton settings selection

### DIFF
--- a/src/components/buttons/CopyToClipboardButton.vue
+++ b/src/components/buttons/CopyToClipboardButton.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import InteractionProvider from "src/providers/ror2/system/InteractionProvider";
+import { ref } from "vue";
+
+export type CopyToClipboardButtonProps = {
+    copyValue: string;
+}
+
+const props = defineProps<CopyToClipboardButtonProps>();
+
+const showLoading = ref(false);
+
+function copy() {
+    InteractionProvider.instance.copyToClipboard(props.copyValue);
+    showLoading.value = true;
+    setTimeout(() => {
+        showLoading.value = false;
+    }, 500);
+}
+
+</script>
+
+<template>
+    <button class="button" @click="copy" v-if="!showLoading">
+        <i class="fas fa-clipboard"></i>
+        <span class="margin-left--half-width smaller-font">
+            <slot></slot>
+        </span>
+    </button>
+    <button @click.prevent class="button is-loading" v-else>
+        <slot></slot>
+    </button>
+</template>

--- a/src/components/buttons/CopyToClipboardButton.vue
+++ b/src/components/buttons/CopyToClipboardButton.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import InteractionProvider from "src/providers/ror2/system/InteractionProvider";
+import InteractionProvider from "../../providers/ror2/system/InteractionProvider";
 import { ref } from "vue";
 
 export type CopyToClipboardButtonProps = {

--- a/src/components/modals/launch-type/LaunchTypeModal.vue
+++ b/src/components/modals/launch-type/LaunchTypeModal.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import ModalCard from '../../ModalCard.vue';
 import {LaunchTypeModalOpen} from "../../../components/modals/launch-type/LaunchTypeRefs";
-import ManagerSettings from "src/r2mm/manager/ManagerSettings";
 import {computed, ref, watchEffect} from "vue";
-import Game from "src/model/game/Game";
-import {getStore} from "src/providers/generic/store/StoreProvider";
-import {State} from "src/store";
-import {getLaunchType, LaunchType} from "src/model/real_enums/launch/LaunchType";
-import {getDeterminedLaunchType, isProtonRequired} from "src/utils/LaunchUtils";
-import EnumResolver from "src/model/enums/_EnumResolver";
+import Game from "../../../model/game/Game";
+import {getStore} from "../../../providers/generic/store/StoreProvider";
+import {State} from "../../../store";
+import {getLaunchType, LaunchType} from "../../../model/real_enums/launch/LaunchType";
+import {getDeterminedLaunchType} from "../../../utils/LaunchUtils";
+import EnumResolver from "../../../model/enums/_EnumResolver";
 
 const store = getStore<State>();
 
@@ -62,7 +61,3 @@ getLaunchType(activeGame.value)
         </template>
     </ModalCard>
 </template>
-
-<style scoped lang="scss">
-
-</style>

--- a/src/components/modals/launch-type/LaunchTypeModal.vue
+++ b/src/components/modals/launch-type/LaunchTypeModal.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import ModalCard from '../../ModalCard.vue';
+import {LaunchTypeModalOpen} from "../../../components/modals/launch-type/LaunchTypeRefs";
+import ManagerSettings from "src/r2mm/manager/ManagerSettings";
+import {computed, ref, watchEffect} from "vue";
+import Game from "src/model/game/Game";
+import {getStore} from "src/providers/generic/store/StoreProvider";
+import {State} from "src/store";
+import {getLaunchType, LaunchType} from "src/model/real_enums/launch/LaunchType";
+import {getDeterminedLaunchType, isProtonRequired} from "src/utils/LaunchUtils";
+import EnumResolver from "src/model/enums/_EnumResolver";
+
+const store = getStore<State>();
+
+function closeModal() {
+    LaunchTypeModalOpen.value = false;
+}
+
+const activeGame = computed<Game>(() => store.state.activeGame);
+const launchOption = ref<string>(LaunchType.AUTO);
+const determinedLaunchType = ref(LaunchType.AUTO);
+
+watchEffect(async () => {
+    const launchTypeString = launchOption.value;
+    const launchType = EnumResolver.from<LaunchType>(LaunchType, launchTypeString);
+    determinedLaunchType.value = await getDeterminedLaunchType(activeGame.value, LaunchType[launchType]);
+})
+
+getLaunchType(activeGame.value)
+    .then(launchType => launchOption.value = launchType)
+
+</script>
+
+<template>
+    <ModalCard id="launch-type-modal" v-show="LaunchTypeModalOpen" :is-active="LaunchTypeModalOpen" :can-close="true" @close-modal="closeModal">
+        <template v-slot:header>
+            <h2 class="modal-title">Set launch behaviour</h2>
+        </template>
+        <template v-slot:body>
+            <div>
+                <input id="launch-type-option-auto" type="radio" name="launch-type-option" :value="LaunchType.AUTO" v-model="launchOption"/>
+                <label for="launch-type-option-auto"><span class="margin-right margin-right--half-width"/>Auto</label>
+            </div>
+            <div>
+                <input id="launch-type-option-native" type="radio" name="launch-type-option" :value="LaunchType.NATIVE" v-model="launchOption"/>
+                <label for="launch-type-option-native"><span class="margin-right margin-right--half-width"/>Native</label>
+            </div>
+            <div>
+                <input id="launch-type-option-proton" type="radio" name="launch-type-option" :value="LaunchType.PROTON" v-model="launchOption"/>
+                <label for="launch-type-option-proton"><span class="margin-right margin-right--half-width"/>Proton</label>
+            </div>
+            <p v-if="launchOption === LaunchType.AUTO" class="margin-top">
+                By selecting <strong>Auto</strong> we have determined that {{ activeGame.displayName }} will be launched under
+                <strong class="tag">{{ determinedLaunchType }}</strong>
+                mode.
+            </p>
+        </template>
+        <template v-slot:footer>
+            <button class="button is-info" @click="closeModal">
+                Close
+            </button>
+        </template>
+    </ModalCard>
+</template>
+
+<style scoped lang="scss">
+
+</style>

--- a/src/components/modals/launch-type/LaunchTypeModal.vue
+++ b/src/components/modals/launch-type/LaunchTypeModal.vue
@@ -66,7 +66,7 @@ async function updateAndClose() {
               <strong class="tag">{{ determinedLaunchType }}</strong>
               mode.
           </p>
-          <div v-if="determinedLaunchType === LaunchType.PROTON && !wrapperProvided" class="margin-top">
+          <div v-if="determinedLaunchType === LaunchType.NATIVE && !wrapperProvided" class="margin-top">
             <p>
               We were unable to determine if the required wrapper arguments have been set.
             </p>

--- a/src/components/modals/launch-type/LaunchTypeModal.vue
+++ b/src/components/modals/launch-type/LaunchTypeModal.vue
@@ -9,7 +9,7 @@ import {getLaunchType, LaunchType} from "../../../model/real_enums/launch/Launch
 import {areWrapperArgumentsProvided, getDeterminedLaunchType, getWrapperLaunchArgs} from "../../../utils/LaunchUtils";
 import EnumResolver from "../../../model/enums/_EnumResolver";
 import CopyToClipboardButton from "../../buttons/CopyToClipboardButton.vue";
-import ManagerSettings from "src/r2mm/manager/ManagerSettings";
+import ManagerSettings from "../../../r2mm/manager/ManagerSettings";
 
 const store = getStore<State>();
 

--- a/src/components/modals/launch-type/LaunchTypeModal.vue
+++ b/src/components/modals/launch-type/LaunchTypeModal.vue
@@ -8,13 +8,10 @@ import {State} from "../../../store";
 import {getLaunchType, LaunchType} from "../../../model/real_enums/launch/LaunchType";
 import {areWrapperArgumentsProvided, getDeterminedLaunchType, getWrapperLaunchArgs} from "../../../utils/LaunchUtils";
 import EnumResolver from "../../../model/enums/_EnumResolver";
-import CopyToClipboardButton from "components/buttons/CopyToClipboardButton.vue";
+import CopyToClipboardButton from "../../buttons/CopyToClipboardButton.vue";
+import ManagerSettings from "src/r2mm/manager/ManagerSettings";
 
 const store = getStore<State>();
-
-function closeModal() {
-    LaunchTypeModalOpen.value = false;
-}
 
 const activeGame = computed<Game>(() => store.state.activeGame);
 const launchOption = ref<string>(LaunchType.AUTO);
@@ -32,7 +29,17 @@ watchEffect(async () => {
 })
 
 getLaunchType(activeGame.value)
-    .then(launchType => launchOption.value = launchType)
+    .then(launchType => launchOption.value = LaunchType[launchType]);
+
+function closeModal() {
+  LaunchTypeModalOpen.value = false;
+}
+
+async function updateAndClose() {
+  const settings = await ManagerSettings.getSingleton(activeGame.value);
+  await settings.setLaunchType(launchOption.value);
+  closeModal();
+}
 
 </script>
 
@@ -79,8 +86,8 @@ getLaunchType(activeGame.value)
           </div>
         </template>
         <template v-slot:footer>
-            <button class="button is-info" @click="closeModal">
-                Close
+            <button class="button is-info" @click="updateAndClose">
+                Update
             </button>
         </template>
     </ModalCard>

--- a/src/components/modals/launch-type/LaunchTypeModal.vue
+++ b/src/components/modals/launch-type/LaunchTypeModal.vue
@@ -8,6 +8,7 @@ import {State} from "../../../store";
 import {getLaunchType, LaunchType} from "../../../model/real_enums/launch/LaunchType";
 import {areWrapperArgumentsProvided, getDeterminedLaunchType, getWrapperLaunchArgs} from "../../../utils/LaunchUtils";
 import EnumResolver from "../../../model/enums/_EnumResolver";
+import CopyToClipboardButton from "components/buttons/CopyToClipboardButton.vue";
 
 const store = getStore<State>();
 
@@ -71,10 +72,9 @@ getLaunchType(activeGame.value)
               </code>
             </div>
             <div class="margin-top">
-              <button class="button">
-                <i class="fas fa-clipboard"></i>
-                <span class="margin-left--half-width smaller-font">Copy launch arguments</span>
-              </button>
+              <CopyToClipboardButton :copy-value="launchArgs">
+                Copy launch arguments
+              </CopyToClipboardButton>
             </div>
           </div>
         </template>

--- a/src/components/modals/launch-type/LaunchTypeRefs.ts
+++ b/src/components/modals/launch-type/LaunchTypeRefs.ts
@@ -1,0 +1,3 @@
+import { ref } from "vue";
+
+export const LaunchTypeModalOpen = ref(false);

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -17,9 +17,8 @@ import { computed, getCurrentInstance, onMounted, ref, watch } from 'vue';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
 import VueRouter from 'vue-router';
-import {getLaunchType} from "src/model/real_enums/launch/LaunchType";
-import {LaunchTypeModalOpen} from "components/modals/launch-type/LaunchTypeRefs";
-import * as process from "process";
+import {getLaunchType} from "../../model/real_enums/launch/LaunchType";
+import {LaunchTypeModalOpen} from "../../components/modals/launch-type/LaunchTypeRefs";
 
 const store = getStore<State>();
 let router!: VueRouter;

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -17,7 +17,7 @@ import { computed, getCurrentInstance, onMounted, ref, watch } from 'vue';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
 import VueRouter from 'vue-router';
-import {getLaunchType} from "../../model/real_enums/launch/LaunchType";
+import {getLaunchType, LaunchType} from "../../model/real_enums/launch/LaunchType";
 import {LaunchTypeModalOpen} from "../../components/modals/launch-type/LaunchTypeRefs";
 
 const store = getStore<State>();
@@ -350,7 +350,7 @@ onMounted(async () => {
                 'Select specific launch behaviour such as forcing Steam to launch with Proton',
                 async () => {
                     const launchType = await getLaunchType(activeGame.value);
-                    return `The current launch behaviour is set to: ${launchType}`;
+                    return `The current launch behaviour is set to: ${LaunchType[launchType]}`;
                 },
                 'fa-gamepad',
                 () => {

--- a/src/components/settings-components/SettingsView.vue
+++ b/src/components/settings-components/SettingsView.vue
@@ -17,6 +17,9 @@ import { computed, getCurrentInstance, onMounted, ref, watch } from 'vue';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
 import VueRouter from 'vue-router';
+import {getLaunchType} from "src/model/real_enums/launch/LaunchType";
+import {LaunchTypeModalOpen} from "components/modals/launch-type/LaunchTypeRefs";
+import * as process from "process";
 
 const store = getStore<State>();
 let router!: VueRouter;
@@ -338,6 +341,24 @@ onMounted(async () => {
                 () => emitInvoke('ValidateSteamInstallation')
             )
         )
+    }
+
+    if (['linux', 'darwin'].includes(process.platform) && activeGame.value.activePlatform.storePlatform === Platform.STEAM) {
+        settingsList.push(
+            new SettingsRow(
+                'Debugging',
+                'Change launch behaviour',
+                'Select specific launch behaviour such as forcing Steam to launch with Proton',
+                async () => {
+                    const launchType = await getLaunchType(activeGame.value);
+                    return `The current launch behaviour is set to: ${launchType}`;
+                },
+                'fa-gamepad',
+                () => {
+                    LaunchTypeModalOpen.value = true;
+                }
+            )
+        );
     }
     settingsList = settingsList.sort((a, b) => a.action.localeCompare(b.action));
     searchableSettings.value = settingsList;

--- a/src/model/enums/_EnumResolver.ts
+++ b/src/model/enums/_EnumResolver.ts
@@ -1,11 +1,13 @@
 export default class EnumResolver {
 
-    public static from(enumSet: {[key: string]: any}, value: any) {
+    public static from<T>(enumSet: {[key: string]: any}, value: any): T {
         for(const enumIndex in enumSet) {
             if (enumSet[enumIndex] === value) {
-                return enumIndex;
+                return enumIndex as unknown as T;
             }
         }
+        const keys = Object.keys(enumSet).join(", ");
+        throw new Error(`Unknown value: ${value}. Not in keys of: ${keys}`);
     }
 
 }

--- a/src/model/real_enums/launch/LaunchType.ts
+++ b/src/model/real_enums/launch/LaunchType.ts
@@ -18,5 +18,5 @@ export async function getLaunchType(game: Game) {
             return EnumResolver.from<LaunchType>(LaunchType, settings.getContext().gameSpecific.launchType);
         }
     }
-    return LaunchType.AUTO;
+    return EnumResolver.from<LaunchType>(LaunchType, LaunchType.AUTO);
 }

--- a/src/model/real_enums/launch/LaunchType.ts
+++ b/src/model/real_enums/launch/LaunchType.ts
@@ -1,0 +1,22 @@
+import Game from "../../game/Game";
+import {Platform} from "../../../assets/data/ecosystemTypes";
+import ManagerSettings from "../../../r2mm/manager/ManagerSettings";
+import EnumResolver from "../../enums/_EnumResolver";
+
+export enum LaunchType {
+    // AUTO implies Manager determines the best option
+    AUTO = "Auto",
+    NATIVE = "Native",
+    PROTON = "Proton",
+}
+
+export async function getLaunchType(game: Game) {
+    if (game.activePlatform.storePlatform === Platform.STEAM) {
+        const settings = await ManagerSettings.getSingleton(game);
+        const savedLaunchType = settings.getContext().gameSpecific.launchType;
+        if (savedLaunchType !== undefined) {
+            return EnumResolver.from<LaunchType>(LaunchType, settings.getContext().gameSpecific.launchType);
+        }
+    }
+    return LaunchType.AUTO;
+}

--- a/src/model/real_enums/launch/LaunchType.ts
+++ b/src/model/real_enums/launch/LaunchType.ts
@@ -15,7 +15,7 @@ export async function getLaunchType(game: Game) {
         const settings = await ManagerSettings.getSingleton(game);
         const savedLaunchType = settings.getContext().gameSpecific.launchType;
         if (savedLaunchType !== undefined) {
-            return EnumResolver.from<LaunchType>(LaunchType, settings.getContext().gameSpecific.launchType);
+            return EnumResolver.from<LaunchType>(LaunchType, savedLaunchType);
         }
     }
     return EnumResolver.from<LaunchType>(LaunchType, LaunchType.AUTO);

--- a/src/pages/LinuxNativeGameSetup.vue
+++ b/src/pages/LinuxNativeGameSetup.vue
@@ -17,14 +17,12 @@
 </template>
 
 <script lang='ts' setup>
-import PathResolver from '../r2mm/manager/PathResolver';
 import { Hero } from '../components/all';
-import * as path from 'path';
 import { computed, getCurrentInstance, onMounted, ref } from 'vue';
 import { getStore } from '../providers/generic/store/StoreProvider';
 import { State } from '../store';
 import VueRouter from 'vue-router';
-import {getWrapperLaunchArgs} from "src/utils/LaunchUtils";
+import {getWrapperLaunchArgs} from "../utils/LaunchUtils";
 
 const store = getStore<State>();
 let router!: VueRouter;

--- a/src/pages/LinuxNativeGameSetup.vue
+++ b/src/pages/LinuxNativeGameSetup.vue
@@ -7,7 +7,7 @@
 			This needs to be done because of how the BepInEx injection works on Unix systems.<br/>
 			<br/>
 			Please copy and paste the following to your {{ activeGame }} launch options:<br/>
-			<code ref="copyableArgs">{{ launchArgs }} %command%</code>
+			<code ref="copyableArgs">{{ launchArgs }}</code>
 			<br/>
 			<br/>
 			<a ref="copyAction" class="button margin-right margin-right--half-width" @click="copy">Copy to clipboard</a>
@@ -24,6 +24,7 @@ import { computed, getCurrentInstance, onMounted, ref } from 'vue';
 import { getStore } from '../providers/generic/store/StoreProvider';
 import { State } from '../store';
 import VueRouter from 'vue-router';
+import {getWrapperLaunchArgs} from "src/utils/LaunchUtils";
 
 const store = getStore<State>();
 let router!: VueRouter;
@@ -35,8 +36,10 @@ onMounted(() => {
 const copyableArgs = ref<HTMLInputElement>();
 const copyAction = ref<HTMLElement>();
 
+const launchArgs = ref<string>("");
+getWrapperLaunchArgs().then(value => launchArgs.value = value);
+
 const activeGame = computed(() => store.state.activeGame.displayName);
-const launchArgs = computed(() => `"${path.join(PathResolver.MOD_ROOT, process.platform === 'darwin' ? 'macos_proxy' : 'linux_wrapper.sh')}"`);
 const platformName = computed<string>(() => process.platform === 'darwin' ? 'macOS' : process.platform);
 
 function copy(){

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -128,6 +128,7 @@
         <DownloadProgressModal />
         <DownloadModVersionSelectModal />
         <UpdateAllInstalledModsModal />
+        <LaunchTypeModal/>
 
         <div class="router-view">
             <router-view name="subview" v-on:setting-invoked="handleSettingsCallbacks($event)" />
@@ -167,6 +168,7 @@ import UpdateAllInstalledModsModal from '../components/views/UpdateAllInstalledM
 import { getStore } from '../providers/generic/store/StoreProvider';
 import { State } from '../store';
 import VueRouter from 'vue-router';
+import LaunchTypeModal from "components/modals/launch-type/LaunchTypeModal.vue";
 
 const store = getStore<State>();
 let router!: VueRouter;
@@ -538,7 +540,7 @@ async function handleSettingsCallbacks(invokedSetting: any) {
 store.dispatch('profile/loadOrderingSettings');
 store.commit('modFilters/reset');
 
-onMounted(() => {
+onMounted(async () => {
     router = getCurrentInstance()!.proxy.$router;
     launchParametersModel.value = settings.value.getContext().gameSpecific.launchParameters;
     isManagerUpdateAvailable();

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -168,7 +168,7 @@ import UpdateAllInstalledModsModal from '../components/views/UpdateAllInstalledM
 import { getStore } from '../providers/generic/store/StoreProvider';
 import { State } from '../store';
 import VueRouter from 'vue-router';
-import LaunchTypeModal from "components/modals/launch-type/LaunchTypeModal.vue";
+import LaunchTypeModal from "../components/modals/launch-type/LaunchTypeModal.vue";
 
 const store = getStore<State>();
 let router!: VueRouter;

--- a/src/pages/Manager.vue
+++ b/src/pages/Manager.vue
@@ -128,7 +128,7 @@
         <DownloadProgressModal />
         <DownloadModVersionSelectModal />
         <UpdateAllInstalledModsModal />
-        <LaunchTypeModal/>
+        <LaunchTypeModal v-if="canRenderLaunchTypeModal"/>
 
         <div class="router-view">
             <router-view name="subview" v-on:setting-invoked="handleSettingsCallbacks($event)" />
@@ -189,6 +189,10 @@ const activeGame = computed(() => store.state.activeGame);
 const settings = computed(() => store.getters['settings']);
 const profile = computed(() => store.getters['profile/activeProfile']);
 const localModList = computed(() => store.state.profile.modList);
+
+function canRenderLaunchTypeModal() {
+    return ['linux', 'darwin'].includes(process.platform);
+}
 
 function closeSteamInstallationValidationModal() {
     isValidatingSteamInstallation.value = false;

--- a/src/pages/Splash.vue
+++ b/src/pages/Splash.vue
@@ -132,7 +132,7 @@ import { State } from '../store';
 import { getStore } from '../providers/generic/store/StoreProvider';
 import VueRouter from 'vue-router';
 import { useSplashComposable } from '../components/composables/SplashComposable';
-import { isProtonRequired } from '../utils/LaunchUtils';
+import {areWrapperArgumentsProvided, isProtonRequired} from '../utils/LaunchUtils';
 
 const store = getStore<State>();
 let router!: VueRouter;
@@ -172,9 +172,7 @@ async function moveToNextScreen() {
         if (!(await isProtonRequired(activeGame))) {
             console.log('Not proton game');
             await ensureWrapperInGameFolder();
-            const launchArgs = await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).getLaunchArgs(activeGame);
-            console.log(`Launch arguments for this game:`, launchArgs);
-            if (typeof launchArgs === 'string' && !launchArgs.startsWith(path.join(PathResolver.MOD_ROOT, 'linux_wrapper.sh'))) {
+            if (!(await areWrapperArgumentsProvided(activeGame))) {
                 router.push({name: 'linux'});
                 return;
             }

--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
@@ -12,6 +12,7 @@ import { exec } from 'child_process';
 import GameInstructions from '../../instructions/GameInstructions';
 import GameInstructionParser from '../../instructions/GameInstructionParser';
 import { PackageLoader } from '../../../../model/schema/ThunderstoreSchema';
+import {isProtonRequired} from "src/utils/LaunchUtils";
 
 export default class SteamGameRunner_Linux extends GameRunnerProvider {
 
@@ -22,7 +23,7 @@ export default class SteamGameRunner_Linux extends GameRunnerProvider {
 
     public async startModded(game: Game, profile: Profile): Promise<void | R2Error> {
 
-        const isProton = await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).isProtonGame(game);
+        const isProton = await isProtonRequired(game);
         if (isProton instanceof R2Error) {
             return isProton;
         }

--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
@@ -12,7 +12,7 @@ import { exec } from 'child_process';
 import GameInstructions from '../../instructions/GameInstructions';
 import GameInstructionParser from '../../instructions/GameInstructionParser';
 import { PackageLoader } from '../../../../model/schema/ThunderstoreSchema';
-import {isProtonRequired} from "src/utils/LaunchUtils";
+import {isProtonRequired} from "../../../../utils/LaunchUtils";
 
 export default class SteamGameRunner_Linux extends GameRunnerProvider {
 

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -7,6 +7,7 @@ import SettingsDexieStore, { ManagerSettingsInterfaceHolder } from './SettingsDe
 import Game from '../../model/game/Game';
 import { Platform } from '../../model/schema/ThunderstoreSchema';
 import { GameSelectionViewMode } from '../../model/enums/GameSelectionViewMode';
+import {LaunchType} from "src/model/real_enums/launch/LaunchType";
 
 export default class ManagerSettings {
 
@@ -164,6 +165,10 @@ export default class ManagerSettings {
         }
     }
 
+    public getLaunchType(): LaunchType {
+        return EnumResolver.from<LaunchType>(LaunchType, ManagerSettings.CONTEXT.gameSpecific.launchType);
+    }
+
     public async setInstalledDisablePosition(disablePosition: string) {
         ManagerSettings.CONTEXT.gameSpecific.installedDisablePosition = EnumResolver.from(SortLocalDisabledMods, disablePosition)!;
         await this.save();
@@ -195,6 +200,11 @@ export default class ManagerSettings {
 
     public async setGameSelectionViewMode(viewMode: GameSelectionViewMode) {
         ManagerSettings.CONTEXT.global.gameSelectionViewMode = viewMode;
+        await this.save();
+    }
+
+    public async setLaunchType(launchType: LaunchType) {
+        ManagerSettings.CONTEXT.gameSpecific.launchType = launchType;
         await this.save();
     }
 }

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -165,8 +165,11 @@ export default class ManagerSettings {
         }
     }
 
-    public getLaunchType(): LaunchType {
-        return EnumResolver.from<LaunchType>(LaunchType, ManagerSettings.CONTEXT.gameSpecific.launchType);
+    public getLaunchType(): LaunchType | undefined {
+        if (ManagerSettings.CONTEXT.gameSpecific.launchType) {
+            return EnumResolver.from<LaunchType>(LaunchType, ManagerSettings.CONTEXT.gameSpecific.launchType);
+        }
+        return undefined;
     }
 
     public async setInstalledDisablePosition(disablePosition: string) {

--- a/src/r2mm/manager/ManagerSettings.ts
+++ b/src/r2mm/manager/ManagerSettings.ts
@@ -7,7 +7,7 @@ import SettingsDexieStore, { ManagerSettingsInterfaceHolder } from './SettingsDe
 import Game from '../../model/game/Game';
 import { Platform } from '../../model/schema/ThunderstoreSchema';
 import { GameSelectionViewMode } from '../../model/enums/GameSelectionViewMode';
-import {LaunchType} from "src/model/real_enums/launch/LaunchType";
+import { LaunchType } from "../../model/real_enums/launch/LaunchType";
 
 export default class ManagerSettings {
 

--- a/src/r2mm/manager/SettingsDexieStore.ts
+++ b/src/r2mm/manager/SettingsDexieStore.ts
@@ -7,6 +7,7 @@ import { SortLocalDisabledMods } from '../../model/real_enums/sort/SortLocalDisa
 import { Platform } from '../../model/schema/ThunderstoreSchema';
 import { GameSelectionViewMode } from '../../model/enums/GameSelectionViewMode';
 import GameManager from '../../model/game/GameManager'
+import {LaunchType} from "../../model/real_enums/launch/LaunchType";
 
 export const SETTINGS_DB_NAME = "settings";
 
@@ -129,7 +130,8 @@ export default class SettingsDexieStore extends Dexie {
                 installedSortDirection: EnumResolver.from(SortDirection, SortDirection.STANDARD)!,
                 lastSelectedProfile: "Default",
                 launchParameters: "",
-                linkedFiles: []
+                linkedFiles: [],
+                launchType: LaunchType.AUTO,
             }
         }
     }
@@ -211,6 +213,7 @@ export interface ManagerSettingsInterfaceGame_V2 {
     installedSortBy: string;
     installedSortDirection: string;
     installedDisablePosition: string;
+    launchType: string;
 }
 
 /**

--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -12,6 +12,8 @@ import Game from '../../../model/game/Game';
 import GameManager from '../../../model/game/GameManager';
 import { getPropertyFromPath } from '../../../utils/Common';
 import DepotLoader from '../../../depots/loader/DepotLoader';
+import {getLaunchType, LaunchType} from "src/model/real_enums/launch/LaunchType";
+import EnumResolver from "src/model/enums/_EnumResolver";
 
 const FORCE_PROTON_FILENAME = ".forceproton";
 
@@ -96,6 +98,13 @@ export default class GameDirectoryResolverImpl extends GameDirectoryResolverProv
     }
 
     public async isProtonGame(game: Game) {
+
+        // Skip isProtonGame check if user has explicitly declared launch behaviour.
+        const manualLaunchType = await getLaunchType(game);
+        if (manualLaunchType !== EnumResolver.from<LaunchType>(LaunchType, LaunchType.AUTO)) {
+            return manualLaunchType === EnumResolver.from<LaunchType>(LaunchType, LaunchType.PROTON);
+        }
+
         try {
             if (await this._isProtonForced(game)) {
                 console.log(`Proton was forced due to presence of ${FORCE_PROTON_FILENAME} file`);

--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -12,8 +12,8 @@ import Game from '../../../model/game/Game';
 import GameManager from '../../../model/game/GameManager';
 import { getPropertyFromPath } from '../../../utils/Common';
 import DepotLoader from '../../../depots/loader/DepotLoader';
-import {getLaunchType, LaunchType} from "src/model/real_enums/launch/LaunchType";
-import EnumResolver from "src/model/enums/_EnumResolver";
+import {getLaunchType, LaunchType} from "../../../model/real_enums/launch/LaunchType";
+import EnumResolver from "../../../model/enums/_EnumResolver";
 
 const FORCE_PROTON_FILENAME = ".forceproton";
 

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -10,8 +10,7 @@ import {Platform} from '../assets/data/ecosystemTypes';
 import LinuxGameDirectoryResolver from '../r2mm/manager/linux/GameDirectoryResolver';
 import {LaunchType} from "../model/real_enums/launch/LaunchType";
 import path from "path";
-import PathResolver from "src/r2mm/manager/PathResolver";
-import {computed} from "vue";
+import PathResolver from "../r2mm/manager/PathResolver";
 
 export enum LaunchMode { VANILLA, MODDED };
 

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -8,7 +8,7 @@ import ManagerSettings from '../r2mm/manager/ManagerSettings';
 import ModLinker from '../r2mm/manager/ModLinker';
 import {Platform} from '../assets/data/ecosystemTypes';
 import LinuxGameDirectoryResolver from '../r2mm/manager/linux/GameDirectoryResolver';
-import {LaunchType} from "src/model/real_enums/launch/LaunchType";
+import {LaunchType} from "../model/real_enums/launch/LaunchType";
 
 export enum LaunchMode { VANILLA, MODDED };
 

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -1,4 +1,4 @@
-import Profile, { ImmutableProfile } from '../model/Profile';
+import Profile, {ImmutableProfile} from '../model/Profile';
 import R2Error from '../model/errors/R2Error';
 import Game from '../model/game/Game';
 import FsProvider from '../providers/generic/file/FsProvider';
@@ -6,8 +6,9 @@ import GameRunnerProvider from '../providers/generic/game/GameRunnerProvider';
 import GameDirectoryResolverProvider from '../providers/ror2/game/GameDirectoryResolverProvider';
 import ManagerSettings from '../r2mm/manager/ManagerSettings';
 import ModLinker from '../r2mm/manager/ModLinker';
-import { Platform } from '../assets/data/ecosystemTypes';
+import {Platform} from '../assets/data/ecosystemTypes';
 import LinuxGameDirectoryResolver from '../r2mm/manager/linux/GameDirectoryResolver';
+import {LaunchType} from "src/model/real_enums/launch/LaunchType";
 
 export enum LaunchMode { VANILLA, MODDED };
 
@@ -74,4 +75,14 @@ export async function isProtonRequired(activeGame: Game) {
     return [Platform.STEAM, Platform.STEAM_DIRECT].includes(activeGame.activePlatform.storePlatform)
         ? await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).isProtonGame(activeGame)
         : false;
+}
+
+export async function getDeterminedLaunchType(game: Game, launchType: LaunchType): Promise<LaunchType> {
+    if (launchType !== LaunchType.AUTO) {
+        return launchType;
+    }
+    if (await isProtonRequired(game)) {
+        return LaunchType.PROTON;
+    }
+    return LaunchType.NATIVE;
 }

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -68,6 +68,9 @@ export const throwIfNoGameDir = async (game: Game): Promise<void> => {
 };
 
 export async function isProtonRequired(activeGame: Game) {
+    if (process.platform !== 'linux') {
+        return false;
+    }
     return [Platform.STEAM, Platform.STEAM_DIRECT].includes(activeGame.activePlatform.storePlatform)
         ? await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).isProtonGame(activeGame)
         : false;

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -9,6 +9,9 @@ import ModLinker from '../r2mm/manager/ModLinker';
 import {Platform} from '../assets/data/ecosystemTypes';
 import LinuxGameDirectoryResolver from '../r2mm/manager/linux/GameDirectoryResolver';
 import {LaunchType} from "../model/real_enums/launch/LaunchType";
+import path from "path";
+import PathResolver from "src/r2mm/manager/PathResolver";
+import {computed} from "vue";
 
 export enum LaunchMode { VANILLA, MODDED };
 
@@ -85,4 +88,15 @@ export async function getDeterminedLaunchType(game: Game, launchType: LaunchType
         return LaunchType.PROTON;
     }
     return LaunchType.NATIVE;
+}
+
+export async function areWrapperArgumentsProvided(game: Game): Promise<boolean> {
+    return Promise.resolve()
+        .then(async () => await (GameDirectoryResolverProvider.instance as LinuxGameDirectoryResolver).getLaunchArgs(game))
+        .then(launchArgs => typeof launchArgs === 'string' && launchArgs.startsWith(path.join(PathResolver.MOD_ROOT, 'linux_wrapper.sh')))
+        .catch(() => false);
+}
+
+export async function getWrapperLaunchArgs(): Promise<string> {
+    return `"${path.join(PathResolver.MOD_ROOT, process.platform === 'darwin' ? 'macos_proxy' : 'linux_wrapper.sh')}" %command%`;
 }


### PR DESCRIPTION
The previous expected behaviour was to include a `.forceproton` file in the game directory to enable launching the game with Proton. Great, except not entirely. It was obscure and if the manager detected it as a proton game and you wanted it to launch natively then you were out of luck.

This new behaviour gives the user more control and shows exactly which option we're doing when we resolve things ourselves.

This will only appear on non-Windows platforms, and only when the `Steam` platform is selected. Proton also doesn't apply to non-Steam games (to my knowledge) and so it doesn't make sense to include it for any other platform selection.

<img width="691" height="580" alt="image" src="https://github.com/user-attachments/assets/871eb4dc-2c4a-475d-a7a8-c8b760f9bec2" />

<img width="719" height="530" alt="image" src="https://github.com/user-attachments/assets/f3127bd5-5007-46a9-9f02-b6275e807b5b" />

<img width="689" height="319" alt="image" src="https://github.com/user-attachments/assets/4edffa13-4b85-4641-a4d5-9a2144e8757f" />
