### PR TITLE
Minor flatpak metadata fixes

### DIFF
--- a/flatpak/io.github.ebkr.r2modman.desktop
+++ b/flatpak/io.github.ebkr.r2modman.desktop
@@ -3,7 +3,7 @@ Type=Application
 
 Name=r2modman
 Comment=A simple and easy to use mod manager for many games using Thunderstore
-Categories=Game;GameTool;
+Categories=Game;
 
 Icon=io.github.ebkr.r2modman
 Exec=io.github.ebkr.r2modman

--- a/flatpak/io.github.ebkr.r2modman.metainfo.xml
+++ b/flatpak/io.github.ebkr.r2modman.metainfo.xml
@@ -26,23 +26,24 @@
   </description>
 
   <releases>
+    <release version="3.2.15" date="2026-05-11" />
   </releases>
 
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/TB516/flathub-prep/develop/docs/images/gameselection.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/gameselection.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/TB516/flathub-prep/develop/docs/images/installedmodview.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/installedmodview.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/TB516/flathub-prep/develop/docs/images/downloadablemods.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/downloadablemods.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/TB516/flathub-prep/develop/docs/images/configeditor.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/configeditor.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/TB516/flathub-prep/develop/docs/images/profiles.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/profiles.png</image>
     </screenshot>
   </screenshots>
 </component>


### PR DESCRIPTION
- Fix appstream image urls to point to the right repo
- Remove `GameTool` category
  - Its a valid category from freedesktop but the linter is throwing an error so im just removing it for now