### PR TITLE
Update flatpak permissions

### DIFF
--- a/flatpak/io.github.ebkr.r2modman.yaml
+++ b/flatpak/io.github.ebkr.r2modman.yaml
@@ -84,5 +84,5 @@ finish-args:
 
   # File system to find Steam and games
   - --filesystem=host
-  # - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
+  - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
   # - --filesystem=~/.local/share/Steam:rw


### PR DESCRIPTION
Explicitly adds the steam flatpak location, because the host permission excludes the flatpak directories, which causes the auto detection to fail on flatpak steam installs when there isnt a link to the steam files in one of the earlier checked paths.