### PR TITLE
NSFW Indicator + Collapse

### DIFF
--- a/src/components/v2/OnlinePreviewPanel.vue
+++ b/src/components/v2/OnlinePreviewPanel.vue
@@ -33,7 +33,6 @@ const activeTab = ref<"README" | "CHANGELOG" | "Dependencies">("README");
 const loadingPanel = ref<boolean>(true);
 const dependencies = ref<ThunderstoreMod[]>([]);
 const isNsfw = computed<boolean>(() => props.mod?.getNsfwFlag())
-const isPackagePreviewExpanded = ref<boolean>(true);
 
 const maxPanelWidth = ref(getMaxPanelWidth());
 
@@ -196,7 +195,7 @@ function dragEnd(event: DragEvent) {
                 <h2 class="subtitle">
                     By {{ mod.getOwner() }}
                 </h2>
-                <details id="package-preview-details">
+                <details id="package-preview-details" open="true">
                     <summary class='card-timestamp non-selectable'>Package information</summary>
                     <div class="notification is-warning margin-top" v-if="isNsfw">
                         <p>This mod may contain potentially explicit material</p>

--- a/src/components/views/OnlineModListWithPanel.vue
+++ b/src/components/views/OnlineModListWithPanel.vue
@@ -29,6 +29,9 @@
                 <span class='card-header-icon' v-if="isThunderstoreModInstalled(key) && !readOnly">
                     <i class='fas fa-check' v-tooltip.left="'Mod already installed'"></i>
                 </span>
+                <span class='card-header-icon' v-if="key.getNsfwFlag()">
+                    <i class="fas fa-pause-circle" v-tooltip.left="'Mod marked as NSFW'"></i>
+                </span>
             </template>
         </OnlineRowCard>
     </div>


### PR DESCRIPTION
- Adds a NSFW banner and mod icon
- Surround package metadata in a details/summary combination to collapse content if too large.

<img width="1432" height="819" alt="image" src="https://github.com/user-attachments/assets/b96db704-1d68-4fb1-86cc-69f986180519" />
