### PR TITLE
Make NodePathProvider::resolve variadic

### DIFF
--- a/src/providers/node/path/path.ts
+++ b/src/providers/node/path/path.ts
@@ -30,7 +30,7 @@ const nodePath: NodePathProvider = {
     extname: path => getImplementation().extname(path),
     basename: path => getImplementation().basename(path),
     relative: (pathOne, pathTwo) => getImplementation().relative(pathOne, pathTwo),
-    resolve: paths => getImplementation().resolve(paths),
+    resolve: (...args) => getImplementation().resolve(...args),
     get sep() { return getImplementation().sep }
 };
 


### PR DESCRIPTION
The associated node function is variadic, and this is assumed by the linux path management.

I think this partially fixes #1963, although on my local system there's another issue preventing Linux from working.