### PR TITLE
Add indicator for delisted mods

### DIFF
--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -196,6 +196,11 @@ function dependencyStringToModName(x: string) {
                     v-tooltip.right="'This mod is deprecated and could be broken'">
                     Deprecated
                 </span>
+                <span v-if="props.mod.getInstallMode() == 'managed' && !tsMod"
+                    class="tag is-warning margin-right margin-right--half-width"
+                    v-tooltip.right="'This mod was delisted and could be temporarily or permanently unavailable'">
+                    Delisted
+                </span>
                 <span v-if="!mod.isEnabled()"
                     class="tag is-warning margin-right margin-right--half-width"
                     v-tooltip.right="'This mod will not be used in-game'">


### PR DESCRIPTION
Closes #1988.

Implements a delist indicator for installed mods. A mod is considered as delisted if its install type is "managed", and a corresponding Thunderstore entry was not found for the installed mod. This likely means that the mod has either been rejected, or was delisted completely from Thunderstore.

This is an example of how it would look like with mods from the Atlyss community:
- BepInExPack, AppearancePlus by Nuilescent, CodeTalker by Robyn and EasySettings by Nessie are managed installs
- AppearancePlus is present in Thunderstore, but deprecated, so it shows up using its usual Deprecated tag
- CodeTalker has been delisted from Thunderstore, so it shows up using the new Delisted tag
<img width="565" height="310" alt="image" src="https://github.com/user-attachments/assets/759d5778-f667-4746-83ba-ff5a605b2a53" />

Delisted packages that are locally installed remain untagged, meaning an equivalent local install of CodeTalker would remain unaffected.