### PR TITLE
Added tracking for online vs local sourced mods

### DIFF
--- a/src/model/ManifestV2.ts
+++ b/src/model/ManifestV2.ts
@@ -31,6 +31,8 @@ export default class ManifestV2 {
     private enabled: boolean = true;
     private icon: string = '';
 
+    private onlineSource: boolean = false;
+
     // Intended to be used to import a mod with only minimal fields specified.
     // Should support manifest V1. Defaults to an "Unknown" author field if not found.
     public makeSafeFromPartial(data: any): R2Error | ManifestV2 {
@@ -87,6 +89,7 @@ export default class ManifestV2 {
         this.setGameVersion(jsManifestObject.gameVersion);
         this.icon = path.join(PathResolver.MOD_ROOT, 'cache', this.getName(), this.versionNumber.toString(), 'icon.png');
         this.setInstalledAtTime(jsManifestObject.installedAtTime || 0);
+        this.setOnlineSource(jsManifestObject.onlineSource || false);
         if (!jsManifestObject.enabled) {
             this.disable();
         }
@@ -244,5 +247,13 @@ export default class ManifestV2 {
 
     public getDependencyString(): string {
         return `${this.getName()}-${this.getVersionNumber().toString()}`;
+    }
+
+    public isOnlineSource(): boolean {
+        return this.onlineSource;
+    }
+
+    public setOnlineSource(isOnlineSource: boolean) {
+        this.onlineSource = isOnlineSource;
     }
 }

--- a/src/r2mm/downloading/BetterThunderstoreDownloader.ts
+++ b/src/r2mm/downloading/BetterThunderstoreDownloader.ts
@@ -1,4 +1,3 @@
-import StatusEnum from '../../model/enums/StatusEnum';
 import axios, { AxiosResponse } from 'axios';
 import ThunderstoreCombo from '../../model/ThunderstoreCombo';
 import ZipExtract from '../installing/ZipExtract';
@@ -61,6 +60,7 @@ export default class BetterThunderstoreDownloader extends ThunderstoreDownloader
             try {
                 const response = await this._downloadCombo(comboInProgress, singleModProgressCallback);
                 await this._saveDownloadResponse(response, comboInProgress, singleModProgressCallback);
+                await DownloadUtils.markAsDownloadedFromOnline(comboInProgress);
             } catch(e) {
                 throw R2Error.fromThrownValue(e, `Failed to download mod ${comboInProgress.getVersion().getFullName()}`);
             }

--- a/src/utils/ProfileUtils.ts
+++ b/src/utils/ProfileUtils.ts
@@ -14,6 +14,7 @@ import ZipProvider from "../providers/generic/zip/ZipProvider";
 import ProfileInstallerProvider from "../providers/ror2/installing/ProfileInstallerProvider";
 import * as PackageDb from '../r2mm/manager/PackageDexieStore';
 import ProfileModList from "../r2mm/mods/ProfileModList";
+import { wasDownloadedFromOnline } from './DownloadUtils';
 
 export async function exportModsToCombos(
     exportMods: ExportMod[],
@@ -84,6 +85,11 @@ export async function installModsToProfile(
             modName = comboMod.getMod().getName();
 
             const manifestMod = new ManifestV2().fromThunderstoreCombo(comboMod);
+
+            // Mark as downloaded from online if the state file exists in cache
+            if (await wasDownloadedFromOnline(comboMod)) {
+                manifestMod.setOnlineSource(true);
+            }
 
             if (installedVersions.includes(manifestMod.getDependencyString())) {
                 continue;


### PR DESCRIPTION
# Tracking Online Sources

_Prerequisite to identifying if package versions no longer match listed packages on Thunderstore_

## What's covered?

| Action                   | In cache | Online/Local tracked |
|--------------------------|----------|----------------------|
| Download, cache enabled  | No       | Online               |
| Download, cache disabled | No       | Online               |
| Download, cache enabled  | Yes      | Based on last result |
| Download, cache disabled | Yes      | Online               |
| Import                   | No       | Local                |
| Import                   | Yes      | Local                |

## Functionality

The cache has a new untracked folder called "_state" (to mirror the profile's _state folder), which records a list of files and versions that were downloaded from an online source.

Upon download the state files are looked up and if previously in the cache (and caching is enabled), then pull from the cache and set the onlineSource property equivalent to if the state file exists.

If the file is not cached (or caching is disabled), then fetch it from Thunderstore, and write the appropriate state file to disk. Repeat the lookup as part of the previous step.

If a file is locally imported, do not write a state file.

## Follow-up work for later PRs

- Inform the user if the mod is already cached
- If an `onlineSource` enabled mod isn't in the online cache, then inform the user that it is a potentially vulnerable package