### PR TITLE
Improve request game action

### DIFF
--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -1,9 +1,22 @@
 <template>
     <article class="media">
         <div class="media-content">
-
+            <div id="no-content" class="content" v-if="resultCount === 0">
+                <div>
+                    <div>
+                        <i class="fas fa-gamepad fa-4x"></i>
+                        <br/>
+                        <h3 class="title is-4">No {{ activeTab }}s found matching "{{ filterText }}"</h3>
+                        <p class="subtitle">Try a different game title or keyword. We may not support this game yet.</p>
+                        <button class="button margin-top icon-button" @click.prevent.stop="requestNewGame">
+                            <span>Request a new {{ activeTab }}</span>
+                            <i class="margin-left--half-width fas fa-arrow-alt-circle-right"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
             <template v-if="viewMode === GameSelectionViewMode.LIST">
-                <div class="content">
+                <div id="list-content" class="content">
                     <GameSelectionListItem
                         v-for="game of favouriteGameList"
                         :key="game.settingsIdentifier"
@@ -32,6 +45,13 @@
                         @click="markAsSelectedGame(game)"
                         @toggle-favourite="toggleFavourite(game)"
                     />
+                    <div class="request-game margin-bottom" v-if="resultCount > 0">
+                        <h3 class="title is-5">Can't find what you're looking for?</h3>
+                        <button class="button margin-top" @click.prevent.stop="requestNewGame">
+                            <span>Request a new {{ activeTab }}</span>
+                            <i class="margin-left--half-width fas fa-arrow-alt-circle-right"></i>
+                        </button>
+                    </div>
                 </div>
             </template>
 
@@ -130,6 +150,14 @@
                         </GameSelectionSection>
                     </template>
                 </div>
+                <div class="request-game margin-bottom" v-if="resultCount > 0">
+                    <hr/>
+                    <h3 class="title is-5">Can't find what you're looking for?</h3>
+                    <button class="button margin-top" @click.prevent.stop="requestNewGame">
+                        <span>Request a new {{ activeTab }}</span>
+                        <i class="margin-left--half-width fas fa-arrow-alt-circle-right"></i>
+                    </button>
+                </div>
             </template>
 
         </div>
@@ -147,6 +175,7 @@ import Game from '../../model/game/Game';
 import { capitalize } from '../../utils/StringUtils';
 import { EcosystemSupportedGames } from '../../model/schema/ThunderstoreSchema';
 import { isGameNewlyAdded, registerGames } from '../../r2mm/ecosystem/EcosystemGameStatus';
+import LinkProvider from '../../providers/components/LinkProvider';
 
 const emit = defineEmits<{
     'select-game': [game: Game];
@@ -171,6 +200,8 @@ const newGames = computed(() => {
     return result;
 });
 
+const resultCount = computed(() => mergedGameList.value.length + hiddenGameList.value.length);
+
 const {
     hiddenGameList,
     favouriteGameList,
@@ -183,6 +214,10 @@ const {
     filterText,
     isFavourited,
 } = inject(gameSelectionKey)!;
+
+function requestNewGame() {
+    LinkProvider.instance.openLink("https://wiki.thunderstore.io/ecosystem/adding-a-new-game");
+}
 </script>
 
 <style lang="scss" scoped>
@@ -200,5 +235,31 @@ const {
 
 h3 {
     margin-bottom: 0 !important;
+}
+
+.title, .subtitle {
+    color: inherit;
+    display: block;
+    margin-top: 1.25rem !important;
+}
+
+.subtitle {
+    font-weight: lighter;
+}
+
+#no-content {
+    text-align: center;
+}
+
+.icon-button {
+    display: flex;
+    align-self: center;
+    flex: 1;
+    justify-self: center;
+    align-items: center;
+}
+
+.request-game {
+    margin: 2rem 0;
 }
 </style>

--- a/src/components/game-selection/GameSelectionList.vue
+++ b/src/components/game-selection/GameSelectionList.vue
@@ -10,7 +10,7 @@
                         <p class="subtitle">Try a different game title or keyword. We may not support this game yet.</p>
                         <button class="button margin-top icon-button" @click.prevent.stop="requestNewGame">
                             <span>Request a new {{ activeTab }}</span>
-                            <i class="margin-left--half-width fas fa-arrow-alt-circle-right"></i>
+                            <i class="margin-left--half-width fas fa-external-link-alt"></i>
                         </button>
                     </div>
                 </div>
@@ -49,7 +49,7 @@
                         <h3 class="title is-5">Can't find what you're looking for?</h3>
                         <button class="button margin-top" @click.prevent.stop="requestNewGame">
                             <span>Request a new {{ activeTab }}</span>
-                            <i class="margin-left--half-width fas fa-arrow-alt-circle-right"></i>
+                            <i class="margin-left--half-width fas fa-external-link-alt"></i>
                         </button>
                     </div>
                 </div>
@@ -155,7 +155,7 @@
                     <h3 class="title is-5">Can't find what you're looking for?</h3>
                     <button class="button margin-top" @click.prevent.stop="requestNewGame">
                         <span>Request a new {{ activeTab }}</span>
-                        <i class="margin-left--half-width fas fa-arrow-alt-circle-right"></i>
+                        <i class="margin-left--half-width fas fa-external-link-alt"></i>
                     </button>
                 </div>
             </template>

--- a/src/components/navigation/EcosystemUpdateIndicator.vue
+++ b/src/components/navigation/EcosystemUpdateIndicator.vue
@@ -1,11 +1,6 @@
 <template>
     <Teleport to="#activity-bar">
-        <div class="activity-bar--left">
-            <button class="activity-bar__action" @click="requestNewGame">
-                <span class="icon is-small"><i class="fa fa-plus fa-xs"></i></span>
-                <span>Request a new game</span>
-            </button>
-        </div>
+        <div class="activity-bar--left"></div>
         <div class="activity-bar--right">
             <button
                 v-if="status.onClick"
@@ -32,7 +27,6 @@
 import { computed } from 'vue';
 import { getStore } from '../../providers/generic/store/StoreProvider';
 import { State } from '../../store';
-import LinkProvider from '../../providers/components/LinkProvider';
 
 const store = getStore<State>();
 
@@ -70,10 +64,6 @@ const status = computed(() => {
         tooltip: undefined,
     };
 });
-
-function requestNewGame() {
-    LinkProvider.instance.openLink("https://wiki.thunderstore.io/ecosystem/adding-a-new-game");
-}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
# Improve Request Game Action

_Provides a cleaner experience for requesting a game to be added to Thunderstore_

## Why?

Having the action in the activity bar is appropriate but:
1. Less contextually relevant for the entire screen. 
2. Not as visually pleasing
3. Harder to port to TSMM

## Screenshots

<img width="1279" height="761" alt="image" src="https://github.com/user-attachments/assets/e45671c1-5f4f-47dc-b128-bf8f9265c5b5" />

<img width="1279" height="760" alt="image" src="https://github.com/user-attachments/assets/22b25a27-1677-4778-8f45-41e7082c6460" />

<img width="1278" height="760" alt="image" src="https://github.com/user-attachments/assets/f076779d-1a4e-4b54-910f-86f95200457c" />

<img width="1279" height="612" alt="image" src="https://github.com/user-attachments/assets/c389fb3f-b6a0-43f4-8a12-871795a9c86b" />

