### PR TITLE
Fix mod update on RecursiveMelonLoaderInstaller

### DIFF
--- a/src/installers/RecursiveMelonLoaderInstaller.ts
+++ b/src/installers/RecursiveMelonLoaderInstaller.ts
@@ -113,8 +113,8 @@ export class RecursiveMelonLoaderPluginInstaller implements PackageInstaller {
 
     async uninstall(args: InstallArgs): Promise<void> {
         try {
-            FileUtils.recursiveRemoveDirectoryIfExists(this.getModsPath(args));
-            FileUtils.recursiveRemoveDirectoryIfExists(this.getUserDataPath(args));
+            await FileUtils.recursiveRemoveDirectoryIfExists(this.getModsPath(args));
+            await FileUtils.recursiveRemoveDirectoryIfExists(this.getUserDataPath(args));
         } catch (e) {
             this.throwActionError(e, 'uninstall');
         }


### PR DESCRIPTION
Missing await when untinstalling the old version caused installing the new version to fail due to files being in use.