### PR TITLE
Cached ecosystem fetch

### DIFF
--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -18,7 +18,8 @@ export default defineConfig((ctx) => {
         boot: [
             'i18n',
             // 'axios',
-            'floating-vue'
+            'floating-vue',
+            'ecosystem'
         ],
 
         // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#css

--- a/src/boot/ecosystem.ts
+++ b/src/boot/ecosystem.ts
@@ -1,5 +1,5 @@
 import { defineBoot } from '#q-app/wrappers';
-import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemMerge";
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemSchema";
 import FsProvider from "src/providers/generic/file/FsProvider";
 import {NodeFsImplementation} from "src/providers/node/fs/NodeFsImplementation";
 

--- a/src/boot/ecosystem.ts
+++ b/src/boot/ecosystem.ts
@@ -1,7 +1,12 @@
 import { defineBoot } from '#q-app/wrappers';
-import {EcosystemSchema} from "src/model/schema/ThunderstoreSchema";
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemMerge";
+import FsProvider from "src/providers/generic/file/FsProvider";
+import {NodeFsImplementation} from "src/providers/node/fs/NodeFsImplementation";
 
 // @ts-ignore
 export default defineBoot(async ({ app }) => {
-    EcosystemSchema.init();
+    FsProvider.provide(() => NodeFsImplementation);
+    await updateEcosystemReactives();
+    // @ts-ignore
+    FsProvider.provide(() => undefined);
 });

--- a/src/boot/ecosystem.ts
+++ b/src/boot/ecosystem.ts
@@ -1,0 +1,7 @@
+import { defineBoot } from '#q-app/wrappers';
+import {EcosystemSchema} from "src/model/schema/ThunderstoreSchema";
+
+// @ts-ignore
+export default defineBoot(async ({ app }) => {
+    EcosystemSchema.init();
+});

--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -2,7 +2,7 @@ import Game from '../../model/game/Game';
 import StorePlatformMetadata from '../../model/game/StorePlatformMetadata';
 import PathResolver from '../../r2mm/manager/PathResolver';
 import FileUtils from '../../utils/FileUtils';
-import { EcosystemSchema, Platform } from '../schema/ThunderstoreSchema';
+import {EcosystemSupportedGames, Platform} from '../schema/ThunderstoreSchema';
 import path from '../../providers/node/path/path';
 
 export default class GameManager {
@@ -23,7 +23,7 @@ export default class GameManager {
     }
 
     static get gameList(): Game[] {
-        return EcosystemSchema.supportedGames.map(([identifier, game]) => new Game(
+        return EcosystemSupportedGames.value.map(([identifier, game]) => new Game(
             game.meta.displayName,
             game.internalFolderName,
             game.settingsIdentifier,

--- a/src/model/schema/ThunderstoreSchema.ts
+++ b/src/model/schema/ThunderstoreSchema.ts
@@ -2,9 +2,10 @@ import Ajv from "ajv";
 import addFormats from "ajv-formats";
 
 import ecosystem from "../../assets/data/ecosystem.json";
-import { R2Modman, ThunderstoreEcosystem } from "../../assets/data/ecosystemTypes";
+import {ModloaderPackage, R2Modman, ThunderstoreEcosystem} from "../../assets/data/ecosystemTypes";
 import jsonSchema from "../../assets/data/ecosystemJsonSchema.json";
 import R2Error from "../errors/R2Error";
+import {ref} from "@vue/reactivity";
 
 // Re-export generated types/Enums to avoid having the whole codebase
 // tightly coupled with the generated ecosystemTypes.
@@ -15,6 +16,9 @@ export {
     TrackingMethod,
     Platform,
 } from "../../assets/data/ecosystemTypes";
+
+export const EcosystemSupportedGames = ref<[string, R2Modman][]>([]);
+export const EcosystemModloaderPackages = ref<ModloaderPackage[]>([]);
 
 export class EcosystemSchema {
     private static _isValidated: boolean = false;

--- a/src/model/schema/ThunderstoreSchema.ts
+++ b/src/model/schema/ThunderstoreSchema.ts
@@ -23,6 +23,11 @@ export const EcosystemModloaderPackages = ref<ModloaderPackage[]>([]);
 export class EcosystemSchema {
     private static _isValidated: boolean = false;
 
+    public static init() {
+        EcosystemSupportedGames.value = this.supportedGames;
+        EcosystemModloaderPackages.value = this.modloaderPackages;
+    }
+
     /**
      * Get a validated instance of the ecosystem schema.
      */

--- a/src/model/schema/ThunderstoreSchema.ts
+++ b/src/model/schema/ThunderstoreSchema.ts
@@ -1,10 +1,4 @@
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
-
-import ecosystem from "../../assets/data/ecosystem.json";
-import {ModloaderPackage, R2Modman, ThunderstoreEcosystem} from "../../assets/data/ecosystemTypes";
-import jsonSchema from "../../assets/data/ecosystemJsonSchema.json";
-import R2Error from "../errors/R2Error";
+import {ModloaderPackage, R2Modman} from "../../assets/data/ecosystemTypes";
 import {ref} from "@vue/reactivity";
 
 // Re-export generated types/Enums to avoid having the whole codebase
@@ -19,53 +13,3 @@ export {
 
 export const EcosystemSupportedGames = ref<[string, R2Modman][]>([]);
 export const EcosystemModloaderPackages = ref<ModloaderPackage[]>([]);
-
-export class EcosystemSchema {
-    private static _isValidated: boolean = false;
-
-    public static init() {
-        EcosystemSupportedGames.value = this.supportedGames;
-        EcosystemModloaderPackages.value = this.modloaderPackages;
-    }
-
-    /**
-     * Get a validated instance of the ecosystem schema.
-     */
-    private static get ecosystem(): ThunderstoreEcosystem {
-        if (this._isValidated) {
-            return ecosystem as ThunderstoreEcosystem;
-        }
-
-        // Validate the schema via its schema schema.
-        const ajv = new Ajv();
-        addFormats(ajv);
-
-        const validate = ajv.compile(jsonSchema);
-        const isOk = validate(ecosystem);
-
-        if (!isOk) {
-            throw new R2Error("Schema validation error", ajv.errorsText(validate.errors));
-        }
-
-        this._isValidated = true;
-        return ecosystem as ThunderstoreEcosystem;
-    }
-
-    /**
-     * Get a list of [identifier, r2modman] entries i.e. games supported by the mod manager.
-     */
-    static get supportedGames() {
-        const result: [string, R2Modman][] = []
-        for (const [identifier, game] of Object.entries(this.ecosystem.games)) {
-            if (game.r2modman == null) continue;
-            for (const entry of game.r2modman) {
-                result.push([identifier, entry]);
-            }
-        }
-        return result;
-    }
-
-    static get modloaderPackages() {
-        return this.ecosystem.modloaderPackages;
-    }
-}

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -370,8 +370,7 @@ onMounted(async () => {
     await store.dispatch('resetLocalState');
 
     updateEcosystemReactives()
-        // TODO - Allow updating latest schema
-        // .then(updateLatestMergedEcosystemSchema);
+        .then(updateLatestMergedEcosystemSchema);
 
     settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
     const globalSettings = settings.value.getContext().global;

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -369,7 +369,8 @@ onMounted(async () => {
 
     await store.dispatch('resetLocalState');
 
-    updateLatestEcosystemSchema();
+    // TODO - Enable once updating is viable
+    // updateLatestEcosystemSchema();
 
     settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
     const globalSettings = settings.value.getContext().global;

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -369,8 +369,7 @@ onMounted(async () => {
 
     await store.dispatch('resetLocalState');
 
-    updateEcosystemReactives()
-        .then(updateLatestMergedEcosystemSchema);
+    updateLatestMergedEcosystemSchema();
 
     settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
     const globalSettings = settings.value.getContext().global;

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -189,6 +189,7 @@ import { getStore } from '../providers/generic/store/StoreProvider';
 import { State } from '../store';
 import { useRouter } from 'vue-router';
 import ProtocolProvider from '../providers/generic/protocol/ProtocolProvider';
+import {updateEcosystemReactives, updateLatestMergedEcosystemSchema} from "src/r2mm/ecosystem/EcosystemMerge";
 
 const store = getStore<State>();
 const router = useRouter();
@@ -203,7 +204,6 @@ const settings = ref<ManagerSettings | undefined>(undefined);
 const isSettingDefaultPlatform = ref<boolean>(false);
 const viewMode = ref<GameSelectionViewMode>(GameSelectionViewMode.LIST);
 const activeTab = ref<GameInstanceType>(GameInstanceType.GAME);
-const gameImages = reactive({});
 
 const filteredGameList = computed(() => {
     const displayNameInAdditionalSearch = (game: Game, filterText: string): boolean => {
@@ -369,6 +369,10 @@ onMounted(async () => {
 
     await store.dispatch('resetLocalState');
 
+    updateEcosystemReactives()
+        // TODO - Allow updating latest schema
+        // .then(updateLatestMergedEcosystemSchema);
+
     settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
     const globalSettings = settings.value.getContext().global;
     favourites.value = globalSettings.favouriteGames || [];
@@ -384,12 +388,12 @@ onMounted(async () => {
     }
 
     // Skip game selection view if valid default game & platform are set.
-    const {defaultGame, defaultPlatform} = ManagerUtils.getDefaults(settings.value);
+    const {defaultGame, defaultPlatform} = ManagerUtils.getDefaults(settings.value!);
 
     if (defaultGame && defaultPlatform) {
         selectedGame.value = defaultGame;
         selectedPlatform.value = defaultPlatform;
-        proceed();
+        return proceed();
     }
 })
 

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -189,7 +189,7 @@ import { getStore } from '../providers/generic/store/StoreProvider';
 import { State } from '../store';
 import { useRouter } from 'vue-router';
 import ProtocolProvider from '../providers/generic/protocol/ProtocolProvider';
-import {updateEcosystemReactives, updateLatestMergedEcosystemSchema} from "src/r2mm/ecosystem/EcosystemMerge";
+import {updateEcosystemReactives, updateLatestEcosystemSchema} from "src/r2mm/ecosystem/EcosystemSchema";
 
 const store = getStore<State>();
 const router = useRouter();
@@ -369,7 +369,7 @@ onMounted(async () => {
 
     await store.dispatch('resetLocalState');
 
-    updateLatestMergedEcosystemSchema();
+    updateLatestEcosystemSchema();
 
     settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
     const globalSettings = settings.value.getContext().global;

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -118,7 +118,4 @@ async function internalUpdateEcosystemReactives(schema: ThunderstoreEcosystem): 
 export async function updateEcosystemReactives() {
     const mergedSchema = await resolveMergedEcosystemSchema();
     await internalUpdateEcosystemReactives(mergedSchema);
-    return new Promise(resolve => {
-        setTimeout(resolve, 3000);
-    });
 }

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -1,0 +1,3 @@
+export async function generateMergedSchema(): Promise<void> {
+    throw new Error("Not implemented.");
+}

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -14,7 +14,7 @@ import {EcosystemModloaderPackages, EcosystemSupportedGames} from "../../model/s
 export type MergedThunderstoreEcosystem = ThunderstoreEcosystem & {version: string};
 
 async function getMergedEcosystemPath(): Promise<string> {
-    return path.join(PathResolver.MOD_ROOT, "ecosystem-merge.json");
+    return path.join(PathResolver.ROOT, "ecosystem-merge.json");
 }
 
 export async function updateLatestMergedEcosystemSchema(): Promise<void> {
@@ -81,7 +81,13 @@ async function loadBundledSchema(): Promise<ThunderstoreEcosystem> {
 
 async function fetchLatestSchema(): Promise<ThunderstoreEcosystem> {
     // TODO - Implement fetching of latest resource
-    return {} as ThunderstoreEcosystem;
+    return {
+        schemaVersion: "",
+        communities: {},
+        games: {},
+        modloaderPackages: [],
+        packageInstallers: {},
+    };
 }
 
 async function resolveMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -10,6 +10,7 @@ import FsProvider from "../../providers/generic/file/FsProvider";
 import VersionNumber from "../../model/VersionNumber";
 import ManagerInformation from "../../_managerinf/ManagerInformation";
 import {EcosystemModloaderPackages, EcosystemSupportedGames} from "../../model/schema/ThunderstoreSchema";
+import {updateModLoaderExports} from "../installing/profile_installers/ModLoaderVariantRecord";
 
 export type MergedThunderstoreEcosystem = ThunderstoreEcosystem & {version: string};
 
@@ -113,6 +114,7 @@ async function internalUpdateEcosystemReactives(schema: ThunderstoreEcosystem): 
     }
     EcosystemSupportedGames.value = result;
     EcosystemModloaderPackages.value = schema.modloaderPackages;
+    updateModLoaderExports();
 }
 
 export async function updateEcosystemReactives() {

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -1,3 +1,100 @@
-export async function generateMergedSchema(): Promise<void> {
-    throw new Error("Not implemented.");
+import bundledEcosystem from "../../assets/data/ecosystem.json";
+import {R2Modman, ThunderstoreEcosystem} from "../../assets/data/ecosystemTypes";
+import jsonSchema from "../../assets/data/ecosystemJsonSchema.json";
+import R2Error from "../../model/errors/R2Error";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import PathResolver from "../manager/PathResolver";
+import path from "../../providers/node/path/path";
+import FsProvider from "../../providers/generic/file/FsProvider";
+import VersionNumber from "../../model/VersionNumber";
+import ManagerInformation from "../../_managerinf/ManagerInformation";
+import {EcosystemModloaderPackages, EcosystemSupportedGames} from "../../model/schema/ThunderstoreSchema";
+
+export type MergedThunderstoreEcosystem = ThunderstoreEcosystem & {version: string};
+
+async function getMergedEcosystemPath(): Promise<string> {
+    return path.join(PathResolver.MOD_ROOT, "ecosystem-merge.json");
+}
+
+async function updateLatestMergedEcosystemSchema(): Promise<void> {
+    const bundledSchema = await loadBundledSchema();
+    const latestSchema = await fetchLatestSchema();
+    const mergedSchema: ThunderstoreEcosystem = {
+        schemaVersion: "",
+        communities: {},
+        games: {},
+        modloaderPackages: [],
+        packageInstallers: {},
+    };
+    mergedSchema.schemaVersion = latestSchema.schemaVersion;
+    mergedSchema.communities = {
+        ...bundledSchema.communities,
+        ...latestSchema.communities,
+    }
+    mergedSchema.games = {
+        ...bundledSchema.games,
+        ...latestSchema.games,
+    };
+    // Convert to map to handle duplicate keys nicely
+    const modloaderMap = new Map(
+        [...bundledSchema.modloaderPackages, ...latestSchema.modloaderPackages]
+            .map(pkg => [pkg.packageId, pkg])
+    );
+    mergedSchema.modloaderPackages = [...modloaderMap.values()];
+    mergedSchema.packageInstallers = {
+        ...bundledSchema.packageInstallers,
+        ...latestSchema.packageInstallers,
+    };
+}
+
+async function getLastSavedMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
+    const contentBuffer = await FsProvider.instance.readFile(await getMergedEcosystemPath());
+    const content = contentBuffer.toString("utf8");
+    return JSON.parse(content);
+}
+
+async function loadBundledSchema(): Promise<ThunderstoreEcosystem> {
+    const ajv = new Ajv();
+    addFormats(ajv);
+
+    const validate = ajv.compile(jsonSchema);
+    const isOk = validate(bundledEcosystem);
+
+    if (!isOk) {
+        throw new R2Error("Schema validation error", ajv.errorsText(validate.errors));
+    }
+
+    return bundledEcosystem as ThunderstoreEcosystem;
+}
+
+async function fetchLatestSchema(): Promise<ThunderstoreEcosystem> {
+    // TODO - Implement fetching of latest resource
+    return {} as ThunderstoreEcosystem;
+}
+
+async function resolveMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
+    const mergeFilePath = await getMergedEcosystemPath();
+    const bundledSchema = async () => ({...(await loadBundledSchema()), version: ManagerInformation.VERSION.toString()});
+    if (!(await FsProvider.instance.exists(mergeFilePath))) {
+        return bundledSchema();
+    }
+    const content = await getLastSavedMergedEcosystemSchema();
+    if (!new VersionNumber(content.version).isEqualTo(ManagerInformation.VERSION)) {
+        return bundledSchema();
+    }
+    return content;
+}
+
+export async function updateEcosystemReactives() {
+    const mergedSchema = await resolveMergedEcosystemSchema();
+    const result: [string, R2Modman][] = []
+    for (const [identifier, game] of Object.entries(mergedSchema.games)) {
+        if (game.r2modman == null) continue;
+        for (const entry of game.r2modman) {
+            result.push([identifier, entry]);
+        }
+    }
+    EcosystemSupportedGames.value = result;
+    EcosystemModloaderPackages.value = mergedSchema.modloaderPackages;
 }

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -1,0 +1,261 @@
+import bundledEcosystem from "../../assets/data/ecosystem.json";
+import {R2Modman, ThunderstoreEcosystem} from "../../assets/data/ecosystemTypes";
+import jsonSchema from "../../assets/data/ecosystemJsonSchema.json";
+import R2Error from "../../model/errors/R2Error";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import PathResolver from "../manager/PathResolver";
+import path from "../../providers/node/path/path";
+import FsProvider from "../../providers/generic/file/FsProvider";
+import VersionNumber from "../../model/VersionNumber";
+import ManagerInformation from "../../_managerinf/ManagerInformation";
+import {EcosystemModloaderPackages, EcosystemSupportedGames} from "../../model/schema/ThunderstoreSchema";
+import {updateModLoaderExports} from "../installing/profile_installers/ModLoaderVariantRecord";
+import {getAxiosWithTimeouts} from "../../utils/HttpUtils";
+import {retry} from "../../utils/Common";
+
+type EcosystemCacheMetadata = {
+    version: string;
+    lastCheckedAt?: number;
+    lastModified?: string;
+};
+
+type EcosystemCacheWriteMetadata = {
+    lastCheckedAt?: number;
+    lastModified?: string;
+};
+
+type LatestSchemaFetchResult =
+    | {kind: "skipped"}
+    | {kind: "not-modified", lastCheckedAt: number, lastModified?: string}
+    | {kind: "fetched", schema: ThunderstoreEcosystem, lastCheckedAt: number, lastModified?: string}
+    | {kind: "failed"};
+
+export type MergedThunderstoreEcosystem = ThunderstoreEcosystem & EcosystemCacheMetadata;
+
+const ECOSYSTEM_DATA_URL = "https://thunderstore.io/api/experimental/schema/dev/latest/";
+const ECOSYSTEM_REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000;
+
+function createEmptySchema(): ThunderstoreEcosystem {
+    return {
+        schemaVersion: "",
+        communities: {},
+        games: {},
+        modloaderPackages: [],
+        packageInstallers: {},
+    };
+}
+
+function validateSchema(schema: unknown): ThunderstoreEcosystem {
+    const ajv = new Ajv();
+    addFormats(ajv);
+
+    const validate = ajv.compile(jsonSchema);
+    const isOk = validate(schema);
+
+    if (!isOk) {
+        throw new R2Error("Schema validation error", ajv.errorsText(validate.errors));
+    }
+
+    return schema as ThunderstoreEcosystem;
+}
+
+function isSchemaRefreshDue(schema: MergedThunderstoreEcosystem | null): boolean {
+    if (schema == null || schema.lastCheckedAt == null) {
+        return true;
+    }
+    return (Date.now() - schema.lastCheckedAt) >= ECOSYSTEM_REFRESH_INTERVAL_MS;
+}
+
+function mergeSchemas(
+    bundledSchema: ThunderstoreEcosystem,
+    latestSchema: ThunderstoreEcosystem
+): ThunderstoreEcosystem {
+    const mergedSchema: ThunderstoreEcosystem = createEmptySchema();
+    mergedSchema.schemaVersion = latestSchema.schemaVersion;
+    mergedSchema.communities = {
+        ...bundledSchema.communities,
+        ...latestSchema.communities,
+    }
+    mergedSchema.games = {
+        ...bundledSchema.games,
+        ...latestSchema.games,
+    };
+    // Convert to map to handle duplicate keys nicely
+    const modloaderMap = new Map(
+        [...bundledSchema.modloaderPackages, ...latestSchema.modloaderPackages]
+            .map(pkg => [pkg.packageId, pkg])
+    );
+    mergedSchema.modloaderPackages = [...modloaderMap.values()];
+    mergedSchema.packageInstallers = {
+        ...bundledSchema.packageInstallers,
+        ...latestSchema.packageInstallers,
+    };
+    return mergedSchema;
+}
+
+function createCacheMetadata(
+    lastCheckedAt: number,
+    lastModified?: string
+): EcosystemCacheWriteMetadata {
+    const metadata: EcosystemCacheWriteMetadata = {lastCheckedAt};
+    if (lastModified != null) {
+        metadata.lastModified = lastModified;
+    }
+    return metadata;
+}
+
+async function getMergedEcosystemPath(): Promise<string> {
+    return path.join(PathResolver.ROOT, "ecosystem-merge.json");
+}
+
+export async function updateLatestMergedEcosystemSchema(): Promise<void> {
+    const bundledSchema = await loadBundledSchema();
+    const currentMergedSchema = await getValidSavedMergedEcosystemSchema();
+    const latestSchema = await fetchLatestSchema(currentMergedSchema);
+
+    if (latestSchema.kind === "skipped") {
+        return;
+    }
+
+    if (latestSchema.kind === "not-modified") {
+        if (currentMergedSchema == null) {
+            return;
+        }
+
+        const lastModified = latestSchema.lastModified ?? currentMergedSchema.lastModified;
+        await writeLatestMergedEcosystemSchema(
+            currentMergedSchema,
+            createCacheMetadata(latestSchema.lastCheckedAt, lastModified)
+        );
+        return;
+    }
+
+    if (latestSchema.kind === "failed") {
+        if (currentMergedSchema != null) {
+            return;
+        }
+
+        const mergedSchema = mergeSchemas(bundledSchema, createEmptySchema());
+        await writeLatestMergedEcosystemSchema(mergedSchema);
+        await internalUpdateEcosystemReactives(mergedSchema);
+        return;
+    }
+
+    const mergedSchema = mergeSchemas(bundledSchema, latestSchema.schema);
+    await writeLatestMergedEcosystemSchema(
+        mergedSchema,
+        createCacheMetadata(latestSchema.lastCheckedAt, latestSchema.lastModified)
+    );
+    await internalUpdateEcosystemReactives(mergedSchema);
+}
+
+async function writeLatestMergedEcosystemSchema(
+    schema: ThunderstoreEcosystem,
+    metadata?: EcosystemCacheWriteMetadata
+): Promise<void> {
+    const asMergedSchema: MergedThunderstoreEcosystem = {
+        ...schema,
+        version: ManagerInformation.VERSION.toString(),
+        ...(metadata || {}),
+    };
+    const writable = JSON.stringify(asMergedSchema);
+    return FsProvider.instance.writeFile(await getMergedEcosystemPath(), writable);
+}
+
+async function getLastSavedMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
+    const contentBuffer = await FsProvider.instance.readFile(await getMergedEcosystemPath());
+    const content = contentBuffer.toString("utf8");
+    return JSON.parse(content);
+}
+
+async function loadBundledSchema(): Promise<ThunderstoreEcosystem> {
+    return validateSchema(bundledEcosystem);
+}
+
+async function fetchLatestSchema(
+    currentSchema: MergedThunderstoreEcosystem | null
+): Promise<LatestSchemaFetchResult> {
+    if (!isSchemaRefreshDue(currentSchema)) {
+        return {kind: "skipped"};
+    }
+
+    const timeout = 5000;
+    const options = {attempts: 3, interval: 1000, throwLastErrorAsIs: true};
+    const requestConfig = {
+        validateStatus: (status: number) => status === 304 || (status >= 200 && status < 300),
+        ...(currentSchema?.lastModified ? {headers: {"If-Modified-Since": currentSchema.lastModified}} : {}),
+    };
+
+    try {
+        const axios = getAxiosWithTimeouts(timeout, timeout * 2);
+        const response = await retry(
+            () => axios.get(ECOSYSTEM_DATA_URL, requestConfig),
+            options
+        );
+        const lastCheckedAt = Date.now();
+        const lastModified = typeof response.headers["last-modified"] === "string"
+            ? response.headers["last-modified"]
+            : undefined;
+
+        if (response.status === 304) {
+            return {
+                kind: "not-modified",
+                lastCheckedAt,
+                ...(currentSchema?.lastModified ? {lastModified: currentSchema.lastModified} : {}),
+            };
+        }
+
+        return {
+            kind: "fetched",
+            schema: validateSchema(response.data),
+            lastCheckedAt,
+            ...(lastModified ? {lastModified} : {}),
+        };
+    } catch (e) {
+        console.error(e);
+        return {kind: "failed"};
+    }
+}
+
+async function getValidSavedMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem | null> {
+    const mergeFilePath = await getMergedEcosystemPath();
+    if (!(await FsProvider.instance.exists(mergeFilePath))) {
+        return null;
+    }
+
+    const content = await getLastSavedMergedEcosystemSchema();
+    if (!new VersionNumber(content.version).isEqualTo(ManagerInformation.VERSION)) {
+        return null;
+    }
+
+    return content;
+}
+
+async function resolveMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
+    const bundledSchema = async () => ({...(await loadBundledSchema()), version: ManagerInformation.VERSION.toString()});
+    const content = await getValidSavedMergedEcosystemSchema();
+    if (content == null) {
+        return bundledSchema();
+    }
+
+    return content;
+}
+
+async function internalUpdateEcosystemReactives(schema: ThunderstoreEcosystem): Promise<void> {
+    const result: [string, R2Modman][] = []
+    for (const [identifier, game] of Object.entries(schema.games)) {
+        if (game.r2modman == null) continue;
+        for (const entry of game.r2modman) {
+            result.push([identifier, entry]);
+        }
+    }
+    EcosystemSupportedGames.value = result;
+    EcosystemModloaderPackages.value = schema.modloaderPackages;
+    updateModLoaderExports();
+}
+
+export async function updateEcosystemReactives() {
+    const mergedSchema = await resolveMergedEcosystemSchema();
+    await internalUpdateEcosystemReactives(mergedSchema);
+}

--- a/src/r2mm/ecosystem/EcosystemMerge.ts
+++ b/src/r2mm/ecosystem/EcosystemMerge.ts
@@ -17,7 +17,7 @@ async function getMergedEcosystemPath(): Promise<string> {
     return path.join(PathResolver.MOD_ROOT, "ecosystem-merge.json");
 }
 
-async function updateLatestMergedEcosystemSchema(): Promise<void> {
+export async function updateLatestMergedEcosystemSchema(): Promise<void> {
     const bundledSchema = await loadBundledSchema();
     const latestSchema = await fetchLatestSchema();
     const mergedSchema: ThunderstoreEcosystem = {
@@ -46,6 +46,17 @@ async function updateLatestMergedEcosystemSchema(): Promise<void> {
         ...bundledSchema.packageInstallers,
         ...latestSchema.packageInstallers,
     };
+    await writeLatestMergedEcosystemSchema(mergedSchema);
+    await internalUpdateEcosystemReactives(mergedSchema);
+}
+
+async function writeLatestMergedEcosystemSchema(schema: ThunderstoreEcosystem): Promise<void> {
+    const asMergedSchema: MergedThunderstoreEcosystem = {
+        ...schema,
+        version: ManagerInformation.VERSION.toString(),
+    };
+    const writable = JSON.stringify(asMergedSchema);
+    return FsProvider.instance.writeFile(await getMergedEcosystemPath(), writable);
 }
 
 async function getLastSavedMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
@@ -86,15 +97,22 @@ async function resolveMergedEcosystemSchema(): Promise<MergedThunderstoreEcosyst
     return content;
 }
 
-export async function updateEcosystemReactives() {
-    const mergedSchema = await resolveMergedEcosystemSchema();
+async function internalUpdateEcosystemReactives(schema: ThunderstoreEcosystem): Promise<void> {
     const result: [string, R2Modman][] = []
-    for (const [identifier, game] of Object.entries(mergedSchema.games)) {
+    for (const [identifier, game] of Object.entries(schema.games)) {
         if (game.r2modman == null) continue;
         for (const entry of game.r2modman) {
             result.push([identifier, entry]);
         }
     }
     EcosystemSupportedGames.value = result;
-    EcosystemModloaderPackages.value = mergedSchema.modloaderPackages;
+    EcosystemModloaderPackages.value = schema.modloaderPackages;
+}
+
+export async function updateEcosystemReactives() {
+    const mergedSchema = await resolveMergedEcosystemSchema();
+    await internalUpdateEcosystemReactives(mergedSchema);
+    return new Promise(resolve => {
+        setTimeout(resolve, 3000);
+    });
 }

--- a/src/r2mm/ecosystem/EcosystemSchema.ts
+++ b/src/r2mm/ecosystem/EcosystemSchema.ts
@@ -12,47 +12,20 @@ import ManagerInformation from "../../_managerinf/ManagerInformation";
 import {EcosystemModloaderPackages, EcosystemSupportedGames} from "../../model/schema/ThunderstoreSchema";
 import {updateModLoaderExports} from "../installing/profile_installers/ModLoaderVariantRecord";
 
-export type MergedThunderstoreEcosystem = ThunderstoreEcosystem & {version: string};
+export type VersionedThunderstoreEcosystem = ThunderstoreEcosystem & {version: string};
 
 async function getMergedEcosystemPath(): Promise<string> {
-    return path.join(PathResolver.ROOT, "ecosystem-merge.json");
+    return path.join(PathResolver.ROOT, "latest-ecosystem-schema.json");
 }
 
-export async function updateLatestMergedEcosystemSchema(): Promise<void> {
-    const bundledSchema = await loadBundledSchema();
+export async function updateLatestEcosystemSchema(): Promise<void> {
     const latestSchema = await fetchLatestSchema();
-    const mergedSchema: ThunderstoreEcosystem = {
-        schemaVersion: "",
-        communities: {},
-        games: {},
-        modloaderPackages: [],
-        packageInstallers: {},
-    };
-    mergedSchema.schemaVersion = latestSchema.schemaVersion;
-    mergedSchema.communities = {
-        ...bundledSchema.communities,
-        ...latestSchema.communities,
-    }
-    mergedSchema.games = {
-        ...bundledSchema.games,
-        ...latestSchema.games,
-    };
-    // Convert to map to handle duplicate keys nicely
-    const modloaderMap = new Map(
-        [...bundledSchema.modloaderPackages, ...latestSchema.modloaderPackages]
-            .map(pkg => [pkg.packageId, pkg])
-    );
-    mergedSchema.modloaderPackages = [...modloaderMap.values()];
-    mergedSchema.packageInstallers = {
-        ...bundledSchema.packageInstallers,
-        ...latestSchema.packageInstallers,
-    };
-    await writeLatestMergedEcosystemSchema(mergedSchema);
-    await internalUpdateEcosystemReactives(mergedSchema);
+    await writeLatestEcosystemSchema(latestSchema);
+    await internalUpdateEcosystemReactives(latestSchema);
 }
 
-async function writeLatestMergedEcosystemSchema(schema: ThunderstoreEcosystem): Promise<void> {
-    const asMergedSchema: MergedThunderstoreEcosystem = {
+async function writeLatestEcosystemSchema(schema: ThunderstoreEcosystem): Promise<void> {
+    const asMergedSchema: VersionedThunderstoreEcosystem = {
         ...schema,
         version: ManagerInformation.VERSION.toString(),
     };
@@ -60,7 +33,7 @@ async function writeLatestMergedEcosystemSchema(schema: ThunderstoreEcosystem): 
     return FsProvider.instance.writeFile(await getMergedEcosystemPath(), writable);
 }
 
-async function getLastSavedMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
+async function getLastSavedEcosystemSchema(): Promise<VersionedThunderstoreEcosystem> {
     const contentBuffer = await FsProvider.instance.readFile(await getMergedEcosystemPath());
     const content = contentBuffer.toString("utf8");
     return JSON.parse(content);
@@ -91,13 +64,13 @@ async function fetchLatestSchema(): Promise<ThunderstoreEcosystem> {
     };
 }
 
-async function resolveMergedEcosystemSchema(): Promise<MergedThunderstoreEcosystem> {
+async function resolveCachedEcosystemSchema(): Promise<VersionedThunderstoreEcosystem> {
     const mergeFilePath = await getMergedEcosystemPath();
     const bundledSchema = async () => ({...(await loadBundledSchema()), version: ManagerInformation.VERSION.toString()});
     if (!(await FsProvider.instance.exists(mergeFilePath))) {
         return bundledSchema();
     }
-    const content = await getLastSavedMergedEcosystemSchema();
+    const content = await getLastSavedEcosystemSchema();
     if (!new VersionNumber(content.version).isEqualTo(ManagerInformation.VERSION)) {
         return bundledSchema();
     }
@@ -118,6 +91,6 @@ async function internalUpdateEcosystemReactives(schema: ThunderstoreEcosystem): 
 }
 
 export async function updateEcosystemReactives() {
-    const mergedSchema = await resolveMergedEcosystemSchema();
+    const mergedSchema = await resolveCachedEcosystemSchema();
     await internalUpdateEcosystemReactives(mergedSchema);
 }

--- a/src/r2mm/installing/InstallationRules.ts
+++ b/src/r2mm/installing/InstallationRules.ts
@@ -1,6 +1,6 @@
 import { getPluginInstaller } from '../../installers/registry';
 import GameManager from '../../model/game/GameManager';
-import { EcosystemSchema, TrackingMethod } from '../../model/schema/ThunderstoreSchema';
+import {EcosystemSupportedGames, TrackingMethod} from '../../model/schema/ThunderstoreSchema';
 import path from '../../providers/node/path/path';
 
 export type CoreRuleType = {
@@ -39,7 +39,7 @@ export default class InstallationRules {
     }
 
     public static apply() {
-        this._RULES = EcosystemSchema.supportedGames.map(([_, x]) => ({
+        this._RULES = EcosystemSupportedGames.value.map(([_, x]) => ({
             gameName: x.internalFolderName,
             rules: x.installRules,
             relativeFileExclusions: x.relativeFileExclusions,

--- a/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
+++ b/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
@@ -6,17 +6,6 @@ import {
     PackageLoader
 } from '../../../model/schema/ThunderstoreSchema';
 
-/**
- * A set of modloader packages read from the ecosystem schema.
- */
-export const MODLOADER_PACKAGES = EcosystemModloaderPackages.value.map((x) =>
-    new ModLoaderPackageMapping(
-        x.packageId,
-        x.rootFolder,
-        x.loader,
-    ),
-);
-
 type Modloaders = Record<string, ModLoaderPackageMapping[]>;
 
 // Overrides are needed as the "recommended version" information
@@ -32,13 +21,21 @@ const OVERRIDES: Modloaders = {
     ],
 }
 
-export const MOD_LOADER_VARIANTS: Modloaders = Object.fromEntries(
-    EcosystemSupportedGames.value
-        .map(([_, game]) => [
-            game.internalFolderName,
-            OVERRIDES[game.internalFolderName] || MODLOADER_PACKAGES
-        ])
-);
+export let MODLOADER_PACKAGES: ModLoaderPackageMapping[] = [];
+export let MOD_LOADER_VARIANTS: Modloaders = {};
+
+export function updateModLoaderExports() {
+    MODLOADER_PACKAGES = EcosystemModloaderPackages.value.map((x) =>
+        new ModLoaderPackageMapping(x.packageId, x.rootFolder, x.loader)
+    );
+    MOD_LOADER_VARIANTS = Object.fromEntries(
+        EcosystemSupportedGames.value
+            .map(([_, game]) => [
+                game.internalFolderName,
+                OVERRIDES[game.internalFolderName] || MODLOADER_PACKAGES
+            ])
+    );
+}
 
 export const getModLoaderPackageNames = () => {
     const deduplicated = new Set(EcosystemModloaderPackages.value.map((x) => x.packageId));

--- a/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
+++ b/src/r2mm/installing/profile_installers/ModLoaderVariantRecord.ts
@@ -1,11 +1,15 @@
 import ModLoaderPackageMapping from '../../../model/installing/ModLoaderPackageMapping';
 import VersionNumber from '../../../model/VersionNumber';
-import { EcosystemSchema, PackageLoader } from '../../../model/schema/ThunderstoreSchema';
+import {
+    EcosystemModloaderPackages,
+    EcosystemSupportedGames,
+    PackageLoader
+} from '../../../model/schema/ThunderstoreSchema';
 
 /**
  * A set of modloader packages read from the ecosystem schema.
  */
-export const MODLOADER_PACKAGES = EcosystemSchema.modloaderPackages.map((x) =>
+export const MODLOADER_PACKAGES = EcosystemModloaderPackages.value.map((x) =>
     new ModLoaderPackageMapping(
         x.packageId,
         x.rootFolder,
@@ -29,7 +33,7 @@ const OVERRIDES: Modloaders = {
 }
 
 export const MOD_LOADER_VARIANTS: Modloaders = Object.fromEntries(
-    EcosystemSchema.supportedGames
+    EcosystemSupportedGames.value
         .map(([_, game]) => [
             game.internalFolderName,
             OVERRIDES[game.internalFolderName] || MODLOADER_PACKAGES
@@ -37,7 +41,7 @@ export const MOD_LOADER_VARIANTS: Modloaders = Object.fromEntries(
 );
 
 export const getModLoaderPackageNames = () => {
-    const deduplicated = new Set(EcosystemSchema.modloaderPackages.map((x) => x.packageId));
+    const deduplicated = new Set(EcosystemModloaderPackages.value.map((x) => x.packageId));
     const names = Array.from(deduplicated);
     names.sort();
     return names;

--- a/test/vitest/tests/unit/EcosystemMerge/EcosystemMerge.spec.ts
+++ b/test/vitest/tests/unit/EcosystemMerge/EcosystemMerge.spec.ts
@@ -45,19 +45,23 @@ describe('EcosystemMerge', () => {
         test('falls back to bundled schema when no cache file exists', async () => {
             expect(EcosystemSupportedGames.value).toHaveLength(0);
             expect(EcosystemModloaderPackages.value).toHaveLength(0);
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
 
             await updateEcosystemReactives();
 
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
             expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
             expect(EcosystemModloaderPackages.value.length).toBeGreaterThan(0);
         });
 
         test('loads from cache when version matches', async () => {
             expect(EcosystemSupportedGames.value).toHaveLength(0);
-            await writeCacheFile({games: {}, modloaderPackages: []});
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
 
+            await writeCacheFile({games: {}, modloaderPackages: []});
             await updateEcosystemReactives();
 
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(true);
             expect(EcosystemSupportedGames.value).toHaveLength(0);
         });
 

--- a/test/vitest/tests/unit/EcosystemMerge/EcosystemMerge.spec.ts
+++ b/test/vitest/tests/unit/EcosystemMerge/EcosystemMerge.spec.ts
@@ -1,0 +1,136 @@
+import * as path from 'path';
+import {beforeEach, describe, expect, test} from 'vitest';
+
+import {MergedThunderstoreEcosystem, updateEcosystemReactives, updateLatestMergedEcosystemSchema} from '../../../../../src/r2mm/ecosystem/EcosystemMerge';
+import {EcosystemModloaderPackages, EcosystemSupportedGames} from '../../../../../src/model/schema/ThunderstoreSchema';
+import {MODLOADER_PACKAGES, MOD_LOADER_VARIANTS, updateModLoaderExports} from '../../../../../src/r2mm/installing/profile_installers/ModLoaderVariantRecord';
+import InMemoryFsProvider from '../../../stubs/providers/InMemory.FsProvider';
+import FsProvider from '../../../../../src/providers/generic/file/FsProvider';
+import PathResolver from '../../../../../src/r2mm/manager/PathResolver';
+import {providePathImplementation} from '../../../../../src/providers/node/path/path';
+import {TestPathProvider} from '../../../stubs/providers/node/Node.Path.Provider';
+import ManagerInformation from '../../../../../src/_managerinf/ManagerInformation';
+
+const TEST_ROOT = 'TEST_ROOT';
+const mergeFilePath = path.join(TEST_ROOT, 'ecosystem-merge.json');
+
+async function writeCacheFile(schema: Partial<MergedThunderstoreEcosystem>) {
+    const full: MergedThunderstoreEcosystem = {
+        schemaVersion: '0.0.0',
+        communities: {},
+        games: {},
+        modloaderPackages: [],
+        packageInstallers: {},
+        version: ManagerInformation.VERSION.toString(),
+        ...schema,
+    };
+    await FsProvider.instance.writeFile(mergeFilePath, JSON.stringify(full));
+}
+
+describe('EcosystemMerge', () => {
+
+    beforeEach(async () => {
+        providePathImplementation(() => TestPathProvider);
+        InMemoryFsProvider.clear();
+        FsProvider.provide(() => new InMemoryFsProvider());
+        PathResolver.ROOT = TEST_ROOT;
+        EcosystemSupportedGames.value = [];
+        EcosystemModloaderPackages.value = [];
+        updateModLoaderExports();
+        await FsProvider.instance.mkdirs(TEST_ROOT);
+    });
+
+    describe('updateEcosystemReactives', () => {
+
+        test('falls back to bundled schema when no cache file exists', async () => {
+            expect(EcosystemSupportedGames.value).toHaveLength(0);
+            expect(EcosystemModloaderPackages.value).toHaveLength(0);
+
+            await updateEcosystemReactives();
+
+            expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
+            expect(EcosystemModloaderPackages.value.length).toBeGreaterThan(0);
+        });
+
+        test('loads from cache when version matches', async () => {
+            expect(EcosystemSupportedGames.value).toHaveLength(0);
+            await writeCacheFile({games: {}, modloaderPackages: []});
+
+            await updateEcosystemReactives();
+
+            expect(EcosystemSupportedGames.value).toHaveLength(0);
+        });
+
+        test('falls back to bundled schema when cached version is stale', async () => {
+            expect(EcosystemSupportedGames.value).toHaveLength(0);
+            await writeCacheFile({version: '0.0.0'});
+
+            await updateEcosystemReactives();
+
+            expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
+        });
+
+        test('populates mod loader exports after updating reactives', async () => {
+            expect(MODLOADER_PACKAGES.length).toBe(0);
+            expect(Object.keys(MOD_LOADER_VARIANTS).length).toBe(0);
+
+            await updateEcosystemReactives();
+
+            expect(MODLOADER_PACKAGES.length).toBeGreaterThan(0);
+            expect(Object.keys(MOD_LOADER_VARIANTS).length).toBeGreaterThan(0);
+        });
+
+    });
+
+    describe('updateLatestMergedEcosystemSchema', () => {
+
+        test('writes merge file to disk', async () => {
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+
+            await updateLatestMergedEcosystemSchema();
+
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(true);
+        });
+
+        test('written file contains current version', async () => {
+            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+
+            await updateLatestMergedEcosystemSchema();
+
+            const content = (await FsProvider.instance.readFile(mergeFilePath)).toString('utf8');
+            const parsed: MergedThunderstoreEcosystem = JSON.parse(content);
+            expect(parsed.version).toBe(ManagerInformation.VERSION.toString());
+        });
+
+        test('bundled games are preserved when latest schema is empty', async () => {
+            expect(EcosystemSupportedGames.value).toHaveLength(0);
+
+            await updateLatestMergedEcosystemSchema();
+
+            expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
+        });
+
+        test('games absent from latest schema are preserved from bundled', async () => {
+            await writeCacheFile({games: {}, modloaderPackages: []});
+            await updateEcosystemReactives();
+            expect(EcosystemSupportedGames.value.find(([_, g]) => g.internalFolderName === 'RiskOfRain2')).toBeUndefined();
+
+            await updateLatestMergedEcosystemSchema();
+
+            const game = EcosystemSupportedGames.value
+                .find(([_, game]) => game.internalFolderName === 'RiskOfRain2');
+            expect(game).toBeDefined();
+        });
+
+        test('overwrites existing cache file', async () => {
+            await writeCacheFile({games: {}, modloaderPackages: []});
+            expect(EcosystemSupportedGames.value).toHaveLength(0);
+
+            await updateLatestMergedEcosystemSchema();
+
+            expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
+        });
+
+    });
+
+});

--- a/test/vitest/tests/unit/EcosystemSchema/EcosystemSchema.spec.ts
+++ b/test/vitest/tests/unit/EcosystemSchema/EcosystemSchema.spec.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import {beforeEach, describe, expect, test} from 'vitest';
 
-import {MergedThunderstoreEcosystem, updateEcosystemReactives, updateLatestMergedEcosystemSchema} from '../../../../../src/r2mm/ecosystem/EcosystemMerge';
+import {VersionedThunderstoreEcosystem, updateEcosystemReactives, updateLatestEcosystemSchema} from 'src/r2mm/ecosystem/EcosystemSchema';
 import {EcosystemModloaderPackages, EcosystemSupportedGames} from '../../../../../src/model/schema/ThunderstoreSchema';
 import {MODLOADER_PACKAGES, MOD_LOADER_VARIANTS, updateModLoaderExports} from '../../../../../src/r2mm/installing/profile_installers/ModLoaderVariantRecord';
 import InMemoryFsProvider from '../../../stubs/providers/InMemory.FsProvider';
@@ -12,10 +12,10 @@ import {TestPathProvider} from '../../../stubs/providers/node/Node.Path.Provider
 import ManagerInformation from '../../../../../src/_managerinf/ManagerInformation';
 
 const TEST_ROOT = 'TEST_ROOT';
-const mergeFilePath = path.join(TEST_ROOT, 'ecosystem-merge.json');
+const latestSchemaFilePath = path.join(TEST_ROOT, 'latest-ecosystem-schema.json');
 
-async function writeCacheFile(schema: Partial<MergedThunderstoreEcosystem>) {
-    const full: MergedThunderstoreEcosystem = {
+async function writeCacheFile(schema: Partial<VersionedThunderstoreEcosystem>) {
+    const full: VersionedThunderstoreEcosystem = {
         schemaVersion: '0.0.0',
         communities: {},
         games: {},
@@ -24,10 +24,10 @@ async function writeCacheFile(schema: Partial<MergedThunderstoreEcosystem>) {
         version: ManagerInformation.VERSION.toString(),
         ...schema,
     };
-    await FsProvider.instance.writeFile(mergeFilePath, JSON.stringify(full));
+    await FsProvider.instance.writeFile(latestSchemaFilePath, JSON.stringify(full));
 }
 
-describe('EcosystemMerge', () => {
+describe('EcosystemSchema', () => {
 
     beforeEach(async () => {
         providePathImplementation(() => TestPathProvider);
@@ -45,23 +45,23 @@ describe('EcosystemMerge', () => {
         test('falls back to bundled schema when no cache file exists', async () => {
             expect(EcosystemSupportedGames.value).toHaveLength(0);
             expect(EcosystemModloaderPackages.value).toHaveLength(0);
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(false);
 
             await updateEcosystemReactives();
 
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(false);
             expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
             expect(EcosystemModloaderPackages.value.length).toBeGreaterThan(0);
         });
 
         test('loads from cache when version matches', async () => {
             expect(EcosystemSupportedGames.value).toHaveLength(0);
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(false);
 
             await writeCacheFile({games: {}, modloaderPackages: []});
             await updateEcosystemReactives();
 
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(true);
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(true);
             expect(EcosystemSupportedGames.value).toHaveLength(0);
         });
 
@@ -86,53 +86,24 @@ describe('EcosystemMerge', () => {
 
     });
 
-    describe('updateLatestMergedEcosystemSchema', () => {
+    describe('updateLatestEcosystemSchema', () => {
 
-        test('writes merge file to disk', async () => {
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+        test('writes file to disk', async () => {
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(false);
 
-            await updateLatestMergedEcosystemSchema();
+            await updateLatestEcosystemSchema();
 
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(true);
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(true);
         });
 
         test('written file contains current version', async () => {
-            expect(await FsProvider.instance.exists(mergeFilePath)).toBe(false);
+            expect(await FsProvider.instance.exists(latestSchemaFilePath)).toBe(false);
 
-            await updateLatestMergedEcosystemSchema();
+            await updateLatestEcosystemSchema();
 
-            const content = (await FsProvider.instance.readFile(mergeFilePath)).toString('utf8');
-            const parsed: MergedThunderstoreEcosystem = JSON.parse(content);
+            const content = (await FsProvider.instance.readFile(latestSchemaFilePath)).toString('utf8');
+            const parsed: VersionedThunderstoreEcosystem = JSON.parse(content);
             expect(parsed.version).toBe(ManagerInformation.VERSION.toString());
-        });
-
-        test('bundled games are preserved when latest schema is empty', async () => {
-            expect(EcosystemSupportedGames.value).toHaveLength(0);
-
-            await updateLatestMergedEcosystemSchema();
-
-            expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
-        });
-
-        test('games absent from latest schema are preserved from bundled', async () => {
-            await writeCacheFile({games: {}, modloaderPackages: []});
-            await updateEcosystemReactives();
-            expect(EcosystemSupportedGames.value.find(([_, g]) => g.internalFolderName === 'RiskOfRain2')).toBeUndefined();
-
-            await updateLatestMergedEcosystemSchema();
-
-            const game = EcosystemSupportedGames.value
-                .find(([_, game]) => game.internalFolderName === 'RiskOfRain2');
-            expect(game).toBeDefined();
-        });
-
-        test('overwrites existing cache file', async () => {
-            await writeCacheFile({games: {}, modloaderPackages: []});
-            expect(EcosystemSupportedGames.value).toHaveLength(0);
-
-            await updateLatestMergedEcosystemSchema();
-
-            expect(EcosystemSupportedGames.value.length).toBeGreaterThan(0);
         });
 
     });

--- a/test/vitest/tests/unit/GameDirectoryResolver/GameDirectoryResolver.spec.ts
+++ b/test/vitest/tests/unit/GameDirectoryResolver/GameDirectoryResolver.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import {beforeAll, beforeEach, describe, expect, test} from 'vitest';
 import path from 'path';
 import FsProvider from '../../../../../src/providers/generic/file/FsProvider';
 import GameManager from '../../../../../src/model/game/GameManager';
@@ -6,16 +6,21 @@ import GameDirectoryResolverImpl from '../../../../../src/r2mm/manager/win32/Gam
 import InMemoryFsProvider from '../../../stubs/providers/InMemory.FsProvider';
 import { providePathImplementation } from '../../../../../src/providers/node/path/path';
 import { TestPathProvider } from '../../../stubs/providers/node/Node.Path.Provider';
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemMerge";
 
 describe.skipIf(process.platform !== 'win32')('GameDirectoryResolver', () => {
     const steamRoot = 'TEST_STEAM_PATH';
     let resolver: GameDirectoryResolverImpl;
 
-    beforeEach(async () => {
-        providePathImplementation(() => TestPathProvider);
+    beforeAll(async () => {
         const inMemoryFs = new InMemoryFsProvider();
         FsProvider.provide(() => inMemoryFs);
         InMemoryFsProvider.clear();
+        providePathImplementation(() => TestPathProvider);
+        await updateEcosystemReactives();
+    })
+
+    beforeEach(async () => {
         resolver = new GameDirectoryResolverImpl();
         await FsProvider.instance.mkdirs(path.join(steamRoot, 'steamapps', 'common'));
     });

--- a/test/vitest/tests/unit/GameDirectoryResolver/GameDirectoryResolver.spec.ts
+++ b/test/vitest/tests/unit/GameDirectoryResolver/GameDirectoryResolver.spec.ts
@@ -6,7 +6,7 @@ import GameDirectoryResolverImpl from '../../../../../src/r2mm/manager/win32/Gam
 import InMemoryFsProvider from '../../../stubs/providers/InMemory.FsProvider';
 import { providePathImplementation } from '../../../../../src/providers/node/path/path';
 import { TestPathProvider } from '../../../stubs/providers/node/Node.Path.Provider';
-import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemMerge";
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemSchema";
 
 describe.skipIf(process.platform !== 'win32')('GameDirectoryResolver', () => {
     const steamRoot = 'TEST_STEAM_PATH';

--- a/test/vitest/tests/unit/MelonLoader/state.spec.ts
+++ b/test/vitest/tests/unit/MelonLoader/state.spec.ts
@@ -17,7 +17,7 @@ import {describe, beforeEach, afterEach, test, expect, beforeAll} from 'vitest';
 import {providePathImplementation} from "../../../../../src/providers/node/path/path";
 import {TestPathProvider} from "../../../stubs/providers/node/Node.Path.Provider";
 import StubProfileProvider from '../../../stubs/providers/stub.ProfileProvider';
-import {updateEcosystemReactives} from "../../../../../src/r2mm/ecosystem/EcosystemMerge";
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemSchema";
 import InMemoryFsProvider from "../../../stubs/providers/InMemory.FsProvider";
 
 providePathImplementation(() => TestPathProvider);

--- a/test/vitest/tests/unit/MelonLoader/state.spec.ts
+++ b/test/vitest/tests/unit/MelonLoader/state.spec.ts
@@ -13,10 +13,12 @@ import GenericProfileInstaller from '../../../../../src/r2mm/installing/profile_
 import GameManager from '../../../../../src/model/game/GameManager';
 import ConflictManagementProvider from '../../../../../src/providers/generic/installing/ConflictManagementProvider';
 import { addToStateFile } from '../../../../../src/installers/InstallRulePluginInstaller';
-import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import {describe, beforeEach, afterEach, test, expect, beforeAll} from 'vitest';
 import {providePathImplementation} from "../../../../../src/providers/node/path/path";
 import {TestPathProvider} from "../../../stubs/providers/node/Node.Path.Provider";
 import StubProfileProvider from '../../../stubs/providers/stub.ProfileProvider';
+import {updateEcosystemReactives} from "../../../../../src/r2mm/ecosystem/EcosystemMerge";
+import InMemoryFsProvider from "../../../stubs/providers/InMemory.FsProvider";
 
 providePathImplementation(() => TestPathProvider);
 
@@ -40,6 +42,13 @@ let beforeSetup = () => {
 describe("State testing", () => {
 
     describe("State file", () => {
+
+        beforeAll(async () => {
+            const inMemoryFs = new InMemoryFsProvider();
+            FsProvider.provide(() => inMemoryFs);
+            InMemoryFsProvider.clear();
+            await updateEcosystemReactives();
+        })
 
         beforeEach(beforeSetup);
         afterEach(() => {
@@ -66,7 +75,7 @@ describe("State testing", () => {
                 profile
             );
 
-            const out = fsStub.writeFile.args[0][1] as unknown as string;
+            const out = fsStub.writeFile.args[0]![1] as unknown as string;
             const parsed = yaml.parse(out) as ModFileTracker;
             expect(parsed.modName).toBe(fakeMod.getName());
             // JSON serialization for speed comparison
@@ -135,7 +144,7 @@ describe("State testing", () => {
 
             const outputState = await processConflictManagement(modA, modFileTrackerA, modB, modFileTrackerB);
 
-            expect(outputState.currentState.join(",")).toBe([[modFileTrackerA.files[0][1], modA.getName()], [modFileTrackerB.files[0][1], modB.getName()]].join(","));
+            expect(outputState.currentState.join(",")).toBe([[modFileTrackerA.files[0]![1], modA.getName()], [modFileTrackerB.files[0]![1], modB.getName()]].join(","));
 
         });
 
@@ -159,7 +168,7 @@ describe("State testing", () => {
 
             const outputState = await processConflictManagement(modA, modFileTrackerA, modB, modFileTrackerB);
 
-            expect(outputState.currentState.join(",")).toBe([[modFileTrackerB.files[0][1], modB.getName()]].join(","));
+            expect(outputState.currentState.join(",")).toBe([[modFileTrackerB.files[0]![1], modB.getName()]].join(","));
         });
 
         // If a mod is disabled, the mod files should not exist if highest priority for those files.
@@ -182,7 +191,7 @@ describe("State testing", () => {
 
             const outputState = await processConflictManagement(modA, modFileTrackerA, modB, modFileTrackerB);
 
-            expect(outputState.currentState.join(",")).toBe([[`${modFileTrackerA.files[0][1]}.manager.disabled`, modA.getName()], [modFileTrackerB.files[0][1], modB.getName()]].join(","));
+            expect(outputState.currentState.join(",")).toBe([[`${modFileTrackerA.files[0]![1]}.manager.disabled`, modA.getName()], [modFileTrackerB.files[0]![1], modB.getName()]].join(","));
         });
 
         // If a mod is disabled, any lower priority files should not be overwritten.
@@ -205,7 +214,7 @@ describe("State testing", () => {
 
             const outputState = await processConflictManagement(modA, modFileTrackerA, modB, modFileTrackerB);
 
-            expect(outputState.currentState.join(",")).toBe([[modFileTrackerA.files[0][1], modA.getName()], [`${modFileTrackerB.files[0][1]}.manager.disabled`, modB.getName()]].join(","));
+            expect(outputState.currentState.join(",")).toBe([[modFileTrackerA.files[0]![1], modA.getName()], [`${modFileTrackerB.files[0]![1]}.manager.disabled`, modB.getName()]].join(","));
         });
 
     });
@@ -247,5 +256,5 @@ let processConflictManagement = async (modA: ManifestV2, modFileTrackerA: ModFil
 
     await conflictManagement.resolveConflicts([modA, modB], profile.asImmutableProfile());
 
-    return yaml.parse(fsStub.writeFile.args[0][1] as unknown as string) as StateTracker;
+    return yaml.parse(fsStub.writeFile.args[0]![1] as unknown as string) as StateTracker;
 }

--- a/test/vitest/tests/unit/ModLinker/ModLinker.spec.ts
+++ b/test/vitest/tests/unit/ModLinker/ModLinker.spec.ts
@@ -16,6 +16,7 @@ import { providePathImplementation } from '../../../../../src/providers/node/pat
 import { TestPathProvider } from '../../../stubs/providers/node/Node.Path.Provider';
 import { provideAppWindowImplementation } from '../../../../../src/providers/node/app/app_window';
 import { TestAppWindowProvider } from '../../../stubs/providers/node/AppWindow.Provider';
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemMerge";
 
 class ProfileProviderImpl extends ProfileProvider {
     ensureProfileDirectory(directory: string, profile: string): void {
@@ -36,6 +37,9 @@ describe.skipIf(process.platform !== 'win32')('ModLinker', async () => {
         const inMemoryFs = new InMemoryFsProvider();
         FsProvider.provide(() => inMemoryFs);
         InMemoryFsProvider.clear();
+
+        await updateEcosystemReactives();
+
         PathResolver.MOD_ROOT = 'MODS';
         await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);
         ProfileProvider.provide(() => new ProfileProviderImpl());

--- a/test/vitest/tests/unit/ModLinker/ModLinker.spec.ts
+++ b/test/vitest/tests/unit/ModLinker/ModLinker.spec.ts
@@ -16,7 +16,7 @@ import { providePathImplementation } from '../../../../../src/providers/node/pat
 import { TestPathProvider } from '../../../stubs/providers/node/Node.Path.Provider';
 import { provideAppWindowImplementation } from '../../../../../src/providers/node/app/app_window';
 import { TestAppWindowProvider } from '../../../stubs/providers/node/AppWindow.Provider';
-import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemMerge";
+import {updateEcosystemReactives} from "src/r2mm/ecosystem/EcosystemSchema";
 
 class ProfileProviderImpl extends ProfileProvider {
     ensureProfileDirectory(directory: string, profile: string): void {

--- a/test/vitest/tests/unit/Profile/Profile.ts.spec.ts
+++ b/test/vitest/tests/unit/Profile/Profile.ts.spec.ts
@@ -9,7 +9,7 @@ import PathResolver from '../../../../../src/r2mm/manager/PathResolver';
 import { beforeAll, describe, expect, test } from 'vitest';
 import { providePathImplementation } from '../../../../../src/providers/node/path/path';
 import { TestPathProvider } from '../../../stubs/providers/node/Node.Path.Provider';
-import { updateEcosystemReactives } from "src/r2mm/ecosystem/EcosystemMerge";
+import { updateEcosystemReactives } from "src/r2mm/ecosystem/EcosystemSchema";
 
 
 class ProfileProviderImpl extends ProfileProvider {

--- a/test/vitest/tests/unit/Profile/Profile.ts.spec.ts
+++ b/test/vitest/tests/unit/Profile/Profile.ts.spec.ts
@@ -9,6 +9,7 @@ import PathResolver from '../../../../../src/r2mm/manager/PathResolver';
 import { beforeAll, describe, expect, test } from 'vitest';
 import { providePathImplementation } from '../../../../../src/providers/node/path/path';
 import { TestPathProvider } from '../../../stubs/providers/node/Node.Path.Provider';
+import { updateEcosystemReactives } from "src/r2mm/ecosystem/EcosystemMerge";
 
 
 class ProfileProviderImpl extends ProfileProvider {
@@ -34,6 +35,7 @@ describe("ImmutableProfile", () => {
         FsProvider.provide(() => inMemoryFs);
         ProfileProvider.provide(() => new ProfileProviderImpl());
         InMemoryFsProvider.clear();
+        await updateEcosystemReactives();
     });
 
     test("Initializing ImmutableProfile doesn't affect Profile", () => {

--- a/test/vitest/utils/InstallLogicUtils.ts
+++ b/test/vitest/utils/InstallLogicUtils.ts
@@ -19,7 +19,7 @@ import PathResolver from '../../../src/r2mm/manager/PathResolver';
 import {providePathImplementation} from "../../../src/providers/node/path/path";
 import {TestPathProvider} from "../stubs/providers/node/Node.Path.Provider";
 import {expect} from 'vitest';
-import {updateEcosystemReactives} from "../../../src/r2mm/ecosystem/EcosystemMerge";
+import {updateEcosystemReactives} from "../../../src/r2mm/ecosystem/EcosystemSchema";
 
 class ProfileProviderImpl extends ProfileProvider {
     ensureProfileDirectory(directory: string, profile: string): void {

--- a/test/vitest/utils/InstallLogicUtils.ts
+++ b/test/vitest/utils/InstallLogicUtils.ts
@@ -19,6 +19,7 @@ import PathResolver from '../../../src/r2mm/manager/PathResolver';
 import {providePathImplementation} from "../../../src/providers/node/path/path";
 import {TestPathProvider} from "../stubs/providers/node/Node.Path.Provider";
 import {expect} from 'vitest';
+import {updateEcosystemReactives} from "../../../src/r2mm/ecosystem/EcosystemMerge";
 
 class ProfileProviderImpl extends ProfileProvider {
     ensureProfileDirectory(directory: string, profile: string): void {
@@ -36,6 +37,7 @@ export async function installLogicBeforeEach(internalFolderName: string) {
     providePathImplementation(() => TestPathProvider);
     const inMemoryFs = new InMemoryFsProvider();
     FsProvider.provide(() => inMemoryFs);
+    await updateEcosystemReactives();
     InMemoryFsProvider.clear();
     PathResolver.MOD_ROOT = 'MODS';
     await inMemoryFs.mkdirs(PathResolver.MOD_ROOT);


### PR DESCRIPTION
Fetches the latest schema from the API on game selection with a 12 hour refresh window (can be tuned or removed if not necessary). Schema is cached locally and update requests make proper use of the 304 response to avoid pulling the schema when it hasnt been updated.

Depends on #2113