### PR TITLE
More flatpak adjustments

### DIFF
--- a/flatpak/io.github.ebkr.r2modman
+++ b/flatpak/io.github.ebkr.r2modman
@@ -2,10 +2,9 @@
 
 if [ -n "$WAYLAND_DISPLAY" ]; then
   exec zypak-wrapper /app/r2modman \
-    --no-sandbox \
     --enable-features=UseOzonePlatform \
     --ozone-platform=wayland \
     "$@"
 else
-  exec zypak-wrapper /app/r2modman --no-sandbox "$@"
+  exec zypak-wrapper /app/r2modman "$@"
 fi

--- a/flatpak/io.github.ebkr.r2modman.metainfo.xml
+++ b/flatpak/io.github.ebkr.r2modman.metainfo.xml
@@ -31,19 +31,19 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/gameselection.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/refs/tags/v3.2.16/docs/images/gameselection.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/installedmodview.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/refs/tags/v3.2.16/docs/images/installedmodview.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/downloadablemods.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/refs/tags/v3.2.16/docs/images/downloadablemods.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/configeditor.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/refs/tags/v3.2.16/docs/images/configeditor.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/develop/docs/images/profiles.png</image>
+      <image>https://raw.githubusercontent.com/ebkr/r2modmanPlus/refs/tags/v3.2.16/docs/images/profiles.png</image>
     </screenshot>
   </screenshots>
 </component>

--- a/flatpak/io.github.ebkr.r2modman.yaml
+++ b/flatpak/io.github.ebkr.r2modman.yaml
@@ -52,9 +52,6 @@ modules:
       - generated-sources.json
 
       - type: file
-        path: io.github.ebkr.r2modman
-
-      - type: file
         url: https://repo.yarnpkg.com/4.11.0/packages/yarnpkg-cli/bin/yarn.js
         dest-filename: yarn.cjs
         sha256: b0efc6597348fab50c777d2ff4b09e814974058cf012c3d687c9e80bca824358
@@ -65,7 +62,6 @@ modules:
       - >-
         echo "yarnPath: yarn.cjs" >> .yarnrc.yml
       - yarn plugin import $FLATPAK_BUILDER_BUILDDIR/flatpak-node/flatpak-yarn.js
-
       # prepare yarn cache
       - yarn convertToZip $(which yarn)
 
@@ -79,4 +75,4 @@ modules:
 
       - install -Dm644 flatpak/io.github.ebkr.r2modman.desktop /app/share/applications/io.github.ebkr.r2modman.desktop
       - install -Dm644 flatpak/io.github.ebkr.r2modman.metainfo.xml /app/share/metainfo/io.github.ebkr.r2modman.metainfo.xml
-      - install -Dm755 io.github.ebkr.r2modman /app/bin/io.github.ebkr.r2modman
+      - install -Dm755 flatpak/io.github.ebkr.r2modman /app/bin/io.github.ebkr.r2modman

--- a/flatpak/io.github.ebkr.r2modman.yaml
+++ b/flatpak/io.github.ebkr.r2modman.yaml
@@ -8,6 +8,24 @@ base: org.electronjs.Electron2.BaseApp
 base-version: "25.08"
 command: io.github.ebkr.r2modman
 
+finish-args:
+  # Graphics
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+
+  # Flatpak spawn for steam deck
+  - --talk-name=org.freedesktop.Flatpak
+
+  # Network access
+  - --share=network
+  - --share=ipc
+
+  # File system to find Steam and games
+  - --filesystem=host
+  - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
+  # - --filesystem=~/.local/share/Steam:rw
+
 modules:
   - name: r2modmanPlus
     buildsystem: simple
@@ -68,21 +86,3 @@ modules:
       - install -Dm644 io.github.ebkr.r2modman.desktop /app/share/applications/io.github.ebkr.r2modman.desktop
       - install -Dm644 io.github.ebkr.r2modman.metainfo.xml /app/share/metainfo/io.github.ebkr.r2modman.metainfo.xml
       - install -Dm755 io.github.ebkr.r2modman /app/bin/io.github.ebkr.r2modman
-
-finish-args:
-  # Graphics
-  - --socket=wayland
-  - --socket=fallback-x11
-  - --device=dri
-
-  # Flatpak spawn for steam deck
-  - --talk-name=org.freedesktop.Flatpak
-
-  # Network access
-  - --share=network
-  - --share=ipc
-
-  # File system to find Steam and games
-  - --filesystem=host
-  # - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
-  # - --filesystem=~/.local/share/Steam:rw

--- a/flatpak/io.github.ebkr.r2modman.yaml
+++ b/flatpak/io.github.ebkr.r2modman.yaml
@@ -52,12 +52,6 @@ modules:
       - generated-sources.json
 
       - type: file
-        path: io.github.ebkr.r2modman.desktop
-
-      - type: file
-        path: io.github.ebkr.r2modman.metainfo.xml
-
-      - type: file
         path: io.github.ebkr.r2modman
 
       - type: file
@@ -83,6 +77,6 @@ modules:
       - install -Dm644 src/assets/icon/128x128.png /app/share/icons/hicolor/128x128/apps/io.github.ebkr.r2modman.png
       - install -Dm644 src/assets/icon/256x256.png /app/share/icons/hicolor/256x256/apps/io.github.ebkr.r2modman.png
 
-      - install -Dm644 io.github.ebkr.r2modman.desktop /app/share/applications/io.github.ebkr.r2modman.desktop
-      - install -Dm644 io.github.ebkr.r2modman.metainfo.xml /app/share/metainfo/io.github.ebkr.r2modman.metainfo.xml
+      - install -Dm644 flatpak/io.github.ebkr.r2modman.desktop /app/share/applications/io.github.ebkr.r2modman.desktop
+      - install -Dm644 flatpak/io.github.ebkr.r2modman.metainfo.xml /app/share/metainfo/io.github.ebkr.r2modman.metainfo.xml
       - install -Dm755 io.github.ebkr.r2modman /app/bin/io.github.ebkr.r2modman


### PR DESCRIPTION
- Updates the metainfo file to pin the link to the images instead of having them be the latest on the branch. They probably wont be changing so I just have it pinned against `v3.2.16` instead of making it so the links are generated by a script to match the exact current commit.
- Fixes module block location
- Adds `--filesystem=~/.var/app/com.valvesoftware.Steam:rw` override
- Changes the desktop file and metainfo files to be sourced from the source repo instead of local files