### PR TITLE
Added EGS game launch args resolution

### DIFF
--- a/src/r2mm/launching/runners/multiplatform/EgsGameRunner.ts
+++ b/src/r2mm/launching/runners/multiplatform/EgsGameRunner.ts
@@ -10,7 +10,7 @@ import { DynamicGameInstruction } from '../../instructions/DynamicGameInstructio
 import { getUnityDoorstopVersion } from '../../../../utils/UnityDoorstopUtils';
 import path from '../../../../providers/node/path/path';
 import ModLinker from '../../../../r2mm/manager/ModLinker';
-import { buildConfigurationFileFromPath, saveConfigurationFile } from 'src/utils/ConfigUtils';
+import { buildConfigurationFileFromPath, saveConfigurationFile } from '../../../../utils/ConfigUtils';
 
 export type EgsInstallationListEntry = {
     InstallLocation: string;


### PR DESCRIPTION
- Game launches again
- ModLinker is re-applied prior to game launch, meaning you don't need to click Start modded/vanilla twice to get the actual launch behaviour that you'd expect
- `Start vanilla` is now supported for Doorstop v4 on EGS