### PR TITLE
Fix Profiles screen styles for TSMM

### DIFF
--- a/src/pages/Profiles.vue
+++ b/src/pages/Profiles.vue
@@ -175,6 +175,6 @@ onMounted( async () => {
     gap: 1rem;
     justify-content: start;
     text-align: left;
-    width: 100vw;
+    width: 100%;
 }
 </style>


### PR DESCRIPTION
Since TSMM has the ad sidebar, using 100vw caused the profile list to be to wide and render a horizontal scroll bar.