### PR TITLE
In ecosystem.json, add installRules for RAM: Random Access Mayhem

### DIFF
--- a/src/assets/data/ecosystem.json
+++ b/src/assets/data/ecosystem.json
@@ -23676,15 +23676,7 @@
           "additionalSearchStrings": [
             "pad"
           ],
-          "installRules": [
-            {
-              "route": "mods",
-              "defaultFileExtensions": [],
-              "trackingMethod": "package-zip",
-              "subRoutes": [],
-              "isDefaultLocation": true
-            }
-          ],
+          "installRules": [],
           "relativeFileExclusions": null
         }
       ],


### PR DESCRIPTION
Copied from Brotato to mirror their use of Godot mod loader. I hope this is all it needs and doesn't break anything, love u kisses