### PR TITLE
Add missing methods to LovelyPluginInstaller

### DIFF
--- a/src/installers/InstallRulePluginInstaller.ts
+++ b/src/installers/InstallRulePluginInstaller.ts
@@ -298,7 +298,7 @@ async function uninstallSubDir(mod: ManifestV2, profile: ImmutableProfile) {
     }
 }
 
-async function uninstallState(mod: ManifestV2, profile: ImmutableProfile) {
+export async function uninstallState(mod: ManifestV2, profile: ImmutableProfile): Promise<void> {
     const stateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
     if (await FsProvider.instance.exists(stateFilePath)) {
         const read = await FsProvider.instance.readFile(stateFilePath);
@@ -342,7 +342,7 @@ async function applyModeSubDirs(mod: ManifestV2, profile: ImmutableProfile, mode
 }
 
 // Enables or disables a mod installed with InstallRulePluginInstaller using STATE tracking method.
-async function applyModeState(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<void> {
+export async function applyModeState(mod: ManifestV2, profile: ImmutableProfile, mode: number): Promise<void> {
     const modStateFilePath = profile.joinToProfilePath("_state", `${mod.getName()}-state.yml`);
     if (await FsProvider.instance.exists(modStateFilePath)) {
         const fileContents = (await FsProvider.instance.readFile(modStateFilePath)).toString();

--- a/src/installers/LovelyInstaller.ts
+++ b/src/installers/LovelyInstaller.ts
@@ -1,8 +1,9 @@
 import { InstallArgs, PackageInstaller, uninstallModLoader } from "./PackageInstaller";
-import { addToStateFile } from "./InstallRulePluginInstaller";
+import { addToStateFile, applyModeState, uninstallState } from "./InstallRulePluginInstaller";
 import FsProvider from "../providers/generic/file/FsProvider";
 import FileUtils from "../utils/FileUtils";
 import FileTree from "../model/file/FileTree";
+import ModMode from "../model/enums/ModMode";
 import R2Error from "../model/errors/R2Error";
 import path from "../providers/node/path/path";
 
@@ -78,5 +79,17 @@ export class LovelyPluginInstaller implements PackageInstaller {
         }
 
         await addToStateFile(mod, fileRelocations, profile);
+    }
+
+    async uninstall(args: InstallArgs) {
+        await uninstallState(args.mod, args.profile);
+    }
+
+    async enable(args: InstallArgs) {
+        await applyModeState(args.mod, args.profile, ModMode.ENABLED);
+    }
+
+    async disable(args: InstallArgs) {
+        await applyModeState(args.mod, args.profile, ModMode.DISABLED);
     }
 }


### PR DESCRIPTION
The custom installation method tracks intallations in a state file. Use the existing state-based methods to uninstall and disable/enable mods.

This subtly changes the old behaviour since uninstallSubDir and applyModeSubDirs are no longer called like they were in the implementation that resided in GenericProfileInstaller. I assume it's safe to ignore this change and that the state-based methods contain all the logic required for mods installed with addToStateFile.

It's out of the current scope to figure out if lovely actually needs a custom plugin installer or if it would do just fine with the InstallRulePluginInstaller, which has evolved since support for Lovely as introduced.