### PR TITLE
Include settingsIdentifier in Error when saving game settings fail

### DIFF
--- a/src/r2mm/manager/SettingsDexieStore.ts
+++ b/src/r2mm/manager/SettingsDexieStore.ts
@@ -147,7 +147,16 @@ export default class SettingsDexieStore extends Dexie {
             });
 
             // Update the active game's settings.
-            await this.games.put({ identifier: this.activeGame.settingsIdentifier, settings: JSON.stringify(holder.gameSpecific) });
+            try {
+                await this.games.put({
+                    identifier: this.activeGame.settingsIdentifier,
+                    settings: JSON.stringify(holder.gameSpecific)
+                });
+            } catch (e) {
+                throw new Error(
+                    `IDB.Put fail for key "${this.activeGame.settingsIdentifier}": ${e}`
+                );
+            }
         }
 
         await this.transaction("rw!", this.global, this.games, update);


### PR DESCRIPTION
This is to shed some light to the error "Failed to execute 'put' on 'IDBObjectStore': Evaluating the object store's key path yielded a value that is not a valid key." that's seen in production.

The problem might be related to changes done when the mod manager was changed to read the game configs from Thunderstore ecosystem schema. Or it might be caused by users who mess up their Vuex store state by using mouse to navigate back in history, although I think that should cause a different error, but it might be eater up by IndexedDB.