### PR TITLE
Update RivetGameInstructions to use new API

### DIFF
--- a/src/r2mm/launching/instructions/instructions/loader/RivetGameInstructions.ts
+++ b/src/r2mm/launching/instructions/instructions/loader/RivetGameInstructions.ts
@@ -25,8 +25,12 @@ export default class RivetGameInstructions extends GameInstructionGenerator {
 
     public async generate(game: Game, profile: Profile): Promise<GameInstruction> {
         return {
-            moddedParameters: `-rivetEnable true -rivetTarget ${profile.joinToProfilePath("Rivet", "Loader.dll")} -rivetDirectory ${profile.joinToProfilePath("Rivet", "Mods")}`,
-            vanillaParameters: `-rivetEnable false`
+            moddedParameterList: [
+                '-rivetEnable', 'true',
+                '-rivetTarget', profile.joinToProfilePath("Rivet", "Loader.dll"),
+                '-rivetDirectory', profile.joinToProfilePath("Rivet", "Mods")
+            ],
+            vanillaParameterList: ['-rivetEnable', 'false']
         }
     }
 }


### PR DESCRIPTION
Fixes #2154

It seems that the `GameInstruction` type has changed since Rivet was added, this corrects the usage of it in `RivetGameInstructions`