### PR TITLE
Modal Blur

### DIFF
--- a/src/components/ModalCard.vue
+++ b/src/components/ModalCard.vue
@@ -44,5 +44,7 @@ function closeModal() {
 
 
 <style scoped lang="scss">
-
+.modal {
+    backdrop-filter: blur(5px);
+}
 </style>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -528,3 +528,7 @@ code {
 .v-popper__popper {
     z-index: 100 !important;
 }
+
+.modal-background {
+    backdrop-filter: blur(5px);
+}


### PR DESCRIPTION
# Modal Blur

_Adds a backdrop-filter blur to reduce distractions when dealing with a modal_

## Why?

The screen can look busy when a complex modal is open. Blurring softens the backing content and makes it so that it's no longer readable. Combined with the darkened overlay, it's overall less intrusive when dealing with a modal.

It also helps that it's a little more appealing visually and gives it a slightly more modern feel.

## Screenshots

### Before

<img width="1624" height="1102" alt="image" src="https://github.com/user-attachments/assets/df473ce1-5edb-4938-b0a7-9c29bdf7fbbc" />

### After

<img width="1617" height="1104" alt="image" src="https://github.com/user-attachments/assets/9bc216a1-6913-4739-8ec4-9caf1f7a5294" />
