### PR TITLE
Add enable/disable support to InstallRulePluginInstaller

### DIFF
--- a/src/installers/InstallRulePluginInstaller.ts
+++ b/src/installers/InstallRulePluginInstaller.ts
@@ -258,7 +258,7 @@ async function installState(args: InstallRuleArgs) {
 }
 
 // Enables or disables a mod installed with InstallRulePluginInstaller using SUBDIR/SUBDIR_NO_FLATTEN tracking methods.
-export async function applyModeSubDirs(mod: ManifestV2, profile: ImmutableProfile, mode: number, rule: CoreRuleType): Promise<R2Error | void> {
+async function applyModeSubDirs(mod: ManifestV2, profile: ImmutableProfile, mode: number, rule: CoreRuleType): Promise<void> {
     const subDirPaths = InstallationRules.getAllManagedPaths(rule.rules)
         .filter(value => [TrackingMethod.SUBDIR, TrackingMethod.SUBDIR_NO_FLATTEN].includes(value.trackingMethod));
 
@@ -267,10 +267,9 @@ export async function applyModeSubDirs(mod: ManifestV2, profile: ImmutableProfil
             const dirContents = await FsProvider.instance.readdir(profile.joinToProfilePath(dir.route));
             for (const namespacedDir of dirContents) {
                 if (namespacedDir === mod.getName()) {
-                    const tree = await FileTree.buildFromLocation(profile.joinToProfilePath(dir.route, namespacedDir));
-                    if (tree instanceof R2Error) {
-                        return tree;
-                    }
+                    const tree = throwForR2Error(
+                        await FileTree.buildFromLocation(profile.joinToProfilePath(dir.route, namespacedDir))
+                    );
                     for (const value of tree.getRecursiveFiles()) {
                         if (mode === ModMode.DISABLED && mod.isEnabled() && !value.toLowerCase().endsWith(".old")) {
                             await FsProvider.instance.rename(value, `${value}.old`);
@@ -285,26 +284,22 @@ export async function applyModeSubDirs(mod: ManifestV2, profile: ImmutableProfil
 }
 
 // Enables or disables a mod installed with InstallRulePluginInstaller using STATE tracking method.
-export async function applyModeState(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<R2Error | void> {
-    try {
-        const modStateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
-        if (await FsProvider.instance.exists(modStateFilePath)) {
-            const fileContents = (await FsProvider.instance.readFile(modStateFilePath)).toString();
-            const tracker: ModFileTracker = yaml.parse(fileContents);
-            for (const [key, value] of tracker.files) {
-                if (await ConflictManagementProvider.instance.isFileActive(mod, profile, value)) {
-                    const filePath = profile.joinToProfilePath(value);
-                    if (await FsProvider.instance.exists(filePath)) {
-                        await FsProvider.instance.unlink(filePath);
-                    }
-                    if (mode === ModMode.ENABLED) {
-                        await FsProvider.instance.copyFile(key, filePath);
-                    }
+async function applyModeState(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<void> {
+    const modStateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
+    if (await FsProvider.instance.exists(modStateFilePath)) {
+        const fileContents = (await FsProvider.instance.readFile(modStateFilePath)).toString();
+        const tracker: ModFileTracker = yaml.parse(fileContents);
+        for (const [key, value] of tracker.files) {
+            if (await ConflictManagementProvider.instance.isFileActive(mod, profile, value)) {
+                const filePath = profile.joinToProfilePath(value);
+                if (await FsProvider.instance.exists(filePath)) {
+                    await FsProvider.instance.unlink(filePath);
+                }
+                if (mode === ModMode.ENABLED) {
+                    await FsProvider.instance.copyFile(key, filePath);
                 }
             }
         }
-    } catch (e) {
-        return R2Error.fromThrownValue(e, `Error installing mod: ${mod.getName()}`);
     }
 }
 
@@ -344,5 +339,19 @@ export class InstallRulePluginInstaller implements PackageInstaller {
                 case TrackingMethod.PACKAGE_ZIP: await installPackageZip(profile, managedRule, files, mod); break;
             }
         }
+    }
+
+    // PACKAGE_ZIP tracking method not supported currently.
+    // NONE tracking method won't implement enabling.
+    async enable(args: InstallArgs) {
+        await applyModeSubDirs(args.mod, args.profile, ModMode.ENABLED, this.rule);
+        await applyModeState(args.mod, args.profile, ModMode.ENABLED);
+    }
+
+    // PACKAGE_ZIP tracking method not supported currently.
+    // NONE tracking method won't implement disabling.
+    async disable(args: InstallArgs) {
+        await applyModeSubDirs(args.mod, args.profile, ModMode.DISABLED, this.rule);
+        await applyModeState(args.mod, args.profile, ModMode.DISABLED);
     }
 }

--- a/src/installers/ReturnOfModdingInstaller.ts
+++ b/src/installers/ReturnOfModdingInstaller.ts
@@ -140,5 +140,13 @@ export class ReturnOfModdingPluginInstaller implements PackageInstaller {
             const solution = "Is the game still running?";
             throw FileWriteError.fromThrownValue(e, name, solution);
         }
-    };
+    }
+
+    async enable(args: InstallArgs) {
+        await this.installer().enable(args);
+    }
+
+    async disable(args: InstallArgs) {
+        await this.installer().disable(args);
+    }
 }

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -7,7 +7,6 @@ import path from "../../../providers/node/path/path";
 import FsProvider from '../../../providers/generic/file/FsProvider';
 import ModFileTracker from '../../../model/installing/ModFileTracker';
 import yaml from 'yaml';
-import ModMode from '../../../model/enums/ModMode';
 import InstallationRules, { CoreRuleType } from '../../installing/InstallationRules';
 import PathResolver from '../../../r2mm/manager/PathResolver';
 import GameManager from '../../../model/game/GameManager';
@@ -16,8 +15,7 @@ import FileWriteError from '../../../model/errors/FileWriteError';
 import FileUtils from '../../../utils/FileUtils';
 import { getPluginInstaller, PackageLoaderInstallers } from "../../../installers/registry";
 import { InstallArgs, PackageInstaller } from "../../../installers/PackageInstaller";
-import { applyModeState, applyModeSubDirs, InstallRulePluginInstaller } from "../../../installers/InstallRulePluginInstaller";
-import { ReturnOfModdingPluginInstaller } from "../../../installers/ReturnOfModdingInstaller";
+import { InstallRulePluginInstaller } from "../../../installers/InstallRulePluginInstaller";
 
 
 export default class GenericProfileInstaller extends ProfileInstallerProvider {
@@ -31,40 +29,6 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
         this.legacyInstaller = new InstallRulePluginInstaller(this.rule);
     }
 
-    private async applyModModeForSubdir(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<R2Error | void> {
-        // TODO: Call through the installer interface. For now we hardcode the only known cases because expanding the
-        //       installer system is out of scope.
-        //
-        //       In other words, this entire functionality of enabling & disabling mods should exist as a callable on
-        //       installers rather than here. Below is a dirty hack to fetch the install rules for the current only
-        //       known case.
-        let rule = this.rule;
-        const installer = getPluginInstaller(GameManager.activeGame.packageLoader);
-        if (installer instanceof ReturnOfModdingPluginInstaller) {
-            rule = installer.installer().rule;
-        }
-        if (!rule) {
-            return;
-        }
-
-        return await applyModeSubDirs(mod, profile, mode, rule);
-    }
-
-    private async applyModModeForState(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<R2Error | void> {
-        return await applyModeState(mod, profile, mode);
-    }
-
-    private async applyModMode(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<R2Error | void> {
-        const appliedState = await this.applyModModeForState(mod, profile, mode);
-        if (appliedState instanceof R2Error) {
-            return appliedState;
-        }
-        const appliedSub = await this.applyModModeForSubdir(mod, profile, mode);
-        if (appliedSub instanceof R2Error) {
-            return appliedSub;
-        }
-    }
-
     async disableMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | void> {
         // Support for installer specific disable methods are rolled out
         // gradually and therefore might not be defined yet. Disabling
@@ -73,11 +37,12 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
             if (await this.disableModWithInstaller(mod, profile)) {
                 return;
             }
+
+            const args = this.getInstallArgs(mod, profile);
+            await this.legacyInstaller.disable(args);
         } catch (e) {
             return R2Error.fromThrownValue(e);
         }
-
-        return this.applyModMode(mod, profile, ModMode.DISABLED);
     }
 
     async enableMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | void> {
@@ -88,11 +53,12 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
             if (await this.enableModWithInstaller(mod, profile)) {
                 return;
             }
+
+            const args = this.getInstallArgs(mod, profile);
+            await this.legacyInstaller.enable(args);
         } catch (e) {
             return R2Error.fromThrownValue(e);
         }
-
-        return this.applyModMode(mod, profile, ModMode.ENABLED);
     }
 
     async installForManifestV2(args: InstallArgs): Promise<R2Error | null> {


### PR DESCRIPTION
ReturnOfModdingPluginInstaller also depends on this implementation, as it's built on top of the IRPI.

Some extra logic is still left in GenericProfileInstaller - these can be cleaned out once getPluginInstaller starts returning IRPI as the installer for the games that currently fall back to legacy implementation that's embedded into GenericProfileInstaller.

Other than that, GenericProfileInstaller no longer has any enable or disable logic - it's all compartmentalized inside the various classes that implement PackageInstaller.