### PR TITLE
Local Mod List Improvements #2

### DIFF
--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -9,7 +9,7 @@ import { LogSeverity } from '../../../providers/ror2/logging/LoggerProvider';
 import Dependants from '../../../r2mm/mods/Dependants';
 import { valueToReadableDate } from '../../../utils/DateUtils';
 import { splitToNameAndVersion } from '../../../utils/DependencyUtils';
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { getStore } from '../../../providers/generic/store/StoreProvider';
 import { State } from '../../../store';
 
@@ -34,7 +34,7 @@ const isLatestVersion = computed(() => store.getters['tsMods/isLatestVersion'](p
 const localModList = computed(() => store.state.profile.modList);
 const tsMod = computed(() => store.getters['tsMods/tsMod'](props.mod));
 
-function updateDependencies() {
+async function updateDependencies() {
     if (props.mod.getDependencies().length === 0) {
         return;
     }
@@ -167,9 +167,9 @@ function viewAssociatedMods() {
     store.commit('openAssociatedModsModal', props.mod);
 }
 
-function created() {
+onMounted(() => {
     updateDependencies();
-}
+})
 
 // Need to wrap util call in method to allow access from Vue context
 function getReadableDate(value: number): string {
@@ -284,7 +284,7 @@ function dependencyStringToModName(x: string) {
             Enable {{disabledDependencies[0].getDisplayName()}}
         </a>
 
-        <DonateButton :mod="tsMod"/>
+        <DonateButton v-if="tsMod" :mod="tsMod"/>
     </ExpandableCard>
 </template>
 

--- a/src/components/views/LocalModList/LocalModDraggableList.vue
+++ b/src/components/views/LocalModList/LocalModDraggableList.vue
@@ -1,0 +1,55 @@
+<template>
+    <draggable v-model='draggableList'
+               group="local-mods"
+               handle=".handle"
+               @start="drag=store.getters['profile/canSortMods']"
+               @end="drag=false"
+               :force-fallback="true"
+               :scroll-sensitivity="100"
+               item-key="id">
+        <template #item="{element}">
+            <local-mod-card
+                :mod="element" />
+        </template>
+    </draggable>
+</template>
+<script setup lang="ts">
+import Draggable from 'vuedraggable';
+import LocalModCard from './LocalModCard.vue';
+import { computed, onMounted, ref, watch } from 'vue';
+import { getStore } from '../../../providers/generic/store/StoreProvider';
+import { State } from '../../../store';
+import ManifestV2 from '../../../model/ManifestV2';
+import R2Error from '../../../model/errors/R2Error';
+import { ImmutableProfile } from '../../../model/Profile';
+
+
+const store = getStore<State>();
+
+const profile = computed<ImmutableProfile>(() => store.getters['profile/activeProfile'].asImmutableProfile());
+
+// Hack to workaround draggable issue where the VueX update is slightly delayed, which causes a jumping effect.
+const internalVisibleList = ref<ManifestV2[]>([]);
+const visibleModList = computed(() => store.getters['profile/visibleModList']);
+watch(visibleModList, (newList) => internalVisibleList.value = newList);
+onMounted(() => {
+    internalVisibleList.value = store.getters['profile/visibleModList'];
+})
+
+const draggableList = computed({
+    get() {
+        return internalVisibleList.value;
+    },
+    set(newList: ManifestV2[]) {
+        internalVisibleList.value = newList;
+        try {
+            store.dispatch(
+                'profile/saveModListToDisk',
+                {mods: newList, profile: profile.value}
+            );
+        } catch (e) {
+            store.commit('error/handleError', R2Error.fromThrownValue(e));
+        }
+    }
+});
+</script>

--- a/src/components/views/LocalModList/SkeletonLocalModCard.vue
+++ b/src/components/views/LocalModList/SkeletonLocalModCard.vue
@@ -1,0 +1,53 @@
+<script lang="ts" setup>
+import { ExpandableCard } from '../../all';
+import ManifestV2 from '../../../model/ManifestV2';
+
+type LocalModCardProps = {
+    mod: ManifestV2;
+}
+
+const props = defineProps<LocalModCardProps>();
+</script>
+
+<template>
+    <ExpandableCard
+        :description="mod.getDescription()"
+        :enabled="mod.isEnabled()"
+        :id="`${mod.getAuthorName()}-${mod.getName()}-${mod.getVersionNumber()}`"
+        :image="mod.getIcon()">
+
+        <template v-slot:title>
+            <span class="non-selectable">
+                <span v-if="!mod.isEnabled()"
+                      class="tag is-warning margin-right margin-right--half-width"
+                      v-tooltip.right="'This mod will not be used in-game'">
+                    Disabled
+                </span>
+                <span class="card-title selectable">
+                    <component :is="mod.isEnabled() ? 'span' : 'strike'" class="selectable">
+                        {{mod.getDisplayName()}}
+                        <span class="selectable card-byline">
+                            v{{mod.getVersionNumber()}}
+                        </span>
+                        <span :class="`card-byline ${mod.isEnabled() && 'selectable'}`">
+                            by {{mod.getAuthorName()}}
+                        </span>
+                    </component>
+                </span>
+            </span>
+        </template>
+
+        <template v-slot:description>
+        </template>
+
+        <!-- Show icon button row even when card is collapsed -->
+        <template v-slot:other-icons>
+        </template>
+    </ExpandableCard>
+</template>
+
+<style scoped lang="scss">
+.switch {
+    position: relative;
+}
+</style>

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -39,7 +39,7 @@
                 Website <i class="fas fa-external-link-alt margin-left margin-left--half-width"></i>
             </ExternalLink>
             <template v-if="!readOnly">
-                <DonateButton :mod="key"/>
+                <DonateButton v-if="key" :mod="key"/>
             </template>
             <div class='card-footer-item non-selectable'>
                 <span><i class='fas fa-download'/> {{key.getDownloadCount()}}</span>

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -45,7 +45,7 @@ export default class ProfileModList {
                 const parsedYaml: any = parseYaml(fileContent) || [];
                 for(let modIndex in parsedYaml){
                     const mod = new ManifestV2().fromJsObject(parsedYaml[modIndex]);
-                    await this.setIconPath(mod, profile);
+                    this.setIconPath(mod, profile);
                     parsedYaml[modIndex] = mod;
                 }
                 return parsedYaml;
@@ -71,7 +71,14 @@ export default class ProfileModList {
     public static async saveModList(profile: ImmutableProfile, modList: ManifestV2[]): Promise<R2Error | null> {
         const fs = FsProvider.instance;
         try {
-            const yamlModList: string = stringifyYaml(modList);
+            const yamlModList: string = stringifyYaml(modList, {
+                replacer: (key, value) => {
+                    if (key === 'icon') {
+                        return undefined;
+                    }
+                    return value;
+                }
+            });
             try {
                 await fs.writeFile(
                     profile.joinToProfilePath('mods.yml'),


### PR DESCRIPTION
# Local Mod List Improvements

## Mods.yml

### Primary change 

Dropped mods.yml size down from 16139KB to 105KB. This is on a profile with 177 mods.

This was done using the `reducer` when stringify-ing the content of mods.yml and stripping out the `icon` key/value.

### Secondary effect

This has an added bonus of **drastically** improving the load times to get to the profiles screen.

## Fixing dragging ghost-effect

Prior to this change, when you drag a mod, due to the asynchronous behaviour of the manager, the mod list is treated as being reset before the state has changed. This gave the appearance of the mod jumping back to the original drag position, and then momentarily after being updated to the real position.

There's now a new ref variable which holds the local state and is updated by both the draggable list and the VueX state.

## Suspense

I've also introduced a new SkeletonLocalModCard. This is used as a loading placeholder whilst the actual state and dependency calculation is done in the background for mods.

It means that the installed list can be seen far quicker, albeit non-interactive until loaded. Regardless it's still a nice improvement that's been needed for a while.

## Summary

Overall this PR provides massive speed boosts in larger profiles for the following actions:
- Loading
- Installing
- Uninstalling
- Disabling
- Enabling
- Re-ordering mods

In addition to that, once all profiles have been updated, the time to load into profile selection screen has been significantly improved. Assuming all profiles have been updated to the new format, it can load to the selection screen near instantly.

The suspense implementation provides much faster feedback to see what's available in the current profile.