### PR TITLE
add OnTogether.exe name

### DIFF
--- a/src/assets/data/ecosystem.json
+++ b/src/assets/data/ecosystem.json
@@ -23718,7 +23718,8 @@
           "steamFolderName": "On-Together/On-Together",
           "dataFolderName": "On-Together_Data",
           "exeNames": [
-            "On-Together.exe"
+            "On-Together.exe",
+            "OnTogether.exe"
           ],
           "packageLoader": "bepinex",
           "meta": {


### PR DESCRIPTION
No clue when this happened, but the exe renamed. Figured might as well keep the old one, it's unique enough
<img width="1043" height="675" alt="image" src="https://github.com/user-attachments/assets/e8631bdb-31b9-4919-af3d-af579c208e2e" />
<img width="1001" height="445" alt="image" src="https://github.com/user-attachments/assets/6b77c3ab-3545-4b5b-99b1-1dfd3ba795fa" />
