### PR TITLE
Swapped Steam launch of Titanfall 2 Northstar to use Steam runner over Steam-direct runner

### DIFF
--- a/src/assets/data/ecosystem.json
+++ b/src/assets/data/ecosystem.json
@@ -9675,7 +9675,7 @@
       },
       "distributions": [
         {
-          "platform": "steam-direct",
+          "platform": "steam",
           "identifier": "1237970"
         },
         {
@@ -9693,7 +9693,7 @@
           "dataFolderName": "",
           "distributions": [
             {
-              "platform": "steam-direct",
+              "platform": "steam",
               "identifier": "1237970"
             },
             {


### PR DESCRIPTION
Swaps Titanfall 2 Northstar to use the Steam runner by passing the `-northstar` flag to the Steam launch args instead of trying to launch `NorthstarLauncher.exe`. This fixes #1213 