### PR TITLE
Fix bepisloader launch arguments

### DIFF
--- a/src/r2mm/launching/instructions/instructions/loader/BepisLoaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/BepisLoaderGameInstructions.ts
@@ -17,12 +17,12 @@ export default class BepisLoaderGameInstructions extends GameInstructionGenerato
                 extraArguments += ` --server`;
             }
             if (await FsProvider.instance.exists(Profile.getActiveProfile().joinToProfilePath("unstripped_corlib"))) {
-                extraArguments += ` --doorstop-mono-dll-search-path-override "${DynamicGameInstruction.BEPINEX_CORLIBS}"`;
+                extraArguments += ` --doorstop-dll-search-override "${DynamicGameInstruction.BEPINEX_CORLIBS}"`;
             }
         }
         return {
-            moddedParameters: `--hookfxr-enable --bepinex-target ${path.join(DynamicGameInstruction.PROFILE_DIRECTORY, 'BepInEx')} --doorstop-enabled true --doorstop-target-assembly "${DynamicGameInstruction.BEPINEX_RENDERER_PRELOADER_PATH}"${extraArguments.trimEnd()}`,
-            vanillaParameters: `--hookfxr-disable --doorstop-enabled true`
+            moddedParameters: `--hookfxr-enable --bepinex-target ${path.join(DynamicGameInstruction.PROFILE_DIRECTORY, 'BepInEx')} --doorstop-enable true --doorstop-target "${DynamicGameInstruction.BEPINEX_RENDERER_PRELOADER_PATH}"${extraArguments.trimEnd()}`,
+            vanillaParameters: `--doorstop-enable false --hookfxr-disable`
         };
     }
 

--- a/src/r2mm/launching/instructions/instructions/loader/BepisLoaderGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/BepisLoaderGameInstructions.ts
@@ -21,7 +21,7 @@ export default class BepisLoaderGameInstructions extends GameInstructionGenerato
             }
         }
         return {
-            moddedParameters: `--hookfxr-enable --bepinex-target ${path.join(DynamicGameInstruction.PROFILE_DIRECTORY, 'BepInEx')} --doorstop-enable true --doorstop-target "${DynamicGameInstruction.BEPINEX_RENDERER_PRELOADER_PATH}"${extraArguments.trimEnd()}`,
+            moddedParameters: `--hookfxr-enable --bepinex-target "${path.join(DynamicGameInstruction.PROFILE_DIRECTORY, 'BepInEx')}" --doorstop-enable true --doorstop-target "${DynamicGameInstruction.BEPINEX_RENDERER_PRELOADER_PATH}"${extraArguments.trimEnd()}`,
             vanillaParameters: `--doorstop-enable false --hookfxr-disable`
         };
     }


### PR DESCRIPTION
Fixes BepisLoader launch issues in Resonite:

* Properly quotes the `--bepinex-target` path so launches no longer fail when spaces are present.
* Reverts Doorstop V4 parameter changes (`--doorstop-enabled` / `--doorstop-target-assembly`) that broke compatibility, restoring the correct arguments (`--doorstop-enable` / `--doorstop-target`).