### PR TITLE
Remove Beetleball melonloader override

### DIFF
--- a/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
+++ b/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
@@ -25,15 +25,7 @@ const OVERRIDES: Modloaders = {
             PackageLoader.MELONLOADER,
             new VersionNumber('0.5.4'),
         ),
-    ],
-    Beetleball: [
-        new ModLoaderPackageMapping(
-            'LavaGang-MelonLoader',
-            '',
-            PackageLoader.MELONLOADER,
-            new VersionNumber('0.7.0'),
-        ),
-    ],
+    ], 
 }
 
 export const MOD_LOADER_VARIANTS: Modloaders = Object.fromEntries(


### PR DESCRIPTION
Beatle does not equal beetle. Noted and remembered. 