### PR TITLE
[TS-3696] Use CDN image assets

### DIFF
--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -101,6 +101,8 @@ export default defineConfig((ctx) => {
             port: 9020,
             open: true, // opens browser window automatically
             proxy: {
+                // Proxy for a local ecosystem-schema deployment.
+                // https://github.com/thunderstore-io/ecosystem-schema
                 '/_local-assets': {
                     target: 'http://localhost:1337',
                     changeOrigin: true,

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -100,6 +100,13 @@ export default defineConfig((ctx) => {
             https: false,
             port: 9020,
             open: true, // opens browser window automatically
+            proxy: {
+                '/_local-assets': {
+                    target: 'http://localhost:1337',
+                    changeOrigin: true,
+                    rewrite: (path) => path.replace(/^\/_local-assets/, '/assets'),
+                },
+            },
         },
 
         // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#framework

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,6 +57,8 @@ import { NodeFsImplementation } from './providers/node/fs/NodeFsImplementation';
 import { useRouter } from 'vue-router';
 import { ProtocolProviderImplementation } from './providers/generic/protocol/ProtocolProviderImplementation';
 import { provideProtocolImplementation } from './providers/generic/protocol/ProtocolProvider';
+import GameImageProvider from './providers/generic/image/GameImageProvider';
+import GameImageProviderImpl from './r2mm/image/GameImageProviderImpl';
 import BreadcrumbNavigator from 'components/breadcrumbs/BreadcrumbNavigator.vue';
 
 const store = baseStore;
@@ -101,6 +103,9 @@ PlatformInterceptorProvider.provide(() => new PlatformInterceptorImpl());
 
 provideProtocolImplementation(() => ProtocolProviderImplementation)
 
+const gameImageProvider = new GameImageProviderImpl();
+GameImageProvider.provide(() => gameImageProvider);
+
 BindLoaderImpl.bind();
 
 onMounted(async () => {
@@ -132,6 +137,8 @@ onMounted(async () => {
         }
 
         await FileUtils.ensureDirectory(PathResolver.APPDATA_DIR);
+
+        await GameImageProvider.instance.init();
 
         await ThemeManager.apply();
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,8 +57,8 @@ import { NodeFsImplementation } from './providers/node/fs/NodeFsImplementation';
 import { useRouter } from 'vue-router';
 import { ProtocolProviderImplementation } from './providers/generic/protocol/ProtocolProviderImplementation';
 import { provideProtocolImplementation } from './providers/generic/protocol/ProtocolProvider';
-import GameImageProvider from './providers/generic/image/GameImageProvider';
-import GameImageProviderImpl from './r2mm/image/GameImageProviderImpl';
+import GameImageProvider, { provideGameImageImplementation } from './providers/generic/image/GameImageProvider';
+import { GameImageProviderImplementation } from './r2mm/image/GameImageProviderImpl';
 import BreadcrumbNavigator from 'components/breadcrumbs/BreadcrumbNavigator.vue';
 
 const store = baseStore;
@@ -102,9 +102,7 @@ DataFolderProvider.provide(() => new DataFolderProviderImpl());
 PlatformInterceptorProvider.provide(() => new PlatformInterceptorImpl());
 
 provideProtocolImplementation(() => ProtocolProviderImplementation)
-
-const gameImageProvider = new GameImageProviderImpl();
-GameImageProvider.provide(() => gameImageProvider);
+provideGameImageImplementation(() => GameImageProviderImplementation);
 
 BindLoaderImpl.bind();
 
@@ -138,7 +136,7 @@ onMounted(async () => {
 
         await FileUtils.ensureDirectory(PathResolver.APPDATA_DIR);
 
-        await GameImageProvider.instance.init();
+        await GameImageProvider.init();
 
         await ThemeManager.apply();
 

--- a/src/components/composables/GameImageComposable.ts
+++ b/src/components/composables/GameImageComposable.ts
@@ -1,12 +1,12 @@
-import { ref, watch } from 'vue';
+import { ref } from 'vue';
 import GameImageProvider from '../../providers/generic/image/GameImageProvider';
 
-export function useGameImageComposable(iconUrl: () => string) {
-    const imageSrc = ref<string>(GameImageProvider.instance.placeholderUrl);
+export function useGameImageComposable() {
+    const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
 
-    watch(iconUrl, async (current) => {
-        imageSrc.value = await GameImageProvider.instance.resolve(current);
-    }, { immediate: true });
+    async function setIcon(iconUrl: string) {
+        imageSrc.value = await GameImageProvider.resolve(iconUrl);
+    }
 
-    return { imageSrc };
+    return { imageSrc, setIcon };
 }

--- a/src/components/composables/GameImageComposable.ts
+++ b/src/components/composables/GameImageComposable.ts
@@ -1,12 +1,12 @@
-import { ref, watchEffect } from 'vue';
+import { ref, watch } from 'vue';
 import GameImageProvider from '../../providers/generic/image/GameImageProvider';
 
 export function useGameImageComposable(iconUrl: () => string) {
-    const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
+    const imageSrc = ref<string>(GameImageProvider.instance.placeholderUrl);
 
-    watchEffect(async () => {
-        imageSrc.value = await GameImageProvider.resolve(iconUrl());
-    });
+    watch(iconUrl, async (current) => {
+        imageSrc.value = await GameImageProvider.instance.resolve(current);
+    }, { immediate: true });
 
     return { imageSrc };
 }

--- a/src/components/composables/GameImageComposable.ts
+++ b/src/components/composables/GameImageComposable.ts
@@ -1,0 +1,12 @@
+import { ref, watchEffect } from 'vue';
+import GameImageProvider from '../../providers/generic/image/GameImageProvider';
+
+export function useGameImageComposable(iconUrl: () => string) {
+    const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
+
+    watchEffect(async () => {
+        imageSrc.value = await GameImageProvider.resolve(iconUrl());
+    });
+
+    return { imageSrc };
+}

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -3,7 +3,7 @@
         <div class="game-card">
             <div class="game-card__image">
                 <template v-if="activeTab === GameInstanceType.GAME">
-                    <img :src="getImageHref(`/images/game_selection/${game.gameImage}`)" alt="Game Logo" class="game-card__thumbnail"/>
+                    <img :src="imageSrc" alt="Game Logo" class="game-card__thumbnail"/>
                 </template>
                 <template v-else>
                     <div class="game-card__placeholder">{{ game.displayName }}</div>
@@ -34,9 +34,10 @@
 </template>
 
 <script lang="ts" setup>
+import { ref, watchEffect } from 'vue';
 import Game from '../../model/game/Game';
 import { GameInstanceType } from '../../model/schema/ThunderstoreSchema';
-import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider';
+import GameImageProvider from '../../providers/generic/image/GameImageProvider';
 
 type Props = {
     game: Game;
@@ -53,9 +54,11 @@ const emit = defineEmits<{
     'toggle-favourite': [game: Game];
 }>();
 
-function getImageHref(image: string) {
-    return ProtocolProvider.getPublicAssetUrl(image);
-}
+const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
+
+watchEffect(async () => {
+    imageSrc.value = await GameImageProvider.resolve(props.game.iconUrl);
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -34,6 +34,7 @@
 </template>
 
 <script lang="ts" setup>
+import { watch } from 'vue';
 import Game from '../../model/game/Game';
 import { GameInstanceType } from '../../model/schema/ThunderstoreSchema';
 import { useGameImageComposable } from '../composables/GameImageComposable';
@@ -53,7 +54,8 @@ const emit = defineEmits<{
     'toggle-favourite': [game: Game];
 }>();
 
-const { imageSrc } = useGameImageComposable(() => props.game.iconUrl);
+const { imageSrc, setIcon } = useGameImageComposable();
+watch(() => props.game.iconUrl, setIcon, { immediate: true });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/game-selection/GameSelectionCard.vue
+++ b/src/components/game-selection/GameSelectionCard.vue
@@ -34,10 +34,9 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watchEffect } from 'vue';
 import Game from '../../model/game/Game';
 import { GameInstanceType } from '../../model/schema/ThunderstoreSchema';
-import GameImageProvider from '../../providers/generic/image/GameImageProvider';
+import { useGameImageComposable } from '../composables/GameImageComposable';
 
 type Props = {
     game: Game;
@@ -54,11 +53,7 @@ const emit = defineEmits<{
     'toggle-favourite': [game: Game];
 }>();
 
-const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
-
-watchEffect(async () => {
-    imageSrc.value = await GameImageProvider.resolve(props.game.iconUrl);
-});
+const { imageSrc } = useGameImageComposable(() => props.game.iconUrl);
 </script>
 
 <style scoped lang="scss">

--- a/src/components/navigation/ManagerActivityBar.vue
+++ b/src/components/navigation/ManagerActivityBar.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
@@ -45,7 +45,8 @@ const router = useRouter();
 const activeGame = computed(() => store.state.activeGame);
 const profile = computed(() => store.getters['profile/activeProfile']);
 
-const { imageSrc } = useGameImageComposable(() => activeGame.value.iconUrl);
+const { imageSrc, setIcon } = useGameImageComposable();
+watch(() => activeGame.value.iconUrl, setIcon, { immediate: true });
 
 function changeGame() {
     router.push('/');

--- a/src/components/navigation/ManagerActivityBar.vue
+++ b/src/components/navigation/ManagerActivityBar.vue
@@ -3,7 +3,7 @@
         <div class="activity-bar--left">
             <div class="activity-bar__group">
                 <button class="activity-bar__context-item" id="game-switch-button" @click.prevent.stop="changeGame">
-                    <img class="game-icon" :src="ProtocolProvider.getPublicAssetUrl(`/images/game_selection/${activeGame.gameImage}`)" alt="Game icon"/>
+                    <img class="game-icon" :src="imageSrc" alt="Game icon"/>
                     <span>{{ activeGame.displayName }}</span>
                 </button>
                 <span class="activity-bar__item-label non-selectable activity-bar__item-divider">/</span>
@@ -32,18 +32,24 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, ref, watchEffect } from 'vue';
 import { useRouter } from 'vue-router';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
 import { ActivityDropdown } from '../all';
-import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider';
+import GameImageProvider from '../../providers/generic/image/GameImageProvider';
 
 const store = getStore<State>();
 const router = useRouter();
 
 const activeGame = computed(() => store.state.activeGame);
 const profile = computed(() => store.getters['profile/activeProfile']);
+
+const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
+
+watchEffect(async () => {
+    imageSrc.value = await GameImageProvider.resolve(activeGame.value.iconUrl);
+});
 
 function changeGame() {
     router.push('/');

--- a/src/components/navigation/ManagerActivityBar.vue
+++ b/src/components/navigation/ManagerActivityBar.vue
@@ -32,12 +32,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watchEffect } from 'vue';
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
 import { ActivityDropdown } from '../all';
-import GameImageProvider from '../../providers/generic/image/GameImageProvider';
+import { useGameImageComposable } from '../composables/GameImageComposable';
 
 const store = getStore<State>();
 const router = useRouter();
@@ -45,11 +45,7 @@ const router = useRouter();
 const activeGame = computed(() => store.state.activeGame);
 const profile = computed(() => store.getters['profile/activeProfile']);
 
-const imageSrc = ref<string>(GameImageProvider.placeholderUrl);
-
-watchEffect(async () => {
-    imageSrc.value = await GameImageProvider.resolve(activeGame.value.iconUrl);
-});
+const { imageSrc } = useGameImageComposable(() => activeGame.value.iconUrl);
 
 function changeGame() {
     router.push('/');

--- a/src/model/game/Game.ts
+++ b/src/model/game/Game.ts
@@ -13,7 +13,7 @@ export default class Game {
     private readonly _thunderstoreUrl: string;
     private readonly _thunderstoreIdentifier: string;
     private readonly _storePlatformMetadata: StorePlatformMetadata[];
-    private readonly _gameImage: string;
+    private readonly _iconUrl: string;
     private readonly _displayMode: GameSelectionDisplayMode;
     private readonly _instanceType: GameInstanceType;
     private readonly _packageLoader: PackageLoader;
@@ -32,7 +32,7 @@ export default class Game {
         tsUrl: string,
         tsIdentifier: string,
         platforms: StorePlatformMetadata[],
-        gameImage: string,
+        iconUrl: string,
         displayMode: GameSelectionDisplayMode,
         instanceType: GameInstanceType,
         packageLoader: PackageLoader,
@@ -49,7 +49,7 @@ export default class Game {
         this._thunderstoreIdentifier = tsIdentifier;
         this._storePlatformMetadata = platforms;
         this._activePlatform = platforms[0];
-        this._gameImage = gameImage;
+        this._iconUrl = iconUrl;
         this._displayMode = displayMode;
         this._instanceType = instanceType;
         this._packageLoader = packageLoader;
@@ -109,8 +109,8 @@ export default class Game {
         this._activePlatform = platform;
     }
 
-    get gameImage(): string {
-        return this._gameImage;
+    get iconUrl(): string {
+        return this._iconUrl;
     }
 
     get displayMode(): GameSelectionDisplayMode {

--- a/src/model/game/GameManager.ts
+++ b/src/model/game/GameManager.ts
@@ -35,7 +35,7 @@ export default class GameManager {
             game.distributions.map(
                 (x) => new StorePlatformMetadata(x.platform, x.identifier || undefined)
             ),
-            game.meta.iconUrl || "thunderstore-beta.webp",
+            game.meta.iconUrl ?? "",
             game.gameSelectionDisplayMode,
             game.gameInstanceType,
             game.packageLoader,

--- a/src/providers/generic/connection/CdnProvider.ts
+++ b/src/providers/generic/connection/CdnProvider.ts
@@ -62,15 +62,6 @@ export default class CdnProvider {
             : url;
     }
 
-    public static cdnUrlFor(pathSuffix: string): string | undefined {
-        if (!CdnProvider.preferredCdn) {
-            return undefined;
-        }
-        const { protocol, host } = CdnProvider.preferredCdn;
-        const trimmed = pathSuffix.startsWith("/") ? pathSuffix.slice(1) : pathSuffix;
-        return `${protocol}://${host}/${trimmed}`;
-    }
-
     public static addCdnQueryParameter(url: string) {
         return CdnProvider.preferredCdn
             ? addOrReplaceSearchParams(url, `cdn=${CdnProvider.preferredCdn.host}`)

--- a/src/providers/generic/connection/CdnProvider.ts
+++ b/src/providers/generic/connection/CdnProvider.ts
@@ -62,6 +62,15 @@ export default class CdnProvider {
             : url;
     }
 
+    public static cdnUrlFor(pathSuffix: string): string | undefined {
+        if (!CdnProvider.preferredCdn) {
+            return undefined;
+        }
+        const { protocol, host } = CdnProvider.preferredCdn;
+        const trimmed = pathSuffix.startsWith("/") ? pathSuffix.slice(1) : pathSuffix;
+        return `${protocol}://${host}/${trimmed}`;
+    }
+
     public static addCdnQueryParameter(url: string) {
         return CdnProvider.preferredCdn
             ? addOrReplaceSearchParams(url, `cdn=${CdnProvider.preferredCdn.host}`)

--- a/src/providers/generic/image/GameImageProvider.ts
+++ b/src/providers/generic/image/GameImageProvider.ts
@@ -1,23 +1,28 @@
 import ProviderUtils from '../ProviderUtils';
 
-export default abstract class GameImageProvider {
+export type GameImageProvider = {
+    init(): Promise<void>;
+    readonly placeholderUrl: string;
+    resolve(iconUrl: string): Promise<string>;
+};
 
-    private static provider: () => GameImageProvider;
-    static provide(provided: () => GameImageProvider): void {
-        this.provider = provided;
+let implementation: (() => GameImageProvider) | undefined;
+
+function getImplementation(): GameImageProvider {
+    if (!implementation) {
+        ProviderUtils.throwNotProvidedError("GameImageProvider");
     }
-
-    public static get instance(): GameImageProvider {
-        if (GameImageProvider.provider === undefined) {
-            ProviderUtils.throwNotProvidedError("GameImageProvider");
-        }
-        return GameImageProvider.provider();
-    }
-
-    public abstract init(): Promise<void>;
-
-    public abstract get placeholderUrl(): string;
-
-    public abstract resolve(iconUrl: string): Promise<string>;
-
+    return implementation!();
 }
+
+export function provideGameImageImplementation(provider: () => GameImageProvider) {
+    implementation = provider;
+}
+
+const gameImage: GameImageProvider = {
+    init: () => getImplementation().init(),
+    get placeholderUrl() { return getImplementation().placeholderUrl; },
+    resolve: (iconUrl) => getImplementation().resolve(iconUrl),
+};
+
+export default gameImage;

--- a/src/providers/generic/image/GameImageProvider.ts
+++ b/src/providers/generic/image/GameImageProvider.ts
@@ -1,165 +1,23 @@
-import buffer from '../../node/buffer/buffer';
-import path from '../../node/path/path';
-import CdnProvider from '../connection/CdnProvider';
-import FsProvider from '../file/FsProvider';
-import PathResolver from '../../../r2mm/manager/PathResolver';
-import ProtocolProvider from '../protocol/ProtocolProvider';
-import { getCdns } from '../../cdn/CdnHostList';
+import ProviderUtils from '../ProviderUtils';
 
-const BUNDLED_ASSET_DIR = "/images/game_selection";
-const PLACEHOLDER_FILE = "thunderstore-beta.webp";
-const LOCALHOST_DEV_BASE = "http://localhost:1337";
-const LOCALHOST_PROBE_TIMEOUT_MS = 2000;
-const CDN_FETCH_TIMEOUT_MS = 10000;
-const CDN_BREAKER_THRESHOLD = 3;
-const CACHE_SUBDIR = "image-cache";
+export default abstract class GameImageProvider {
 
-export default class GameImageProvider {
-
-    private static cacheRoot: string | undefined;
-    private static localhostAvailable = false;
-    private static cdnConsecutiveFailures = 0;
-    private static cdnBreakerTripped = false;
-    private static initialised: Promise<void> | undefined;
-
-    public static get placeholderUrl(): string {
-        return GameImageProvider.bundledUrlFor(PLACEHOLDER_FILE);
+    private static provider: () => GameImageProvider;
+    static provide(provided: () => GameImageProvider): void {
+        this.provider = provided;
     }
 
-    public static async resolve(iconUrl: string): Promise<string> {
-        await GameImageProvider.ensureInit();
-
-        if (!iconUrl) {
-            return GameImageProvider.placeholderUrl;
+    public static get instance(): GameImageProvider {
+        if (GameImageProvider.provider === undefined) {
+            ProviderUtils.throwNotProvidedError("GameImageProvider");
         }
-
-        const bundledUrl = GameImageProvider.bundledUrlFor(iconUrl);
-        if (await GameImageProvider.urlReachable(bundledUrl)) {
-            return bundledUrl;
-        }
-
-        if (GameImageProvider.localhostAvailable) {
-            const localhostUrl = `${LOCALHOST_DEV_BASE}/assets/${iconUrl}`;
-            if (await GameImageProvider.urlReachable(localhostUrl)) {
-                return localhostUrl;
-            }
-        }
-
-        const cachePath = GameImageProvider.cachePathFor(iconUrl);
-        if (cachePath && await FsProvider.instance.exists(cachePath)) {
-            return GameImageProvider.fileUrlOf(cachePath);
-        }
-
-        if (cachePath && !GameImageProvider.cdnBreakerTripped) {
-            const cached = await GameImageProvider.fetchFromCdnAndCache(iconUrl, cachePath);
-            if (cached) {
-                return cached;
-            }
-        }
-
-        return GameImageProvider.placeholderUrl;
+        return GameImageProvider.provider();
     }
 
-    private static bundledUrlFor(iconUrl: string): string {
-        return ProtocolProvider.getPublicAssetUrl(`${BUNDLED_ASSET_DIR}/${iconUrl}`);
-    }
+    public abstract init(): Promise<void>;
 
-    private static ensureInit(): Promise<void> {
-        if (!GameImageProvider.initialised) {
-            GameImageProvider.initialised = GameImageProvider.runInit();
-        }
-        return GameImageProvider.initialised;
-    }
+    public abstract get placeholderUrl(): string;
 
-    private static async runInit(): Promise<void> {
-        if (PathResolver.APPDATA_DIR) {
-            const root = path.join(PathResolver.APPDATA_DIR, CACHE_SUBDIR);
-            await FsProvider.instance.mkdirs(root);
-            GameImageProvider.cacheRoot = root;
-        }
+    public abstract resolve(iconUrl: string): Promise<string>;
 
-        if (import.meta.env.MODE === "development") {
-            GameImageProvider.localhostAvailable = await GameImageProvider.probeLocalhost();
-        }
-    }
-
-    private static async probeLocalhost(): Promise<boolean> {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), LOCALHOST_PROBE_TIMEOUT_MS);
-        try {
-            const res = await fetch(`${LOCALHOST_DEV_BASE}/healthz`, { signal: controller.signal });
-            return res.ok;
-        } catch {
-            return false;
-        } finally {
-            clearTimeout(timer);
-        }
-    }
-
-    private static async urlReachable(url: string): Promise<boolean> {
-        try {
-            const res = await fetch(url);
-            return res.ok;
-        } catch {
-            return false;
-        }
-    }
-
-    private static cachePathFor(iconUrl: string): string | undefined {
-        if (!GameImageProvider.cacheRoot) {
-            return undefined;
-        }
-        return path.join(GameImageProvider.cacheRoot, ...iconUrl.split("/"));
-    }
-
-    private static fileUrlOf(filePath: string): string {
-        return `file:///${filePath.replace(/\\/g, "/")}`;
-    }
-
-    private static async fetchFromCdnAndCache(iconUrl: string, cachePath: string): Promise<string | undefined> {
-        const main = getCdns()[0];
-        if (!main) {
-            return undefined;
-        }
-        const cdnUrl = CdnProvider.replaceCdnHost(`${main.protocol}://${main.host}/assets/${iconUrl}`);
-
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), CDN_FETCH_TIMEOUT_MS);
-        let res: Response;
-        try {
-            res = await fetch(cdnUrl, { signal: controller.signal });
-        } catch {
-            GameImageProvider.recordCdnFailure();
-            return undefined;
-        } finally {
-            clearTimeout(timer);
-        }
-
-        if (res.status === 404) {
-            GameImageProvider.cdnConsecutiveFailures = 0;
-            return undefined;
-        }
-        if (!res.ok) {
-            GameImageProvider.recordCdnFailure();
-            return undefined;
-        }
-
-        try {
-            const arrayBuffer = await res.arrayBuffer();
-            await FsProvider.instance.mkdirs(path.dirname(cachePath));
-            await FsProvider.instance.writeFile(cachePath, buffer.from(arrayBuffer));
-            GameImageProvider.cdnConsecutiveFailures = 0;
-            return GameImageProvider.fileUrlOf(cachePath);
-        } catch {
-            GameImageProvider.recordCdnFailure();
-            return undefined;
-        }
-    }
-
-    private static recordCdnFailure(): void {
-        GameImageProvider.cdnConsecutiveFailures += 1;
-        if (GameImageProvider.cdnConsecutiveFailures >= CDN_BREAKER_THRESHOLD) {
-            GameImageProvider.cdnBreakerTripped = true;
-        }
-    }
 }

--- a/src/providers/generic/image/GameImageProvider.ts
+++ b/src/providers/generic/image/GameImageProvider.ts
@@ -3,9 +3,11 @@ import path from '../../node/path/path';
 import CdnProvider from '../connection/CdnProvider';
 import FsProvider from '../file/FsProvider';
 import PathResolver from '../../../r2mm/manager/PathResolver';
+import ProtocolProvider from '../protocol/ProtocolProvider';
+import { getCdns } from '../../cdn/CdnHostList';
 
-const BUNDLED_PROTOCOL_PREFIX = "public://images/game_selection/";
-const PLACEHOLDER_URL = `${BUNDLED_PROTOCOL_PREFIX}thunderstore-beta.webp`;
+const BUNDLED_ASSET_DIR = "/images/game_selection";
+const PLACEHOLDER_FILE = "thunderstore-beta.webp";
 const LOCALHOST_DEV_BASE = "http://localhost:1337";
 const LOCALHOST_PROBE_TIMEOUT_MS = 2000;
 const CDN_FETCH_TIMEOUT_MS = 10000;
@@ -21,17 +23,17 @@ export default class GameImageProvider {
     private static initialised: Promise<void> | undefined;
 
     public static get placeholderUrl(): string {
-        return PLACEHOLDER_URL;
+        return GameImageProvider.bundledUrlFor(PLACEHOLDER_FILE);
     }
 
     public static async resolve(iconUrl: string): Promise<string> {
         await GameImageProvider.ensureInit();
 
         if (!iconUrl) {
-            return PLACEHOLDER_URL;
+            return GameImageProvider.placeholderUrl;
         }
 
-        const bundledUrl = `${BUNDLED_PROTOCOL_PREFIX}${iconUrl}`;
+        const bundledUrl = GameImageProvider.bundledUrlFor(iconUrl);
         if (await GameImageProvider.urlReachable(bundledUrl)) {
             return bundledUrl;
         }
@@ -55,7 +57,11 @@ export default class GameImageProvider {
             }
         }
 
-        return PLACEHOLDER_URL;
+        return GameImageProvider.placeholderUrl;
+    }
+
+    private static bundledUrlFor(iconUrl: string): string {
+        return ProtocolProvider.getPublicAssetUrl(`${BUNDLED_ASSET_DIR}/${iconUrl}`);
     }
 
     private static ensureInit(): Promise<void> {
@@ -111,10 +117,11 @@ export default class GameImageProvider {
     }
 
     private static async fetchFromCdnAndCache(iconUrl: string, cachePath: string): Promise<string | undefined> {
-        const cdnUrl = CdnProvider.cdnUrlFor(`assets/${iconUrl}`);
-        if (!cdnUrl) {
+        const main = getCdns()[0];
+        if (!main) {
             return undefined;
         }
+        const cdnUrl = CdnProvider.replaceCdnHost(`${main.protocol}://${main.host}/assets/${iconUrl}`);
 
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), CDN_FETCH_TIMEOUT_MS);

--- a/src/providers/generic/image/GameImageProvider.ts
+++ b/src/providers/generic/image/GameImageProvider.ts
@@ -1,0 +1,158 @@
+import buffer from '../../node/buffer/buffer';
+import path from '../../node/path/path';
+import CdnProvider from '../connection/CdnProvider';
+import FsProvider from '../file/FsProvider';
+import PathResolver from '../../../r2mm/manager/PathResolver';
+
+const BUNDLED_PROTOCOL_PREFIX = "public://images/game_selection/";
+const PLACEHOLDER_URL = `${BUNDLED_PROTOCOL_PREFIX}thunderstore-beta.webp`;
+const LOCALHOST_DEV_BASE = "http://localhost:1337";
+const LOCALHOST_PROBE_TIMEOUT_MS = 2000;
+const CDN_FETCH_TIMEOUT_MS = 10000;
+const CDN_BREAKER_THRESHOLD = 3;
+const CACHE_SUBDIR = "image-cache";
+
+export default class GameImageProvider {
+
+    private static cacheRoot: string | undefined;
+    private static localhostAvailable = false;
+    private static cdnConsecutiveFailures = 0;
+    private static cdnBreakerTripped = false;
+    private static initialised: Promise<void> | undefined;
+
+    public static get placeholderUrl(): string {
+        return PLACEHOLDER_URL;
+    }
+
+    public static async resolve(iconUrl: string): Promise<string> {
+        await GameImageProvider.ensureInit();
+
+        if (!iconUrl) {
+            return PLACEHOLDER_URL;
+        }
+
+        const bundledUrl = `${BUNDLED_PROTOCOL_PREFIX}${iconUrl}`;
+        if (await GameImageProvider.urlReachable(bundledUrl)) {
+            return bundledUrl;
+        }
+
+        if (GameImageProvider.localhostAvailable) {
+            const localhostUrl = `${LOCALHOST_DEV_BASE}/assets/${iconUrl}`;
+            if (await GameImageProvider.urlReachable(localhostUrl)) {
+                return localhostUrl;
+            }
+        }
+
+        const cachePath = GameImageProvider.cachePathFor(iconUrl);
+        if (cachePath && await FsProvider.instance.exists(cachePath)) {
+            return GameImageProvider.fileUrlOf(cachePath);
+        }
+
+        if (cachePath && !GameImageProvider.cdnBreakerTripped) {
+            const cached = await GameImageProvider.fetchFromCdnAndCache(iconUrl, cachePath);
+            if (cached) {
+                return cached;
+            }
+        }
+
+        return PLACEHOLDER_URL;
+    }
+
+    private static ensureInit(): Promise<void> {
+        if (!GameImageProvider.initialised) {
+            GameImageProvider.initialised = GameImageProvider.runInit();
+        }
+        return GameImageProvider.initialised;
+    }
+
+    private static async runInit(): Promise<void> {
+        if (PathResolver.APPDATA_DIR) {
+            const root = path.join(PathResolver.APPDATA_DIR, CACHE_SUBDIR);
+            await FsProvider.instance.mkdirs(root);
+            GameImageProvider.cacheRoot = root;
+        }
+
+        if (import.meta.env.MODE === "development") {
+            GameImageProvider.localhostAvailable = await GameImageProvider.probeLocalhost();
+        }
+    }
+
+    private static async probeLocalhost(): Promise<boolean> {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), LOCALHOST_PROBE_TIMEOUT_MS);
+        try {
+            const res = await fetch(`${LOCALHOST_DEV_BASE}/healthz`, { signal: controller.signal });
+            return res.ok;
+        } catch {
+            return false;
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    private static async urlReachable(url: string): Promise<boolean> {
+        try {
+            const res = await fetch(url);
+            return res.ok;
+        } catch {
+            return false;
+        }
+    }
+
+    private static cachePathFor(iconUrl: string): string | undefined {
+        if (!GameImageProvider.cacheRoot) {
+            return undefined;
+        }
+        return path.join(GameImageProvider.cacheRoot, ...iconUrl.split("/"));
+    }
+
+    private static fileUrlOf(filePath: string): string {
+        return `file:///${filePath.replace(/\\/g, "/")}`;
+    }
+
+    private static async fetchFromCdnAndCache(iconUrl: string, cachePath: string): Promise<string | undefined> {
+        const cdnUrl = CdnProvider.cdnUrlFor(`assets/${iconUrl}`);
+        if (!cdnUrl) {
+            return undefined;
+        }
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), CDN_FETCH_TIMEOUT_MS);
+        let res: Response;
+        try {
+            res = await fetch(cdnUrl, { signal: controller.signal });
+        } catch {
+            GameImageProvider.recordCdnFailure();
+            return undefined;
+        } finally {
+            clearTimeout(timer);
+        }
+
+        if (res.status === 404) {
+            GameImageProvider.cdnConsecutiveFailures = 0;
+            return undefined;
+        }
+        if (!res.ok) {
+            GameImageProvider.recordCdnFailure();
+            return undefined;
+        }
+
+        try {
+            const arrayBuffer = await res.arrayBuffer();
+            await FsProvider.instance.mkdirs(path.dirname(cachePath));
+            await FsProvider.instance.writeFile(cachePath, buffer.from(arrayBuffer));
+            GameImageProvider.cdnConsecutiveFailures = 0;
+            return GameImageProvider.fileUrlOf(cachePath);
+        } catch {
+            GameImageProvider.recordCdnFailure();
+            return undefined;
+        }
+    }
+
+    private static recordCdnFailure(): void {
+        GameImageProvider.cdnConsecutiveFailures += 1;
+        if (GameImageProvider.cdnConsecutiveFailures >= CDN_BREAKER_THRESHOLD) {
+            GameImageProvider.cdnBreakerTripped = true;
+        }
+    }
+}

--- a/src/r2mm/image/GameImageProviderImpl.ts
+++ b/src/r2mm/image/GameImageProviderImpl.ts
@@ -2,7 +2,7 @@ import buffer from '../../providers/node/buffer/buffer';
 import path from '../../providers/node/path/path';
 import CdnProvider from '../../providers/generic/connection/CdnProvider';
 import FsProvider from '../../providers/generic/file/FsProvider';
-import GameImageProvider from '../../providers/generic/image/GameImageProvider';
+import { GameImageProvider } from '../../providers/generic/image/GameImageProvider';
 import LoggerProvider, { LogSeverity } from '../../providers/ror2/logging/LoggerProvider';
 import PathResolver from '../manager/PathResolver';
 import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider';
@@ -15,7 +15,7 @@ const CDN_FETCH_TIMEOUT_MS = 10000;
 const CDN_BREAKER_THRESHOLD = 3;
 const CACHE_SUBDIR = "image-cache";
 
-export default class GameImageProviderImpl extends GameImageProvider {
+class GameImageProviderImpl implements GameImageProvider {
 
     private cacheRoot: string | undefined;
     private cdnConsecutiveFailures = 0;
@@ -130,3 +130,5 @@ export default class GameImageProviderImpl extends GameImageProvider {
     }
 
 }
+
+export const GameImageProviderImplementation: GameImageProvider = new GameImageProviderImpl();

--- a/src/r2mm/image/GameImageProviderImpl.ts
+++ b/src/r2mm/image/GameImageProviderImpl.ts
@@ -1,0 +1,151 @@
+import buffer from '../../providers/node/buffer/buffer';
+import path from '../../providers/node/path/path';
+import CdnProvider from '../../providers/generic/connection/CdnProvider';
+import FsProvider from '../../providers/generic/file/FsProvider';
+import GameImageProvider from '../../providers/generic/image/GameImageProvider';
+import LoggerProvider, { LogSeverity } from '../../providers/ror2/logging/LoggerProvider';
+import PathResolver from '../manager/PathResolver';
+import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider';
+
+const BUNDLED_ASSET_DIR = "/images/game_selection";
+const PLACEHOLDER_FILE = "thunderstore-beta.webp";
+const CDN_ASSET_BASE = "https://gcdn.thunderstore.io/assets";
+const LOCALHOST_DEV_BASE = "http://localhost:1337";
+const LOCALHOST_PROBE_TIMEOUT_MS = 2000;
+const CDN_FETCH_TIMEOUT_MS = 10000;
+const CDN_BREAKER_THRESHOLD = 3;
+const CACHE_SUBDIR = "image-cache";
+
+export default class GameImageProviderImpl extends GameImageProvider {
+
+    private cacheRoot: string | undefined;
+    private localhostAvailable = false;
+    private cdnConsecutiveFailures = 0;
+    private cdnBreakerTripped = false;
+
+    public async init(): Promise<void> {
+        if (PathResolver.APPDATA_DIR) {
+            const root = path.join(PathResolver.APPDATA_DIR, CACHE_SUBDIR);
+            await FsProvider.instance.mkdirs(root);
+            this.cacheRoot = root;
+        }
+
+        if (import.meta.env.MODE === "development") {
+            this.localhostAvailable = await this.probeLocalhost();
+        }
+    }
+
+    public get placeholderUrl(): string {
+        return this.bundledUrlFor(PLACEHOLDER_FILE);
+    }
+
+    public async resolve(iconUrl: string): Promise<string> {
+        if (!iconUrl) {
+            return this.placeholderUrl;
+        }
+
+        const bundledUrl = this.bundledUrlFor(iconUrl);
+        if (await this.urlReachable(bundledUrl)) {
+            return bundledUrl;
+        }
+
+        if (this.localhostAvailable) {
+            const localhostUrl = `${LOCALHOST_DEV_BASE}/assets/${iconUrl}`;
+            if (await this.urlReachable(localhostUrl)) {
+                return localhostUrl;
+            }
+        }
+
+        const cachePath = this.cachePathFor(iconUrl);
+        if (cachePath && await FsProvider.instance.exists(cachePath)) {
+            return await this.dataUrlFromFile(cachePath);
+        }
+
+        if (cachePath && !this.cdnBreakerTripped) {
+            const cached = await this.fetchFromCdnAndCache(iconUrl, cachePath);
+            if (cached) {
+                return cached;
+            }
+        }
+
+        return this.placeholderUrl;
+    }
+
+    private bundledUrlFor(iconUrl: string): string {
+        return ProtocolProvider.getPublicAssetUrl(`${BUNDLED_ASSET_DIR}/${iconUrl}`);
+    }
+
+    private async probeLocalhost(): Promise<boolean> {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), LOCALHOST_PROBE_TIMEOUT_MS);
+        try {
+            const res = await fetch(`${LOCALHOST_DEV_BASE}/healthz`, { signal: controller.signal });
+            return res.ok;
+        } catch {
+            return false;
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    private async urlReachable(url: string): Promise<boolean> {
+        return fetch(url).then(res => res.ok).catch(() => false);
+    }
+
+    private cachePathFor(iconUrl: string): string | undefined {
+        if (!this.cacheRoot) {
+            return undefined;
+        }
+        return path.join(this.cacheRoot, ...iconUrl.split("/"));
+    }
+
+    private async dataUrlFromFile(filePath: string): Promise<string> {
+        const content = await FsProvider.instance.base64FromZip(filePath);
+        return `data:image/webp;base64,${content}`;
+    }
+
+    private async fetchFromCdnAndCache(iconUrl: string, cachePath: string): Promise<string | undefined> {
+        const cdnUrl = CdnProvider.replaceCdnHost(`${CDN_ASSET_BASE}/${iconUrl}`);
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), CDN_FETCH_TIMEOUT_MS);
+        let res: Response;
+        try {
+            res = await fetch(cdnUrl, { signal: controller.signal });
+        } catch (e) {
+            this.recordCdnFailure(`fetch threw for ${cdnUrl}: ${(e as Error).message}`);
+            return undefined;
+        } finally {
+            clearTimeout(timer);
+        }
+
+        if (res.status === 404) {
+            this.cdnConsecutiveFailures = 0;
+            return undefined;
+        }
+        if (!res.ok) {
+            this.recordCdnFailure(`${res.status} ${res.statusText} on ${cdnUrl}`);
+            return undefined;
+        }
+
+        try {
+            const arrayBuffer = await res.arrayBuffer();
+            await FsProvider.instance.mkdirs(path.dirname(cachePath));
+            await FsProvider.instance.writeFile(cachePath, buffer.from(arrayBuffer));
+            this.cdnConsecutiveFailures = 0;
+            return await this.dataUrlFromFile(cachePath);
+        } catch (e) {
+            this.recordCdnFailure(`Failed to cache ${cdnUrl}: ${(e as Error).message}`);
+            return undefined;
+        }
+    }
+
+    private recordCdnFailure(detail: string): void {
+        this.cdnConsecutiveFailures += 1;
+        LoggerProvider.instance.Log(LogSeverity.ERROR, `GameImage CDN fetch failed: ${detail}`);
+        if (this.cdnConsecutiveFailures >= CDN_BREAKER_THRESHOLD) {
+            this.cdnBreakerTripped = true;
+        }
+    }
+
+}

--- a/src/r2mm/image/GameImageProviderImpl.ts
+++ b/src/r2mm/image/GameImageProviderImpl.ts
@@ -10,8 +10,7 @@ import ProtocolProvider from '../../providers/generic/protocol/ProtocolProvider'
 const BUNDLED_ASSET_DIR = "/images/game_selection";
 const PLACEHOLDER_FILE = "thunderstore-beta.webp";
 const CDN_ASSET_BASE = "https://gcdn.thunderstore.io/assets";
-const LOCALHOST_DEV_BASE = "http://localhost:1337";
-const LOCALHOST_PROBE_TIMEOUT_MS = 2000;
+const LOCAL_DEV_ASSET_BASE = "/_local-assets";
 const CDN_FETCH_TIMEOUT_MS = 10000;
 const CDN_BREAKER_THRESHOLD = 3;
 const CACHE_SUBDIR = "image-cache";
@@ -19,7 +18,6 @@ const CACHE_SUBDIR = "image-cache";
 export default class GameImageProviderImpl extends GameImageProvider {
 
     private cacheRoot: string | undefined;
-    private localhostAvailable = false;
     private cdnConsecutiveFailures = 0;
     private cdnBreakerTripped = false;
 
@@ -28,10 +26,6 @@ export default class GameImageProviderImpl extends GameImageProvider {
             const root = path.join(PathResolver.APPDATA_DIR, CACHE_SUBDIR);
             await FsProvider.instance.mkdirs(root);
             this.cacheRoot = root;
-        }
-
-        if (import.meta.env.MODE === "development") {
-            this.localhostAvailable = await this.probeLocalhost();
         }
     }
 
@@ -49,10 +43,10 @@ export default class GameImageProviderImpl extends GameImageProvider {
             return bundledUrl;
         }
 
-        if (this.localhostAvailable) {
-            const localhostUrl = `${LOCALHOST_DEV_BASE}/assets/${iconUrl}`;
-            if (await this.urlReachable(localhostUrl)) {
-                return localhostUrl;
+        if (import.meta.env.MODE === "development") {
+            const localUrl = `${LOCAL_DEV_ASSET_BASE}/${iconUrl}`;
+            if (await this.urlReachable(localUrl)) {
+                return localUrl;
             }
         }
 
@@ -73,19 +67,6 @@ export default class GameImageProviderImpl extends GameImageProvider {
 
     private bundledUrlFor(iconUrl: string): string {
         return ProtocolProvider.getPublicAssetUrl(`${BUNDLED_ASSET_DIR}/${iconUrl}`);
-    }
-
-    private async probeLocalhost(): Promise<boolean> {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), LOCALHOST_PROBE_TIMEOUT_MS);
-        try {
-            const res = await fetch(`${LOCALHOST_DEV_BASE}/healthz`, { signal: controller.signal });
-            return res.ok;
-        } catch {
-            return false;
-        } finally {
-            clearTimeout(timer);
-        }
     }
 
     private async urlReachable(url: string): Promise<boolean> {


### PR DESCRIPTION
This is basically a four-step approach. The provider:
1. Checks to see if the images are bundled.
2. Checks to see if an instance of the schema is being served on localhost:1337
3. Checks to see if any images have been cached locally.
4. Retrieves the image from the CDN.

This PR has a soft dependency on https://github.com/thunderstore-io/ecosystem-schema/pull/330. I recommend cloning that specific branch to test the localhost functionality. 

It is, however, hard blocked by https://github.com/thunderstore-io/ecosystem-schema/pull/320

My big concern at the moment are to do with race conditions on startup. I didnt see anything strange from my own testing, but there's likely an edge case where the community list renders before image assets have been acquired. Not super experienced with vue so I'm unsure. Will perform more testing later. 

And about the new assets - if needed I can move these to a separate PR. 