### PR TITLE
Simplified provider assignments

### DIFF
--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -16,6 +16,7 @@ export default defineConfig((ctx) => {
         // --> boot files are part of "main.js"
         // https://v2.quasar.dev/quasar-cli-vite/boot-files
         boot: [
+            'providers',
             'i18n',
             // 'axios',
             'floating-vue'

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,53 +16,25 @@
 <script lang="ts" setup>
 import 'bulma-steps/dist/js/bulma-steps.min.js';
 import ManagerSettings from './r2mm/manager/ManagerSettings';
-import ProfileProvider from './providers/ror2/model_implementation/ProfileProvider';
-import ProfileImpl from './r2mm/model_implementation/ProfileImpl';
-import LogOutput from './r2mm/data/LogOutput';
-import LogOutputProvider from './providers/ror2/data/LogOutputProvider';
-import ThunderstoreDownloaderProvider from './providers/ror2/downloading/ThunderstoreDownloaderProvider';
-import BetterThunderstoreDownloader from './r2mm/downloading/BetterThunderstoreDownloader';
 import PathResolver from './r2mm/manager/PathResolver';
 import path from './providers/node/path/path';
 import ThemeManager from './r2mm/manager/ThemeManager';
 import 'bulma-switch/dist/css/bulma-switch.min.css';
 import LoggerProvider, { LogSeverity } from './providers/ror2/logging/LoggerProvider';
 import ManagerInformation from './_managerinf/ManagerInformation';
-import LocalModInstallerProvider from './providers/ror2/installing/LocalModInstallerProvider';
-import LocalModInstaller from './r2mm/installing/LocalModInstaller';
-import { Logger } from './r2mm/logging/Logger';
+import InstallationRules from './r2mm/installing/InstallationRules';
 import FileUtils from './utils/FileUtils';
 import LinkProvider from './providers/components/LinkProvider';
-import LinkImpl from './r2mm/component_override/LinkImpl';
-import FsProvider from './providers/generic/file/FsProvider';
-import { DataFolderProvider } from './providers/ror2/system/DataFolderProvider';
-import { DataFolderProviderImpl } from './r2mm/system/DataFolderProviderImpl';
-import InteractionProvider from './providers/ror2/system/InteractionProvider';
-import InteractionProviderImpl from './r2mm/system/InteractionProviderImpl';
-import ZipProvider from './providers/generic/zip/ZipProvider';
-import AdmZipProvider from './providers/generic/zip/AdmZipProvider';
 import ManagerSettingsMigration from './r2mm/manager/ManagerSettingsMigration';
-import BindLoaderImpl from './providers/components/loaders/bind_impls/BindLoaderImpl';
-import PlatformInterceptorProvider from './providers/generic/game/platform_interceptor/PlatformInterceptorProvider';
-import PlatformInterceptorImpl from './providers/generic/game/platform_interceptor/PlatformInterceptorImpl';
-import ProfileInstallerProvider from './providers/ror2/installing/ProfileInstallerProvider';
-import InstallationRules from './r2mm/installing/InstallationRules';
-import GenericProfileInstaller from './r2mm/installing/profile_installers/GenericProfileInstaller';
 import ErrorModal from './components/modals/ErrorModal.vue';
-import { provideStoreImplementation } from './providers/generic/store/StoreProvider';
 import baseStore from './store';
 import { onMounted, ref, watchEffect } from 'vue';
 import { useUtilityComposable } from './components/composables/UtilityComposable';
 import { useQuasar } from 'quasar';
-import { NodeFsImplementation } from './providers/node/fs/NodeFsImplementation';
 import { useRouter } from 'vue-router';
-import { ProtocolProviderImplementation } from './providers/generic/protocol/ProtocolProviderImplementation';
-import { provideProtocolImplementation } from './providers/generic/protocol/ProtocolProvider';
-import BreadcrumbNavigator from 'components/breadcrumbs/BreadcrumbNavigator.vue';
 
 const store = baseStore;
 const router = useRouter();
-provideStoreImplementation(() => store);
 
 const quasar = useQuasar();
 
@@ -81,28 +53,6 @@ const {
 } = useUtilityComposable();
 
 const visible = ref<boolean>(false);
-
-FsProvider.provide(() => NodeFsImplementation);
-
-ProfileProvider.provide(() => new ProfileImpl());
-LogOutputProvider.provide(() => LogOutput.getSingleton());
-
-const betterThunderstoreDownloader = new BetterThunderstoreDownloader();
-ThunderstoreDownloaderProvider.provide(() => betterThunderstoreDownloader);
-
-ZipProvider.provide(() => new AdmZipProvider());
-LocalModInstallerProvider.provide(() => new LocalModInstaller());
-ProfileInstallerProvider.provide(() => new GenericProfileInstaller());
-LoggerProvider.provide(() => new Logger());
-LinkProvider.provide(() => new LinkImpl());
-InteractionProvider.provide(() => new InteractionProviderImpl());
-DataFolderProvider.provide(() => new DataFolderProviderImpl());
-
-PlatformInterceptorProvider.provide(() => new PlatformInterceptorImpl());
-
-provideProtocolImplementation(() => ProtocolProviderImplementation)
-
-BindLoaderImpl.bind();
 
 onMounted(async () => {
     const settings: ManagerSettings = await store.dispatch('resetActiveGame');

--- a/src/AppWrapper.vue
+++ b/src/AppWrapper.vue
@@ -9,19 +9,6 @@ import App from "./App.vue";
 import SettingsLoader from "./components/SettingsLoader.vue";
 import R2Error from "./model/errors/R2Error";
 import LinkProvider from './providers/components/LinkProvider';
-import { providePathImplementation } from './providers/node/path/path';
-import { NodePathImplementation } from './providers/node/path/NodePathImplementation';
-import { provideChildProcessImplementation } from './providers/node/child_process/child_process';
-import { NodeChildProcessImplementation } from './providers/node/child_process/ChildProcessImplementation';
-import {provideOsImplementation} from "./providers/node/os/os";
-import {NodeOsImplementation} from "./providers/node/os/NodeOsImplementation";
-import { provideBufferImplementation } from './providers/node/buffer/buffer';
-import { NodeBufferImplementation } from './providers/node/buffer/BufferImplementation';
-
-providePathImplementation(() => NodePathImplementation);
-provideChildProcessImplementation(() => NodeChildProcessImplementation);
-provideOsImplementation(() => NodeOsImplementation);
-provideBufferImplementation(() => NodeBufferImplementation);
 
 function logError(error: R2Error) {
     console.error(error.name, error.message, error.stack);

--- a/src/boot/providers.ts
+++ b/src/boot/providers.ts
@@ -1,0 +1,66 @@
+import { defineBoot } from '#q-app/wrappers';
+import { NodePathImplementation } from '../providers/node/path/NodePathImplementation';
+import { providePathImplementation } from '../providers/node/path/path';
+import { NodeChildProcessImplementation } from '../providers/node/child_process/ChildProcessImplementation';
+import { provideChildProcessImplementation } from '../providers/node/child_process/child_process';
+import { NodeOsImplementation } from '../providers/node/os/NodeOsImplementation';
+import { provideOsImplementation } from '../providers/node/os/os';
+import { NodeBufferImplementation } from '../providers/node/buffer/BufferImplementation';
+import { provideBufferImplementation } from '../providers/node/buffer/buffer';
+import { provideStoreImplementation } from '../providers/generic/store/StoreProvider';
+import baseStore from '../store';
+import FsProvider from '../providers/generic/file/FsProvider';
+import { NodeFsImplementation } from '../providers/node/fs/NodeFsImplementation';
+import ProfileProvider from '../providers/ror2/model_implementation/ProfileProvider';
+import ProfileImpl from '../r2mm/model_implementation/ProfileImpl';
+import LogOutput from '../r2mm/data/LogOutput';
+import LogOutputProvider from '../providers/ror2/data/LogOutputProvider';
+import ThunderstoreDownloaderProvider from '../providers/ror2/downloading/ThunderstoreDownloaderProvider';
+import BetterThunderstoreDownloader from '../r2mm/downloading/BetterThunderstoreDownloader';
+import ZipProvider from '../providers/generic/zip/ZipProvider';
+import AdmZipProvider from '../providers/generic/zip/AdmZipProvider';
+import LocalModInstallerProvider from '../providers/ror2/installing/LocalModInstallerProvider';
+import LocalModInstaller from '../r2mm/installing/LocalModInstaller';
+import ProfileInstallerProvider from '../providers/ror2/installing/ProfileInstallerProvider';
+import GenericProfileInstaller from '../r2mm/installing/profile_installers/GenericProfileInstaller';
+import LoggerProvider from '../providers/ror2/logging/LoggerProvider';
+import { Logger } from '../r2mm/logging/Logger';
+import LinkProvider from '../providers/components/LinkProvider';
+import LinkImpl from '../r2mm/component_override/LinkImpl';
+import InteractionProvider from '../providers/ror2/system/InteractionProvider';
+import InteractionProviderImpl from '../r2mm/system/InteractionProviderImpl';
+import { DataFolderProvider } from '../providers/ror2/system/DataFolderProvider';
+import { DataFolderProviderImpl } from '../r2mm/system/DataFolderProviderImpl';
+import PlatformInterceptorProvider from '../providers/generic/game/platform_interceptor/PlatformInterceptorProvider';
+import PlatformInterceptorImpl from '../providers/generic/game/platform_interceptor/PlatformInterceptorImpl';
+import { provideProtocolImplementation } from '../providers/generic/protocol/ProtocolProvider';
+import { ProtocolProviderImplementation } from '../providers/generic/protocol/ProtocolProviderImplementation';
+import BindLoaderImpl from '../providers/components/loaders/bind_impls/BindLoaderImpl';
+
+export default defineBoot(() => {
+    providePathImplementation(() => NodePathImplementation);
+    provideChildProcessImplementation(() => NodeChildProcessImplementation);
+    provideOsImplementation(() => NodeOsImplementation);
+    provideBufferImplementation(() => NodeBufferImplementation);
+    provideStoreImplementation(() => baseStore);
+    FsProvider.provide(() => NodeFsImplementation);
+    ProfileProvider.provide(() => new ProfileImpl());
+    LogOutputProvider.provide(() => LogOutput.getSingleton());
+    provideThunderstoreDownloadImplementation();
+    ZipProvider.provide(() => new AdmZipProvider());
+    LocalModInstallerProvider.provide(() => new LocalModInstaller());
+    ProfileInstallerProvider.provide(() => new GenericProfileInstaller());
+    LoggerProvider.provide(() => new Logger());
+    LinkProvider.provide(() => new LinkImpl());
+    InteractionProvider.provide(() => new InteractionProviderImpl());
+    DataFolderProvider.provide(() => new DataFolderProviderImpl());
+    PlatformInterceptorProvider.provide(() => new PlatformInterceptorImpl());
+    provideProtocolImplementation(() => ProtocolProviderImplementation);
+
+    BindLoaderImpl.bind();
+});
+
+function provideThunderstoreDownloadImplementation() {
+    const betterThunderstoreDownloader = new BetterThunderstoreDownloader();
+    ThunderstoreDownloaderProvider.provide(() => betterThunderstoreDownloader);
+}


### PR DESCRIPTION
# Simplified provider assignments

_This moves binding logic from AppWrapper.vue and App.vue into a single boot file to make it easier to identify required order of providers._

## Explanation

Previously, it was awkward to identify the order to declare providers when it comes to tests, and even new features if a provider depends on an existing dependency.

The ordering may still not be perfectly optimized, but it does help to give a general sense of where to start setting up providers.

There doesn't appear to be any real reason that some providers weren't all setup in AppWrapper.vue. It was likely just accumulated over the years. 🤷 
I've done a standard run-through and everything seems fine. No errors.