### PR TITLE
Improve single select configs

### DIFF
--- a/src/components/config-components/ConfigEntryEditor.vue
+++ b/src/components/config-components/ConfigEntryEditor.vue
@@ -41,6 +41,11 @@
                             <template v-if="entry.displayType === 'single-select' || entry.displayType === 'boolean'">
                                 <div class="settings-input-container">
                                     <select class="select select--full" v-model="entry.value">
+                                        <template v-if="!getSelectOptions(entry).includes(entry.value)">
+                                            <option :value="entry.value">
+                                                {{ entry.value }}
+                                            </option>
+                                        </template>
                                         <option v-for="(opt, optIndex) in getSelectOptions(entry)" :value="opt">
                                             {{ opt }}
                                         </option>

--- a/src/utils/ConfigUtils.ts
+++ b/src/utils/ConfigUtils.ts
@@ -137,7 +137,7 @@ export function getSelectOptions(entry: ConfigurationEntry): string[] {
     if (!acceptableValuesComment) {
         throw new Error(`Could not find metadata comment for acceptable values on entry: ${entry.entryName}`);
     }
-    return acceptableValuesComment.rawValue.substring("# Acceptable values: ".length).split(",").map(value => value.trim());
+    return acceptableValuesComment.rawValue.substring("# Acceptable values: ".length).split(",").map(value => value.trim()).sort();
 }
 
 export async function saveConfigurationFile(configurationFile: ConfigurationFile) {


### PR DESCRIPTION
Adds two changes for single select style config entries:
- When a value is encountered that is not part of the acceptable values, it's displayed as a temporary option that is selected by default. It disappears when selecting another valid option.
- The list of acceptable values is sorted alphabetically. In the case of enums like KeyCode, this should make it easier to find a specific enum value if you know what you're looking for.
