### PR TITLE
Sync root mod files to game directory after install

### DIFF
--- a/src/store/modules/DownloadModule.ts
+++ b/src/store/modules/DownloadModule.ts
@@ -14,6 +14,7 @@ import { State as RootState } from "../../store";
 import * as DownloadUtils from "../../utils/DownloadUtils";
 import { getFullDependencyList, InstallMode } from "../../utils/DependencyUtils";
 import { installModsToProfile } from "../../utils/ProfileUtils";
+import { syncProfileRootFiles } from "../../utils/LaunchUtils";
 
 interface DownloadProgress {
     downloadId: UUID;
@@ -136,6 +137,11 @@ export const DownloadModule = {
                 commit('setInstalling', downloadId);
                 await dispatch('_installModsAndResolveConflicts', { combos: modsWithDependencies, profile, downloadId });
                 commit('setInstalled', downloadId);
+
+                // Sync mod loader root files to the game directory so updates
+                // take effect even without requiring "Start Modded".
+                // Prevents issues with outdated files for users starting games using launch arguments.
+                await syncProfileRootFiles(game, profile);
             } catch (e) {
                 const r2Error = R2Error.fromThrownValue(e);
                 if (downloadId) {

--- a/src/utils/LaunchUtils.ts
+++ b/src/utils/LaunchUtils.ts
@@ -43,6 +43,20 @@ export const linkProfileFiles = async (game: Game, profile: ImmutableProfile): P
     await settings.setLinkedFiles(newLinkedFiles);
 };
 
+/**
+ * Non-fatal wrapper around linkProfileFiles.
+ * Syncs mod loader root files from the profile to the game directory.
+ * Failures are logged but do not propagate, so callers such as install/update flows
+ * won't fail if the game directory is not configured or the files are locked by a running game.
+ */
+export const syncProfileRootFiles = async (game: Game, profile: ImmutableProfile): Promise<void> => {
+    try {
+        await linkProfileFiles(game, profile);
+    } catch (e) {
+        console.warn('Failed to sync root mod files to game directory:', e);
+    }
+};
+
 export const setGameDirIfUnset = async (game: Game): Promise<void> => {
     const settings = await ManagerSettings.getSingleton(game);
     const currentDir = settings.getContext().gameSpecific.gameDirectory;


### PR DESCRIPTION
When mod loader packages (e.g. ReturnOfModding, BepInEx) are updated via the mod manager, root files like e.g. `d3d12.dll` are only synced to the game directory when clicking "Start Modded". Users who launch games using launch arguments on e.g. Steam will run with an outdated mod loader DLL until they use "Start Modded" again.

This PR calls `ModLinker.link()` after any mod installation completes, using the same logic already used by "Start Modded". The call is non-fatal - if the game is running and files are locked, or the game directory isn't configured, it fails silently and "Start Modded" remains the fallback - though the game will likely still crash just through the new mod being installed, but it won't be due to this change.

Tested this locally for ReturnOfModding/Hades II. After an update to Hell2Modding/any mod, the newest dll was copied to the install directory.