### PR TITLE
Game grouping

### DIFF
--- a/src/components/composables/GameSelectionComposable.ts
+++ b/src/components/composables/GameSelectionComposable.ts
@@ -1,0 +1,203 @@
+import { computed, ref, InjectionKey } from 'vue';
+import { useRouter } from 'vue-router';
+import Game from '../../model/game/Game';
+import GameManager from '../../model/game/GameManager';
+import { GameInstanceType, GameSelectionDisplayMode, Platform } from '../../model/schema/ThunderstoreSchema';
+import { GameSelectionViewMode } from '../../model/enums/GameSelectionViewMode';
+import ManagerSettings from '../../r2mm/manager/ManagerSettings';
+import * as ManagerUtils from '../../utils/ManagerUtils';
+import ProviderUtils from '../../providers/generic/ProviderUtils';
+import R2Error from '../../model/errors/R2Error';
+import { getStore } from '../../providers/generic/store/StoreProvider';
+import { State } from '../../store';
+
+export function useGameSelectionComposable() {
+    const store = getStore<State>();
+    const router = useRouter();
+
+    const favourites = ref<string[]>([]);
+    const selectedGame = ref<Game | null>(null);
+    const selectedPlatform = ref<Platform | null>(null);
+    const filterText = ref<string>('');
+    const activeTab = ref<GameInstanceType>(GameInstanceType.GAME);
+    const viewMode = ref<GameSelectionViewMode>(GameSelectionViewMode.LIST);
+    const settings = ref<ManagerSettings | undefined>(undefined);
+    const runningMigration = ref<boolean>(false);
+    const isSettingDefaultPlatform = ref<boolean>(false);
+
+    const gameList = computed<Game[]>(() => {
+        return GameManager.gameList.sort((a, b) => {
+            if (favourites.value.includes(a.settingsIdentifier)) {
+                if (favourites.value.includes(b.settingsIdentifier)) {
+                    return a.displayName.toLowerCase().localeCompare(b.displayName.toLowerCase());
+                } else {
+                    return -1;
+                }
+            } else if (favourites.value.includes(b.settingsIdentifier)) {
+                return 1;
+            }
+            return a.displayName.toLowerCase().localeCompare(b.displayName.toLowerCase());
+        });
+    });
+
+    const matchesSearch = (game: Game): boolean => {
+        const text = filterText.value;
+        if (text.trim().length === 0) return true;
+        if (game.displayName.toLowerCase().indexOf(text.toLowerCase()) >= 0) return true;
+        return game.additionalSearchStrings.find(
+            value => value.toLowerCase().trim().indexOf(text.toLowerCase().trim()) >= 0
+        ) !== undefined;
+    };
+
+    const filteredGameList = computed(() => {
+        return gameList.value
+            .filter(matchesSearch)
+            .filter((value: Game) => value.displayMode === GameSelectionDisplayMode.VISIBLE)
+            .filter((value: Game) => value.instanceType === activeTab.value);
+    });
+
+    const favouriteGameList = computed(() => {
+        return filteredGameList.value.filter(
+            (value: Game) => favourites.value.includes(value.settingsIdentifier)
+        );
+    });
+
+    const nonFavouriteGameList = computed(() => {
+        return filteredGameList.value.filter(
+            (value: Game) => !favourites.value.includes(value.settingsIdentifier)
+        );
+    });
+
+    function isFavourited(game: Game): boolean {
+        return favourites.value.includes(game.settingsIdentifier);
+    }
+
+    function isGameSelected(game: Game): boolean {
+        return selectedGame.value !== null
+            && selectedGame.value.internalFolderName === game.internalFolderName;
+    }
+
+    function markAsSelectedGame(game: Game) {
+        selectedGame.value = game;
+    }
+
+    function toggleFavourite(game: Game) {
+        if (favourites.value.includes(game.settingsIdentifier)) {
+            favourites.value = favourites.value.filter(v => v !== game.settingsIdentifier);
+        } else {
+            favourites.value = [...favourites.value, game.settingsIdentifier];
+        }
+        settings.value?.setFavouriteGames(favourites.value);
+    }
+
+    function changeTab(tab: GameInstanceType) {
+        activeTab.value = tab;
+    }
+
+    function toggleViewMode() {
+        viewMode.value = viewMode.value === GameSelectionViewMode.LIST
+            ? GameSelectionViewMode.CARD
+            : GameSelectionViewMode.LIST;
+        settings.value?.setGameSelectionViewMode(viewMode.value);
+    }
+
+    async function proceed() {
+        if (runningMigration.value || selectedGame.value === null || selectedPlatform.value === null) {
+            return;
+        }
+
+        try {
+            ProviderUtils.setupGameProviders(selectedGame.value, selectedPlatform.value);
+        } catch (error) {
+            if (error instanceof R2Error) {
+                store.commit('error/handleError', error);
+                return;
+            }
+            throw error;
+        }
+
+        const s = await ManagerSettings.getSingleton(selectedGame.value);
+        await s.setLastSelectedGame(selectedGame.value);
+        await s.setLastSelectedPlatform(selectedPlatform.value);
+        await GameManager.activate(selectedGame.value, selectedPlatform.value);
+        await store.dispatch('setActiveGame', selectedGame.value);
+
+        await router.push({ name: 'splash' });
+    }
+
+    async function selectPlatformForGame(game: Game) {
+        const s = await ManagerSettings.getSingleton(game);
+        const platform = await s.getLastSelectedPlatform();
+        selectedPlatform.value = platform ? Platform[platform] : null;
+    }
+
+    async function initialize() {
+        runningMigration.value = true;
+        await store.dispatch('checkMigrations');
+        runningMigration.value = false;
+
+        await store.dispatch('resetLocalState');
+
+        settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
+        const globalSettings = settings.value.getContext().global;
+        favourites.value = globalSettings.favouriteGames || [];
+
+        const lastGame = GameManager.findByFolderName(globalSettings.lastSelectedGame);
+        if (lastGame) markAsSelectedGame(lastGame);
+
+        switch (globalSettings.gameSelectionViewMode) {
+            case GameSelectionViewMode.LIST:
+            case GameSelectionViewMode.CARD:
+                viewMode.value = globalSettings.gameSelectionViewMode;
+                break;
+            default:
+                viewMode.value = GameSelectionViewMode.CARD;
+        }
+
+        const { defaultGame, defaultPlatform } = ManagerUtils.getDefaults(settings.value);
+        if (defaultGame && defaultPlatform) {
+            markAsSelectedGame(defaultGame);
+            selectedPlatform.value = defaultPlatform;
+            await proceed();
+        }
+    }
+
+    async function proceedDefault() {
+        if (runningMigration.value || selectedGame.value === null || selectedPlatform.value === null) {
+            return;
+        }
+
+        const s = await ManagerSettings.getSingleton(selectedGame.value);
+        await s.setDefaultGame(selectedGame.value);
+        await s.setDefaultStorePlatform(selectedPlatform.value);
+
+        return proceed();
+    }
+
+    return {
+        favourites,
+        selectedGame,
+        selectedPlatform,
+        filterText,
+        activeTab,
+        viewMode,
+        settings,
+        runningMigration,
+        isSettingDefaultPlatform,
+        favouriteGameList,
+        nonFavouriteGameList,
+        isFavourited,
+        isGameSelected,
+        markAsSelectedGame,
+        toggleFavourite,
+        changeTab,
+        toggleViewMode,
+        proceed,
+        proceedDefault,
+        selectPlatformForGame,
+        initialize,
+    };
+}
+
+export type GameSelectionComposable = ReturnType<typeof useGameSelectionComposable>;
+export const gameSelectionKey: InjectionKey<GameSelectionComposable> = Symbol('gameSelection');

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -1,28 +1,33 @@
 <template>
-    <div class="game-card" :class="{'game-card--highlighted': props.isFavourited && props.highlightFavourite}">
-        <div class="game-card__image">
-            <template v-if="activeTab === GameInstanceType.GAME">
-                <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="game-card__thumbnail"/>
-            </template>
-            <template v-else>
-                <div class="game-card__placeholder">{{ game.displayName }}</div>
-            </template>
+    <div class="game-card-wrapper">
+        <div class="game-card" :class="{'game-card--highlighted': props.isFavourited && props.highlightFavourite}">
+            <div class="game-card__image">
+                <template v-if="activeTab === GameInstanceType.GAME">
+                    <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="game-card__thumbnail"/>
+                </template>
+                <template v-else>
+                    <div class="game-card__placeholder">{{ game.displayName }}</div>
+                </template>
+            </div>
+            <div class="game-card__overlay">
+                <div class="game-card__overlay-spacer"></div>
+                <div class="game-card__overlay-body">
+                    <button class="button is-info" @click="emit('select', game)">
+                        Select {{ activeTab.toLowerCase() }}
+                    </button>
+                    <button class="button" @click="emit('set-default', game)">Set as default</button>
+                </div>
+                <div class="game-card__overlay-spacer"></div>
+            </div>
         </div>
-        <div class="game-card__overlay">
-            <div class="game-card__overlay-header">
-                <p class="title is-5 has-text-white">{{ game.displayName }}</p>
-                <a :id="`${game.settingsIdentifier}-star`" href="#" @click.prevent="emit('toggle-favourite', game)">
-                    <i class="fas fa-star fa-lg text-warning" v-if="isFavourited"></i>
-                    <i class="far fa-star fa-lg" v-else></i>
-                </a>
-            </div>
-            <div class="game-card__overlay-body">
-                <button class="button is-info" @click="emit('select', game)">
-                    Select {{ activeTab.toLowerCase() }}
-                </button>
-                <button class="button" @click="emit('set-default', game)">Set as default</button>
-            </div>
-            <div class="game-card__overlay-spacer"></div>
+        <div class="game-card-wrapper__footer">
+            <p>
+                {{ game.displayName }}
+            </p>
+            <a :id="`${game.settingsIdentifier}-star`" href="#" @click.prevent="emit('toggle-favourite', game)">
+                <i class="fas fa-star text-warning" v-if="isFavourited"></i>
+                <i class="far fa-star" v-else></i>
+            </a>
         </div>
     </div>
 </template>
@@ -55,6 +60,17 @@ function getImageHref(image: string) {
 </script>
 
 <style scoped lang="scss">
+.game-card-wrapper {
+    width: 188px;
+}
+
+.game-card-wrapper__footer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+}
+
 .game-card {
     position: relative;
     display: inline-block;
@@ -110,7 +126,7 @@ function getImageHref(image: string) {
 .game-card__overlay-header {
     display: flex;
     flex: 1;
-    justify-content: space-between;
+    justify-content: right;
     align-items: flex-start;
     padding: 0.75rem;
 

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -1,40 +1,28 @@
 <template>
-    <div class="inline">
-        <div class="card is-shadowless">
-            <div class="cursor-pointer">
-                <header class="card-header is-shadowless is-relative has-background-black">
-                    <div class="absolute-full z-fab flex">
-                        <div class="card-action-overlay rounded">
-                            <div class="absolute-top card-header-title">
-                                <p class="text-left title is-5 has-text-white">{{ game.displayName }}</p>
-                            </div>
-                            <div class="absolute-top-right card-header-title">
-                                <p class="text-left title is-5">
-                                    <a :id="`${game.settingsIdentifier}-star`" href="#" @click.prevent="emit('toggle-favourite', game)">
-                                        <i class="fas fa-star text-warning" v-if="isFavourited"></i>
-                                        <i class="far fa-star" v-else></i>
-                                    </a>
-                                </p>
-                            </div>
-                            <div class="absolute-center text-center">
-                                <button class="button is-info" @click="emit('select', game)">
-                                    Select {{ activeTab.toLowerCase() }}
-                                </button>
-                                <br/><br/>
-                                <button class="button" @click="emit('set-default', game)">Set as default</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="image is-fullwidth border border--border-box rounded" :class="[{'border--warning warning-shadow': props.isFavourited && props.highlightFavourite}]">
-                        <template v-if="activeTab === GameInstanceType.GAME">
-                            <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="rounded game-thumbnail"/>
-                        </template>
-                        <template v-else>
-                            <h2 style="height: 250px; width: 188px" class="text-center pad pad--sides">{{ game.displayName }}</h2>
-                        </template>
-                    </div>
-                </header>
+    <div class="game-card" :class="{'game-card--highlighted': props.isFavourited && props.highlightFavourite}">
+        <div class="game-card__image">
+            <template v-if="activeTab === GameInstanceType.GAME">
+                <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="game-card__thumbnail"/>
+            </template>
+            <template v-else>
+                <div class="game-card__placeholder">{{ game.displayName }}</div>
+            </template>
+        </div>
+        <div class="game-card__overlay">
+            <div class="game-card__overlay-header">
+                <p class="title is-5 has-text-white">{{ game.displayName }}</p>
+                <a :id="`${game.settingsIdentifier}-star`" href="#" @click.prevent="emit('toggle-favourite', game)">
+                    <i class="fas fa-star fa-lg text-warning" v-if="isFavourited"></i>
+                    <i class="far fa-star fa-lg" v-else></i>
+                </a>
             </div>
+            <div class="game-card__overlay-body">
+                <button class="button is-info" @click="emit('select', game)">
+                    Select {{ activeTab.toLowerCase() }}
+                </button>
+                <button class="button" @click="emit('set-default', game)">Set as default</button>
+            </div>
+            <div class="game-card__overlay-spacer"></div>
         </div>
     </div>
 </template>
@@ -67,9 +55,84 @@ function getImageHref(image: string) {
 </script>
 
 <style scoped lang="scss">
-.game-thumbnail {
+.game-card {
+    position: relative;
+    display: inline-block;
+    border-radius: 4px;
+    overflow: hidden;
+    cursor: pointer;
+
+    &--highlighted {
+        box-shadow: 0px 0px 4px 2px $warning;
+        outline: 2px solid $warning;
+    }
+}
+
+.game-card__image {
+    display: block;
+    background-color: black;
+}
+
+.game-card__thumbnail {
+    display: block;
     width: 188px;
     height: 250px;
     object-fit: cover;
+}
+
+.game-card__placeholder {
+    width: 188px;
+    height: 250px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1rem;
+}
+
+.game-card__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    background-color: rgba(0, 0, 0, 0.8);
+    border-radius: 4px;
+    opacity: 0;
+    transition: opacity 0.1s linear;
+
+    &:hover,
+    &:focus,
+    &:focus-within {
+        opacity: 1;
+    }
+}
+
+.game-card__overlay-header {
+    display: flex;
+    flex: 1;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 0.75rem;
+
+    .title {
+        margin: 0;
+    }
+}
+
+.game-card__overlay-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.game-card__overlay-spacer {
+    flex: 1;
+}
+
+.button {
+    height: min-content;
 }
 </style>

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="game-card-wrapper">
-        <div class="game-card" :class="{'game-card--highlighted': props.isFavourited && props.highlightFavourite}">
+        <div class="game-card">
             <div class="game-card__image">
                 <template v-if="activeTab === GameInstanceType.GAME">
                     <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="game-card__thumbnail"/>
@@ -41,12 +41,9 @@ type Props = {
     game: Game;
     isFavourited: boolean;
     activeTab: GameInstanceType;
-    highlightFavourite?: boolean;
 };
 
-const props = withDefaults(defineProps<Props>(), {
-    highlightFavourite: false,
-});
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
     select: [game: Game];

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -74,11 +74,6 @@ function getImageHref(image: string) {
     border-radius: 4px;
     overflow: hidden;
     cursor: pointer;
-
-    &--highlighted {
-        box-shadow: 0px 0px 4px 2px $warning;
-        outline: 2px solid $warning;
-    }
 }
 
 .game-card__image {

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -65,12 +65,12 @@ function getImageHref(image: string) {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-
+    margin-top: 0.4rem;
 }
 
 .game-card {
     position: relative;
-    display: inline-block;
+    display: block;
     border-radius: 4px;
     overflow: hidden;
     cursor: pointer;
@@ -94,13 +94,13 @@ function getImageHref(image: string) {
 }
 
 .game-card__placeholder {
-    width: 188px;
     height: 250px;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     padding: 1rem;
+    background-color: var(--border-secondary, #c9d3ee);
 }
 
 .game-card__overlay {

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -1,0 +1,76 @@
+<template>
+    <div class="inline">
+        <div class="card is-shadowless">
+            <div class="cursor-pointer">
+                <header class="card-header is-shadowless is-relative has-background-black">
+                    <div class="absolute-full z-fab flex">
+                        <div class="card-action-overlay rounded">
+                            <div class="absolute-top card-header-title">
+                                <p class="text-left title is-5 has-text-white">{{ game.displayName }}</p>
+                            </div>
+                            <div class="absolute-top-right card-header-title">
+                                <p class="text-left title is-5">
+                                    <a :id="`${game.settingsIdentifier}-star`" href="#" @click.prevent="emit('toggle-favourite', game)">
+                                        <i class="fas fa-star text-warning" v-if="isFavourited"></i>
+                                        <i class="far fa-star" v-else></i>
+                                    </a>
+                                </p>
+                            </div>
+                            <div class="absolute-center text-center">
+                                <button class="button is-info" @click="emit('select', game)">
+                                    Select {{ activeTab.toLowerCase() }}
+                                </button>
+                                <br/><br/>
+                                <button class="button" @click="emit('set-default', game)">Set as default</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="image is-fullwidth border border--border-box rounded" :class="[{'border--warning warning-shadow': props.isFavourited && props.highlightFavourite}]">
+                        <template v-if="activeTab === GameInstanceType.GAME">
+                            <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="rounded game-thumbnail"/>
+                        </template>
+                        <template v-else>
+                            <h2 style="height: 250px; width: 188px" class="text-center pad pad--sides">{{ game.displayName }}</h2>
+                        </template>
+                    </div>
+                </header>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import Game from '../../model/game/Game';
+import { GameInstanceType } from '../../model/schema/ThunderstoreSchema';
+import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider';
+
+type Props = {
+    game: Game;
+    isSelected: boolean;
+    isFavourited: boolean;
+    activeTab: GameInstanceType;
+    highlightFavourite?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+    highlightFavourite: false,
+});
+
+const emit = defineEmits<{
+    select: [game: Game];
+    'set-default': [game: Game];
+    'toggle-favourite': [game: Game];
+}>();
+
+function getImageHref(image: string) {
+    return ProtocolProvider.getPublicAssetUrl(image);
+}
+</script>
+
+<style scoped lang="scss">
+.game-thumbnail {
+    width: 188px;
+    height: 250px;
+    object-fit: cover;
+}
+</style>

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -46,7 +46,6 @@ import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider'
 
 type Props = {
     game: Game;
-    isSelected: boolean;
     isFavourited: boolean;
     activeTab: GameInstanceType;
     highlightFavourite?: boolean;

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -29,12 +29,11 @@
                 <div class="content pad--sides pad--top-none">
                     <template v-if="filterText.length === 0">
                         <template v-if="favouriteGameList.length > 0">
-                            <GameSelectionSection title="Favourites" :count="favouriteGameList.length">
+                            <GameSelectionSection title="Favourites" :count="favouriteGameList.length" :default-open="true">
                                 <div class="game-cards-container">
                                     <div v-for="game of favouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
                                         <GameSelectionCard
                                             :game="game"
-                                            :is-selected="isGameSelected(game)"
                                             :is-favourited="true"
                                             :active-tab="activeTab"
                                             @select="emit('select-game', $event)"
@@ -50,12 +49,12 @@
                         <GameSelectionSection
                             :title="`${capitalize(activeTab)}s`"
                             :count="nonFavouriteGameList.length"
+                            :default-open="true"
                         >
                             <div class="game-cards-container">
                                 <div v-for="game of nonFavouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
                                     <GameSelectionCard
                                         :game="game"
-                                        :is-selected="isGameSelected(game)"
                                         :is-favourited="false"
                                         :active-tab="activeTab"
                                         @select="emit('select-game', $event)"
@@ -70,12 +69,12 @@
                         <GameSelectionSection
                             title="All games"
                             :count="mergedGameList.length"
+                            :default-open="true"
                         >
                             <div class="game-cards-container">
                                 <div v-for="game of mergedGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
                                     <GameSelectionCard
                                         :game="game"
-                                        :is-selected="isGameSelected(game)"
                                         :is-favourited="isFavourited(game)"
                                         :active-tab="activeTab"
                                         :highlight-favourite="true"

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -48,7 +48,7 @@
                         </template>
 
                         <GameSelectionSection
-                            :title="`Other ${activeTab}s`"
+                            :title="`${capitalize(activeTab)}s`"
                             :count="nonFavouriteGameList.length"
                         >
                             <div class="game-cards-container">
@@ -102,6 +102,7 @@ import GameSelectionCard from './GameSelectionCard.vue';
 import GameSelectionListItem from './GameSelectionListItem.vue';
 import GameSelectionSection from './GameSelectionSection.vue';
 import Game from '../../model/game/Game';
+import { capitalize } from '../../utils/StringUtils';
 
 const emit = defineEmits<{
     'select-game': [game: Game];

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -77,7 +77,6 @@
                                         :game="game"
                                         :is-favourited="isFavourited(game)"
                                         :active-tab="activeTab"
-                                        :highlight-favourite="true"
                                         @select="emit('select-game', $event)"
                                         @set-default="emit('set-default-game', $event)"
                                         @toggle-favourite="toggleFavourite($event)"

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -1,0 +1,142 @@
+<template>
+    <article class="media">
+        <div class="media-content">
+
+            <template v-if="viewMode === GameSelectionViewMode.LIST">
+                <div class="content">
+                    <GameSelectionListItem
+                        v-for="game of favouriteGameList"
+                        :key="game.settingsIdentifier"
+                        :game="game"
+                        :is-selected="isGameSelected(game)"
+                        :is-favourited="true"
+                        @click="markAsSelectedGame(game)"
+                        @toggle-favourite="toggleFavourite(game)"
+                    />
+                    <GameSelectionListItem
+                        v-for="game of nonFavouriteGameList"
+                        :key="game.settingsIdentifier"
+                        :game="game"
+                        :is-selected="isGameSelected(game)"
+                        :is-favourited="false"
+                        @click="markAsSelectedGame(game)"
+                        @toggle-favourite="toggleFavourite(game)"
+                    />
+                </div>
+            </template>
+
+            <template v-else>
+                <div class="content pad--sides pad--top-none">
+                    <template v-if="filterText.length === 0">
+                        <template v-if="favouriteGameList.length > 0">
+                            <GameSelectionSection title="Favourites" :count="favouriteGameList.length">
+                                <div class="game-cards-container">
+                                    <div v-for="game of favouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
+                                        <GameSelectionCard
+                                            :game="game"
+                                            :is-selected="isGameSelected(game)"
+                                            :is-favourited="true"
+                                            :active-tab="activeTab"
+                                            @select="emit('select-game', $event)"
+                                            @set-default="emit('set-default-game', $event)"
+                                            @toggle-favourite="toggleFavourite($event)"
+                                        />
+                                    </div>
+                                </div>
+                            </GameSelectionSection>
+                            <hr/>
+                        </template>
+
+                        <GameSelectionSection
+                            :title="`Other ${activeTab}s`"
+                            :count="nonFavouriteGameList.length"
+                        >
+                            <div class="game-cards-container">
+                                <div v-for="game of nonFavouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
+                                    <GameSelectionCard
+                                        :game="game"
+                                        :is-selected="isGameSelected(game)"
+                                        :is-favourited="false"
+                                        :active-tab="activeTab"
+                                        @select="emit('select-game', $event)"
+                                        @set-default="emit('set-default-game', $event)"
+                                        @toggle-favourite="toggleFavourite($event)"
+                                    />
+                                </div>
+                            </div>
+                        </GameSelectionSection>
+                    </template>
+                    <template v-else>
+                        <GameSelectionSection
+                            title="All games"
+                            :count="mergedGameList.length"
+                        >
+                            <div class="game-cards-container">
+                                <div v-for="game of mergedGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
+                                    <GameSelectionCard
+                                        :game="game"
+                                        :is-selected="isGameSelected(game)"
+                                        :is-favourited="isFavourited(game)"
+                                        :active-tab="activeTab"
+                                        :highlight-favourite="true"
+                                        @select="emit('select-game', $event)"
+                                        @set-default="emit('set-default-game', $event)"
+                                        @toggle-favourite="toggleFavourite($event)"
+                                    />
+                                </div>
+                            </div>
+                        </GameSelectionSection>
+                    </template>
+                </div>
+            </template>
+
+        </div>
+    </article>
+</template>
+
+<script lang="ts" setup>
+import { inject, computed } from 'vue';
+import { GameSelectionViewMode } from '../../model/enums/GameSelectionViewMode';
+import { gameSelectionKey } from '../composables/GameSelectionComposable';
+import GameSelectionCard from './GameSelectionCard.vue';
+import GameSelectionListItem from './GameSelectionListItem.vue';
+import GameSelectionSection from './GameSelectionSection.vue';
+import Game from '../../model/game/Game';
+
+const emit = defineEmits<{
+    'select-game': [game: Game];
+    'set-default-game': [game: Game];
+}>();
+
+const mergedGameList = computed(() => {
+    const favourites = favouriteGameList.value;
+    const others = nonFavouriteGameList.value;
+    return [...favourites, ...others];
+})
+
+const {
+    favouriteGameList,
+    nonFavouriteGameList,
+    activeTab,
+    viewMode,
+    isGameSelected,
+    markAsSelectedGame,
+    toggleFavourite,
+    filterText,
+    isFavourited,
+} = inject(gameSelectionKey)!;
+</script>
+
+<style lang="scss" scoped>
+.game-cards-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+.card-header-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+</style>

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -67,7 +67,7 @@
                     </template>
                     <template v-else>
                         <GameSelectionSection
-                            title="All games"
+                            title="Search results"
                             :count="mergedGameList.length"
                             :default-open="true"
                         >

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -31,7 +31,7 @@
                         <template v-if="favouriteGameList.length > 0">
                             <GameSelectionSection title="Favourites" :count="favouriteGameList.length" :default-open="true">
                                 <div class="game-cards-container">
-                                    <div v-for="game of favouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
+                                    <div v-for="game of favouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right">
                                         <GameSelectionCard
                                             :game="game"
                                             :is-favourited="true"

--- a/src/components/game-selection/GameSelectionListItem.vue
+++ b/src/components/game-selection/GameSelectionListItem.vue
@@ -1,0 +1,35 @@
+<template>
+    <a @click="emit('click', game)">
+        <div class="border-at-bottom cursor-pointer">
+            <div class="card is-shadowless">
+                <p :class="['card-header-title', {'has-text-info': isSelected}]">
+                    <a :id="`${game.settingsIdentifier}-star`" href="#" class="margin-right" @click.prevent="emit('toggle-favourite', game)">
+                        <i class="fas fa-star text-warning" v-if="isFavourited"></i>
+                        <i class="far fa-star" v-else></i>
+                    </a>
+                    {{ game.displayName }}
+                </p>
+            </div>
+        </div>
+    </a>
+</template>
+
+<script lang="ts" setup>
+import Game from '../../model/game/Game';
+
+type Props = {
+    game: Game;
+    isSelected: boolean;
+    isFavourited: boolean;
+};
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    click: [game: Game];
+    'toggle-favourite': [game: Game];
+}>();
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/src/components/game-selection/GameSelectionSection.vue
+++ b/src/components/game-selection/GameSelectionSection.vue
@@ -1,0 +1,41 @@
+<template>
+    <div>
+        <a class="section-toggle" @click="isOpen = !isOpen">
+            <h3 class="section-header">
+                {{ title }} <span class="tag is-inactive-link">{{ count }}</span>
+                <i :class="['fas', isOpen ? 'fa-angle-down' : 'fa-angle-right']"></i>
+            </h3>
+        </a>
+        <slot v-if="isOpen" />
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+type Props = {
+    title: string;
+    count: number;
+    defaultOpen?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+    defaultOpen: true
+});
+
+const isOpen = ref(props.defaultOpen ?? true);
+</script>
+
+<style scoped lang="scss">
+.section-header {
+    color: var(--v2-primary-text-color);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.section-toggle {
+    cursor: pointer;
+    display: block;
+}
+</style>

--- a/src/components/game-selection/GameSelectionSection.vue
+++ b/src/components/game-selection/GameSelectionSection.vue
@@ -1,12 +1,14 @@
 <template>
     <div>
-        <a class="section-toggle" @click="isOpen = !isOpen">
-            <h3 class="section-header">
-                {{ title }} <span class="tag is-inactive-link">{{ count }}</span>
-                <i :class="['fas', isOpen ? 'fa-angle-down' : 'fa-angle-right']"></i>
-            </h3>
-        </a>
-        <slot v-if="isOpen" />
+        <details :open="isOpen" @toggle="isOpen = ($event.target as HTMLDetailsElement).open">
+            <summary class="section-toggle">
+                <h3 class="section-header">
+                    {{ title }} <span class="tag is-inactive-link">{{ count }}</span>
+                    <i :class="['fas', isOpen ? 'fa-angle-down' : 'fa-angle-right']"></i>
+                </h3>
+            </summary>
+            <slot/>
+        </details>
     </div>
 </template>
 
@@ -23,7 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
     defaultOpen: true
 });
 
-const isOpen = ref(props.defaultOpen ?? true);
+const isOpen = ref(props.defaultOpen);
 </script>
 
 <style scoped lang="scss">

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -454,6 +454,9 @@ code {
     }
     &--top {
         padding-top: 1rem;
+        &-none {
+            padding-top: 0;
+        }
     }
 }
 

--- a/src/model/platform/StorePlatform.ts
+++ b/src/model/platform/StorePlatform.ts
@@ -5,7 +5,7 @@ export const StorePlatform = {
     [Platform.STEAM_DIRECT]: "Steam",
     [Platform.EPIC_GAMES_STORE]: "Epic Games Store",
     [Platform.OCULUS_STORE]: "Oculus Store",
-    [Platform.ORIGIN]: "Origin / EA Desktop",
+    [Platform.ORIGIN]: "EA App",
     [Platform.XBOX_GAME_PASS]: "Xbox Game Pass",
     [Platform.OTHER]: "Other"
 }

--- a/src/model/platform/StorePlatform.ts
+++ b/src/model/platform/StorePlatform.ts
@@ -1,0 +1,11 @@
+import { Platform } from "../../assets/data/ecosystemTypes"
+
+export const StorePlatform = {
+    [Platform.STEAM]: "Steam",
+    [Platform.STEAM_DIRECT]: "Steam",
+    [Platform.EPIC_GAMES_STORE]: "Epic Games Store",
+    [Platform.OCULUS_STORE]: "Oculus Store",
+    [Platform.ORIGIN]: "Origin / EA Desktop",
+    [Platform.XBOX_GAME_PASS]: "Xbox Game Pass",
+    [Platform.OTHER]: "Other"
+}

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -87,7 +87,7 @@
 
 <script lang="ts" setup>
 import { Hero } from '../components/all';
-import { GameInstanceType, Platform } from '../model/schema/ThunderstoreSchema';
+import { GameInstanceType } from '../model/schema/ThunderstoreSchema';
 import { GameSelectionViewMode } from '../model/enums/GameSelectionViewMode';
 import ModalCard from '../components/ModalCard.vue';
 import { onMounted, provide, ref } from 'vue';
@@ -95,6 +95,7 @@ import { useGameSelectionComposable, gameSelectionKey } from '../components/comp
 import GameSelectionList from '../components/game-selection/GameSelectionList.vue';
 import Game from '../model/game/Game';
 import { capitalize } from '../utils/StringUtils';
+import { StorePlatform as platformLabels } from '../model/platform/StorePlatform';
 
 
 const gameSelection = useGameSelectionComposable();
@@ -118,16 +119,6 @@ const {
 } = gameSelection;
 
 const showPlatformModal = ref<boolean>(false);
-
-const platformLabels = {
-    [Platform.STEAM]: "Steam",
-    [Platform.STEAM_DIRECT]: "Steam",
-    [Platform.EPIC_GAMES_STORE]: "Epic Games Store",
-    [Platform.OCULUS_STORE]: "Oculus Store",
-    [Platform.ORIGIN]: "Origin / EA Desktop",
-    [Platform.XBOX_GAME_PASS]: "Xbox Game Pass",
-    [Platform.OTHER]: "Other"
-}
 
 function selectGame(game: Game) {
     markAsSelectedGame(game);

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -37,136 +37,48 @@
             <div class="column is-full">
                 <div class="sticky-top is-shadowless background-bg z-top">
                     <div class="container">
-                        <nav class="level mb-2" v-if="viewMode === 'List'">
-                            <div class="level-item">
-                                <div class="card-header-title">
-                                    <div class="input-group input-group--flex margin-right">
-                                        <input
-                                            v-model="filterText"
-                                            id="game-selection-list-search"
-                                            class="input margin-right"
-                                            type="text"
-                                            placeholder="Search for a game"
-                                            autocomplete="off"
-                                        />
-                                    </div>
+                        <nav class="pad--sides pad--top-none flex">
+                            <div class="input-group input-group--flex margin-right">
+                                <input
+                                    v-model="filterText"
+                                    id="game-selection-search"
+                                    class="input margin-right"
+                                    type="text"
+                                    placeholder="Search for a game"
+                                    autocomplete="off"
+                                />
+                            </div>
+                            <template v-if="viewMode === GameSelectionViewMode.LIST">
+                                <div class="margin-right">
+                                    <button class="button is-info"
+                                       :disabled="selectedGame === null || runningMigration" @click="selectGame(selectedGame!)">Select {{ activeTab.toLowerCase() }}</button>
                                 </div>
-                            </div>
-                            <div class="margin-right">
-                                <button class="button is-info"
-                                   :disabled="!isAnyGameSelected() && !runningMigration" @click="selectGame(selectedGame)">Select {{ activeTab.toLowerCase() }}</button>
-                            </div>
-                            <div class="margin-right">
-                                <button class="button"
-                                   :disabled="!isAnyGameSelected() && !runningMigration" @click="selectDefaultGame(selectedGame)">Set as default</button>
-                            </div>
+                                <div class="margin-right">
+                                    <button class="button"
+                                       :disabled="selectedGame === null || runningMigration" @click="selectDefaultGame(selectedGame!)">Set as default</button>
+                                </div>
+                            </template>
                             <div>
-                                <i class="button fas fa-th-large" @click="toggleViewMode"></i>
+                                <i :class="['button', 'fas', viewMode === GameSelectionViewMode.LIST ? 'fa-th-large' : 'fa-list']" @click="toggleViewMode"></i>
                             </div>
                         </nav>
-                        <nav class="level mb-2" v-else>
-                            <div class="level-item">
-                                <div class="card-header-title">
-                                    <div class="input-group input-group--flex margin-right">
-                                        <input
-                                            v-model="filterText"
-                                            id="game-selection-cards-search"
-                                            class="input margin-right"
-                                            type="text"
-                                            placeholder="Search for a game"
-                                            autocomplete="off"
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                            <div>
-                                <i class="button fas fa-list" @click="toggleViewMode"></i>
-                            </div>
-                        </nav>
-                        <div class="level">
-                            <div class="level-item">
-                                <div class="tabs">
-                                    <ul class="text-center">
-                                        <li v-for="(value) in GameInstanceType" :key="`tab-${value}`"
-                                            :class="[{'is-active': activeTab === value}]">
-                                            <a @click="changeTab(value)">{{capitalize(value)}}</a>
-                                        </li>
-                                    </ul>
-                                </div>
+                        <div class="pad--sides pad--top-none">
+                            <div class="tabs">
+                                <ul>
+                                    <li v-for="(value) in GameInstanceType" :key="`tab-${value}`"
+                                        :class="[{'is-active': activeTab === value}]">
+                                        <a @click="changeTab(value)">{{capitalize(value)}}</a>
+                                    </li>
+                                </ul>
                             </div>
                         </div>
                     </div>
                 </div>
                 <div class="container">
-                    <article class="media">
-                        <div class="media-content">
-                            <div class="content" v-if="viewMode === 'List'">
-                                <div v-for="(game, index) of filteredGameList" :key="`${index}-${game.displayName}-${isGameSelected(game)}-${isFavourited(game)}`">
-                                    <a @click="markAsSelectedGame(game)">
-                                        <div class="border-at-bottom cursor-pointer">
-                                            <div class="card is-shadowless">
-                                                <p
-                                                    :class="['card-header-title', {'has-text-info':isGameSelected(game)}]"
-                                                >
-                                                    <a :id="`${game.settingsIdentifier}-star`" href="#" class="margin-right" @click.prevent="toggleFavourite(game)">
-                                                        <i class="fas fa-star text-warning" v-if="favourites.includes(game.settingsIdentifier)"></i>
-                                                        <i class="far fa-star" v-else></i>
-                                                    </a>
-                                                    {{ game.displayName }}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="content pad--sides" v-else>
-                                <div class="game-cards-container">
-                                    <div v-for="(game, index) of filteredGameList" :key="`${index}-${game.displayName}-${isGameSelected(game)}-${isFavourited(game)}`" class="inline-block margin-right margin-bottom">
-
-                                        <div class="inline">
-                                            <div class='card is-shadowless'>
-                                                <div class='cursor-pointer'>
-                                                    <header class='card-header is-shadowless is-relative has-background-black'>
-                                                        <div class="absolute-full z-fab flex">
-                                                            <div class="card-action-overlay rounded">
-                                                                <div class="absolute-top card-header-title">
-                                                                    <p class="text-left title is-5 has-text-white">{{ game.displayName }}</p>
-                                                                </div>
-                                                                <div class="absolute-top-right card-header-title">
-                                                                    <p class="text-left title is-5">
-                                                                        <a :id="`${game.settingsIdentifier}-star`" href="#" @click.prevent="toggleFavourite(game)">
-                                                                            <i class="fas fa-star text-warning" v-if="favourites.includes(game.settingsIdentifier)"></i>
-                                                                            <i class="far fa-star" v-else></i>
-                                                                        </a>
-                                                                    </p>
-                                                                </div>
-                                                                <div class="absolute-center text-center">
-                                                                    <button class="button is-info" @click="selectGame(game)" :class="[{'is-disabled': selectedGame === null}]">Select
-                                                                        {{ activeTab.toLowerCase() }}</button>
-                                                                    <br/><br/>
-                                                                    <button class="button" @click="selectDefaultGame(game)">Set as default</button>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                        <div class="image is-fullwidth border border--border-box rounded" :class="[{'border--warning warning-shadow': isFavourited(game)}]">
-                                                            <template v-if="activeTab === GameInstanceType.GAME">
-                                                                <img :src='getImageHref(`/images/game_selection/${game.gameImage}`)' alt='Mod Logo' class="rounded game-thumbnail"/>
-                                                            </template>
-                                                            <template v-else>
-                                                                <h2 style="height: 250px; width: 188px" class="text-center pad pad--sides">{{ game.displayName }}</h2>
-                                                            </template>
-                                                        </div>
-                                                    </header>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                    </div>
-                                </div>
-                            </div>
-
-                        </div>
-                    </article>
+                    <GameSelectionList
+                        @select-game="selectGame"
+                        @set-default-game="selectDefaultGame"
+                    />
                 </div>
             </div>
         </div>
@@ -174,109 +86,36 @@
 </template>
 
 <script lang="ts" setup>
-import Game from '../model/game/Game';
-import GameManager from '../model/game/GameManager';
 import { Hero } from '../components/all';
-import * as ManagerUtils from '../utils/ManagerUtils';
-import ManagerSettings from '../r2mm/manager/ManagerSettings';
+import { GameInstanceType, Platform } from '../model/schema/ThunderstoreSchema';
 import { GameSelectionViewMode } from '../model/enums/GameSelectionViewMode';
-import R2Error from '../model/errors/R2Error';
-import { GameInstanceType, GameSelectionDisplayMode, Platform } from '../model/schema/ThunderstoreSchema';
-import ProviderUtils from '../providers/generic/ProviderUtils';
 import ModalCard from '../components/ModalCard.vue';
-import { computed, onMounted, reactive, ref } from 'vue';
-import { getStore } from '../providers/generic/store/StoreProvider';
-import { State } from '../store';
-import { useRouter } from 'vue-router';
-import ProtocolProvider from '../providers/generic/protocol/ProtocolProvider';
-import {updateEcosystemReactives, updateLatestEcosystemSchema} from "src/r2mm/ecosystem/EcosystemSchema";
+import { onMounted, provide, ref } from 'vue';
+import { useGameSelectionComposable, gameSelectionKey } from '../components/composables/GameSelectionComposable';
+import GameSelectionList from '../components/game-selection/GameSelectionList.vue';
+import Game from '../model/game/Game';
 
-const store = getStore<State>();
-const router = useRouter();
+const gameSelection = useGameSelectionComposable();
+provide(gameSelectionKey, gameSelection);
 
-const runningMigration = ref<boolean>(false);
-const selectedGame = ref<Game | null>(null);
-const filterText = ref<string>("");
+const {
+    selectedGame,
+    selectedPlatform,
+    filterText,
+    activeTab,
+    viewMode,
+    runningMigration,
+    isSettingDefaultPlatform,
+    markAsSelectedGame,
+    changeTab,
+    toggleViewMode,
+    proceed,
+    proceedDefault,
+    selectPlatformForGame,
+    initialize,
+} = gameSelection;
+
 const showPlatformModal = ref<boolean>(false);
-const selectedPlatform = ref<Platform | null>(null);
-const favourites = ref<string[]>([]);
-const settings = ref<ManagerSettings | undefined>(undefined);
-const isSettingDefaultPlatform = ref<boolean>(false);
-const viewMode = ref<GameSelectionViewMode>(GameSelectionViewMode.LIST);
-const activeTab = ref<GameInstanceType>(GameInstanceType.GAME);
-
-const filteredGameList = computed(() => {
-    const displayNameInAdditionalSearch = (game: Game, filterText: string): boolean => {
-        return game.additionalSearchStrings.find(value => value.toLowerCase().trim().indexOf(filterText.toLowerCase().trim()) >= 0) !== undefined;
-    }
-    return gameList.value
-        .filter(value => value.displayName.toLowerCase().indexOf(
-            filterText.value.toLowerCase()) >= 0
-            || filterText.value.trim().length === 0
-            || displayNameInAdditionalSearch(value, filterText.value))
-        .filter(value => value.displayMode === GameSelectionDisplayMode.VISIBLE)
-        .filter(value => value.instanceType === activeTab.value);
-});
-
-const gameList = computed<Game[]>(() => {
-    return GameManager.gameList.sort((a, b) => {
-        if (favourites.value.includes(a.settingsIdentifier)) {
-            if (favourites.value.includes(b.settingsIdentifier)) {
-                return a.displayName.toLowerCase().localeCompare(b.displayName.toLowerCase());
-            } else {
-                return -1;
-            }
-        } else if (favourites.value.includes(b.settingsIdentifier)) {
-            return 1;
-        }
-        return a.displayName.toLowerCase().localeCompare(b.displayName.toLowerCase());
-    });
-});
-
-function getImageHref(image: string) {
-    return ProtocolProvider.getPublicAssetUrl(image);
-}
-
-function changeTab(tab: GameInstanceType) {
-    activeTab.value = tab;
-}
-
-function markAsSelectedGame(game: Game) {
-    selectedGame.value = game;
-}
-
-function selectGame(game: Game) {
-    selectedGame.value = game;
-    isSettingDefaultPlatform.value = false;
-    if (game.storePlatformMetadata.length > 1) {
-        ManagerSettings.getSingleton(game)
-            .then(settings => settings.getLastSelectedPlatform())
-            .then(platform => {
-                if (platform) {
-                    selectedPlatform.value = Platform[platform]
-                } else {
-                    selectedPlatform.value = null;
-                }
-            });
-        showPlatformModal.value = true;
-    } else {
-        selectedPlatform.value = game.storePlatformMetadata[0]!.storePlatform;
-        showPlatformModal.value = false;
-        proceed();
-    }
-}
-
-function selectDefaultGame(game: Game) {
-    selectedGame.value = game;
-    isSettingDefaultPlatform.value = true;
-    if (game.storePlatformMetadata.length > 1) {
-        showPlatformModal.value = true;
-    } else {
-        selectedPlatform.value = game.storePlatformMetadata[0]!.storePlatform;
-        showPlatformModal.value = false;
-        proceedDefault();
-    }
-}
 
 const platformLabels = {
     [Platform.STEAM]: "Steam",
@@ -288,124 +127,44 @@ const platformLabels = {
     [Platform.OTHER]: "Other"
 }
 
+function selectGame(game: Game) {
+    markAsSelectedGame(game);
+    isSettingDefaultPlatform.value = false;
+    if (game.storePlatformMetadata.length > 1) {
+        selectPlatformForGame(game);
+        showPlatformModal.value = true;
+    } else {
+        selectedPlatform.value = game.storePlatformMetadata[0]!.storePlatform;
+        showPlatformModal.value = false;
+        proceed();
+    }
+}
+
+function selectDefaultGame(game: Game) {
+    markAsSelectedGame(game);
+    isSettingDefaultPlatform.value = true;
+    if (game.storePlatformMetadata.length > 1) {
+        showPlatformModal.value = true;
+    } else {
+        selectedPlatform.value = game.storePlatformMetadata[0]!.storePlatform;
+        showPlatformModal.value = false;
+        proceedDefault();
+    }
+}
+
 function selectPlatform() {
+    showPlatformModal.value = false;
     if (isSettingDefaultPlatform.value) {
-        proceedDefault()
+        proceedDefault();
     } else {
         proceed();
     }
 }
 
-async function proceed() {
-    if (runningMigration.value || selectedGame.value === null || selectedPlatform.value === null) {
-        return;
-    }
-
-    try {
-        ProviderUtils.setupGameProviders(selectedGame.value, selectedPlatform.value);
-    } catch (error) {
-        if (error instanceof R2Error) {
-            store.commit('error/handleError', error);
-            return;
-        }
-
-        throw error;
-    }
-
-    const settings = await ManagerSettings.getSingleton(selectedGame.value);
-    await settings.setLastSelectedGame(selectedGame.value);
-    await settings.setLastSelectedPlatform(selectedPlatform.value);
-    await GameManager.activate(selectedGame.value, selectedPlatform.value);
-    await store.dispatch("setActiveGame", selectedGame.value);
-
-    await router.push({name: "splash"});
-}
-
-async function proceedDefault() {
-    if (runningMigration.value || selectedGame.value === null || selectedPlatform.value === null) {
-        return;
-    }
-
-    const settings = await ManagerSettings.getSingleton(selectedGame.value);
-    await settings.setDefaultGame(selectedGame.value);
-    await settings.setDefaultStorePlatform(selectedPlatform.value);
-
-    return proceed();
-}
-
-function toggleFavourite(game: Game) {
-    if (favourites.value.includes(game.settingsIdentifier)) {
-        favourites.value = favourites.value.filter(value => value !== game.settingsIdentifier)
-    } else {
-        favourites.value = [...favourites.value, game.settingsIdentifier];
-    }
-    if (settings.value !== undefined) {
-        settings.value.setFavouriteGames(favourites.value);
-    }
-}
-
-function isFavourited(game: Game) {
-    if (settings.value !== undefined) {
-        return favourites.value.includes(game.settingsIdentifier);
-    }
-}
-
-function isGameSelected(game: Game) {
-    return selectedGame.value !== null && selectedGame.value.internalFolderName === game.internalFolderName;
-}
-
-function isAnyGameSelected() {
-    return selectedGame.value !== null;
-}
-
 onMounted(async () => {
-
-    // Check for updates in the background
-    window.app.checkForApplicationUpdates()
-
-    runningMigration.value = true;
-    await store.dispatch('checkMigrations');
-    runningMigration.value = false;
-
-    await store.dispatch('resetLocalState');
-
-    // TODO - Enable once updating is viable
-    // updateLatestEcosystemSchema();
-
-    settings.value = await ManagerSettings.getSingleton(GameManager.defaultGame);
-    const globalSettings = settings.value.getContext().global;
-    favourites.value = globalSettings.favouriteGames || [];
-    selectedGame.value = GameManager.findByFolderName(globalSettings.lastSelectedGame) || null;
-
-    switch(globalSettings.gameSelectionViewMode) {
-        case GameSelectionViewMode.LIST:
-        case GameSelectionViewMode.CARD:
-            viewMode.value = globalSettings.gameSelectionViewMode;
-            break;
-        default:
-            viewMode.value = GameSelectionViewMode.CARD;
-    }
-
-    // Skip game selection view if valid default game & platform are set.
-    const {defaultGame, defaultPlatform} = ManagerUtils.getDefaults(settings.value!);
-
-    if (defaultGame && defaultPlatform) {
-        selectedGame.value = defaultGame;
-        selectedPlatform.value = defaultPlatform;
-        return proceed();
-    }
+    window.app.checkForApplicationUpdates();
+    await initialize();
 })
-
-function toggleViewMode() {
-    if (viewMode.value === GameSelectionViewMode.LIST) {
-        viewMode.value = GameSelectionViewMode.CARD;
-    } else {
-        viewMode.value = GameSelectionViewMode.LIST;
-    }
-    if (settings.value !== undefined) {
-        settings.value.setGameSelectionViewMode(viewMode.value);
-    }
-}
 
 function capitalize(str: string) {
     return str.slice(0, 1).toUpperCase() + str.slice(1);
@@ -414,19 +173,8 @@ function capitalize(str: string) {
 
 
 <style lang="scss" scoped>
-.game-cards-container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-}
 .mb-2 {
     margin-bottom: 0.5rem !important;
-}
-.game-thumbnail {
-    width: 188px;
-    height: 250px;
-    object-fit: cover;
 }
 
 #game-selection-screen {
@@ -435,5 +183,9 @@ function capitalize(str: string) {
     flex-direction: column;
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+#game-selection-search {
+    min-width: 100px;
 }
 </style>

--- a/src/pages/GameSelectionScreen.vue
+++ b/src/pages/GameSelectionScreen.vue
@@ -94,6 +94,8 @@ import { onMounted, provide, ref } from 'vue';
 import { useGameSelectionComposable, gameSelectionKey } from '../components/composables/GameSelectionComposable';
 import GameSelectionList from '../components/game-selection/GameSelectionList.vue';
 import Game from '../model/game/Game';
+import { capitalize } from '../utils/StringUtils';
+
 
 const gameSelection = useGameSelectionComposable();
 provide(gameSelectionKey, gameSelection);
@@ -164,11 +166,7 @@ function selectPlatform() {
 onMounted(async () => {
     window.app.checkForApplicationUpdates();
     await initialize();
-})
-
-function capitalize(str: string) {
-    return str.slice(0, 1).toUpperCase() + str.slice(1);
-}
+});
 </script>
 
 

--- a/src/utils/StringUtils.ts
+++ b/src/utils/StringUtils.ts
@@ -1,0 +1,3 @@
+export function capitalize(str: string) {
+    return str.slice(0, 1).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
# Game Grouping

_Basis for providing a more separated game selection screen_

## Why?

This PR adds support for game groups. These are currently:
- Favourite
- Other (text matches tab)

## Future work

There will be a separate PR to add support for "Hidden" games. These are games which have been removed from the ecosystem schema. In theory this shouldn't happen but is a precaution to allow users to continue to manage mods for their existing games.

## Screenshots

<img width="2559" height="1525" alt="image" src="https://github.com/user-attachments/assets/abfebd8b-0903-416e-9b42-96b2e3218218" />


<img width="2559" height="1519" alt="image" src="https://github.com/user-attachments/assets/54999413-2607-4e19-8854-3f685f744be1" />


<img width="2559" height="1517" alt="image" src="https://github.com/user-attachments/assets/2c571b44-28a6-4df3-b2a1-c7193fe53c9a" />
