### PR TITLE
Add GodotML v7 support to GodotMLInstaller

### DIFF
--- a/src/installers/GodotMLInstaller.ts
+++ b/src/installers/GodotMLInstaller.ts
@@ -1,23 +1,34 @@
-import { InstallArgs, PackageInstaller } from "./PackageInstaller";
-import path from "path";
-import FsProvider from "../providers/generic/file/FsProvider";
+import path from 'path';
+
+import { InstallArgs, PackageInstaller } from './PackageInstaller';
+import FileWriteError from '../model/errors/FileWriteError';
+import FsProvider from '../providers/generic/file/FsProvider';
+import FileUtils from '../utils/FileUtils';
+
 
 export class GodotMLInstaller implements PackageInstaller {
+    // JSON_Schema_Validator present on v7.0.1+ only.
+    private static readonly TRACKED = ['mod_loader', 'JSON_Schema_Validator']
+
     /**
      * Handles installation of GodotML
      */
     async install(args: InstallArgs) {
         const { packagePath, profile } = args;
 
-        const copyFrom = path.join(packagePath, "addons", "mod_loader");
-        const copyTo = profile.joinToProfilePath("addons", "mod_loader");
-        const fs = FsProvider.instance;
+        try {
+            for (const fileOrFolder of GodotMLInstaller.TRACKED) {
+                const copyFrom = path.join(packagePath, 'addons', fileOrFolder);
 
-        if (await fs.exists(copyFrom)) {
-            if (!await fs.exists(copyTo)) {
-                await fs.mkdirs(copyTo);
+                if (!await FsProvider.instance.exists(copyFrom)) {
+                    continue;
+                }
+
+                const copyTo = profile.joinToProfilePath('addons', fileOrFolder);
+                await FileUtils.copyFileOrFolder(copyFrom, copyTo);
             }
-            await fs.copyFolder(copyFrom, copyTo);
+        } catch (e) {
+            throw FileWriteError.fromThrownValue(e, 'Failed to install GodotML');
         }
     }
 }


### PR DESCRIPTION
The mod loader package now contains an extra folder which needs to be copied when the mod loader is installed.