### PR TITLE
Added dynamic scaling to game selection grid

### DIFF
--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -58,7 +58,7 @@ function getImageHref(image: string) {
 
 <style scoped lang="scss">
 .game-card-wrapper {
-    width: 188px;
+    width: 100%;
 }
 
 .game-card-wrapper__footer {
@@ -83,13 +83,13 @@ function getImageHref(image: string) {
 
 .game-card__thumbnail {
     display: block;
-    width: 188px;
-    height: 250px;
+    width: 100%;
+    aspect-ratio: 3 / 4;
     object-fit: cover;
 }
 
 .game-card__placeholder {
-    height: 250px;
+    aspect-ratio: 3 / 4;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -41,16 +41,16 @@
                         <template v-if="favouriteGameList.length > 0">
                             <GameSelectionSection title="Favourites" :count="favouriteGameList.length" :default-open="true">
                                 <div class="game-cards-container">
-                                    <div v-for="game of favouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right">
-                                        <GameSelectionCard
-                                            :game="game"
-                                            :is-favourited="true"
-                                            :active-tab="activeTab"
-                                            @select="emit('select-game', $event)"
-                                            @set-default="emit('set-default-game', $event)"
-                                            @toggle-favourite="toggleFavourite($event)"
-                                        />
-                                    </div>
+                                    <GameSelectionCard
+                                        v-for="game of favouriteGameList"
+                                        :key="game.settingsIdentifier"
+                                        :game="game"
+                                        :is-favourited="true"
+                                        :active-tab="activeTab"
+                                        @select="emit('select-game', $event)"
+                                        @set-default="emit('set-default-game', $event)"
+                                        @toggle-favourite="toggleFavourite($event)"
+                                    />
                                 </div>
                             </GameSelectionSection>
                         </template>
@@ -64,17 +64,17 @@
                                 :default-open="true"
                             >
                                 <div class="game-cards-container">
-                                    <div v-for="game of nonFavouriteGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
-                                        <GameSelectionCard
-                                            :game="game"
-                                            :is-selected="isGameSelected(game)"
-                                            :is-favourited="false"
-                                            :active-tab="activeTab"
-                                            @select="emit('select-game', $event)"
-                                            @set-default="emit('set-default-game', $event)"
-                                            @toggle-favourite="toggleFavourite($event)"
-                                        />
-                                    </div>
+                                    <GameSelectionCard
+                                        v-for="game of nonFavouriteGameList"
+                                        :key="game.settingsIdentifier"
+                                        :game="game"
+                                        :is-selected="isGameSelected(game)"
+                                        :is-favourited="false"
+                                        :active-tab="activeTab"
+                                        @select="emit('select-game', $event)"
+                                        @set-default="emit('set-default-game', $event)"
+                                        @toggle-favourite="toggleFavourite($event)"
+                                    />
                                 </div>
                             </GameSelectionSection>
                         </template>
@@ -87,16 +87,16 @@
                             v-if="mergedGameList.length > 0"
                         >
                             <div class="game-cards-container">
-                                <div v-for="game of mergedGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
-                                    <GameSelectionCard
-                                        :game="game"
-                                        :is-favourited="isFavourited(game)"
-                                        :active-tab="activeTab"
-                                        @select="emit('select-game', $event)"
-                                        @set-default="emit('set-default-game', $event)"
-                                        @toggle-favourite="toggleFavourite($event)"
-                                    />
-                                </div>
+                                <GameSelectionCard
+                                    v-for="game of mergedGameList"
+                                    :key="game.settingsIdentifier"
+                                    :game="game"
+                                    :is-favourited="isFavourited(game)"
+                                    :active-tab="activeTab"
+                                    @select="emit('select-game', $event)"
+                                    @set-default="emit('set-default-game', $event)"
+                                    @toggle-favourite="toggleFavourite($event)"
+                                />
                             </div>
                         </GameSelectionSection>
                     </template>
@@ -111,18 +111,18 @@
                                 These games are no longer supported.
                             </div>
                             <div class="game-cards-container">
-                                <div v-for="game of hiddenGameList" :key="game.settingsIdentifier" class="inline-block margin-right margin-bottom">
-                                    <GameSelectionCard
-                                        :game="game"
-                                        :is-selected="isGameSelected(game)"
-                                        :is-favourited="isFavourited(game)"
-                                        :active-tab="activeTab"
-                                        :highlight-favourite="true"
-                                        @select="emit('select-game', $event)"
-                                        @set-default="emit('set-default-game', $event)"
-                                        @toggle-favourite="toggleFavourite($event)"
-                                    />
-                                </div>
+                                <GameSelectionCard
+                                    v-for="game of hiddenGameList"
+                                    :key="game.settingsIdentifier"
+                                    :game="game"
+                                    :is-selected="isGameSelected(game)"
+                                    :is-favourited="isFavourited(game)"
+                                    :active-tab="activeTab"
+                                    :highlight-favourite="true"
+                                    @select="emit('select-game', $event)"
+                                    @set-default="emit('set-default-game', $event)"
+                                    @toggle-favourite="toggleFavourite($event)"
+                                />
                             </div>
                         </GameSelectionSection>
                     </template>
@@ -170,9 +170,9 @@ const {
 
 <style lang="scss" scoped>
 .game-cards-container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(188px, 1fr));
+    gap: 1rem;
 }
 
 .card-header-title {


### PR DESCRIPTION
This adds dynamic sizing to the images to improve card spacing, and fixes several margin/padding issues.

<img width="1749" height="913" alt="image" src="https://github.com/user-attachments/assets/d713f2d7-3f56-48bb-aa87-44a2a5e0dac2" />

<img width="2556" height="1513" alt="image" src="https://github.com/user-attachments/assets/fa43be74-d652-4d88-8c8b-1b2a53af87c7" />
