### PR TITLE
fix: update banner url missing release tag

### DIFF
--- a/src/components/banner/ManagerUpdateBanner.vue
+++ b/src/components/banner/ManagerUpdateBanner.vue
@@ -6,7 +6,6 @@ import VersionNumber from '../../model/VersionNumber';
 
 const appName = computed<string>(() => ManagerInformation.APP_NAME);
 const portableUpdateAvailable = ref<boolean>(false);
-const updateTagName = ref<string>('');
 
 async function isManagerUpdateAvailable() {
     if (!ManagerInformation.IS_PORTABLE) {
@@ -20,7 +19,6 @@ async function isManagerUpdateAvailable() {
                     return false;
                 }
                 const releaseVersion = new VersionNumber(release.name);
-                updateTagName.value = release.tag_name;
                 return releaseVersion.isNewerThan(ManagerInformation.VERSION);
             }) !== undefined;
         }).catch(err => {
@@ -38,7 +36,7 @@ onMounted(async () => {
         <div class='container'>
             <p>
                 An {{ appName }} update is available.
-                <ExternalLink :url="`https://github.com/ebkr/r2modmanPlus/releases/tag/${updateTagName}`">
+                <ExternalLink :url="`https://github.com/ebkr/r2modmanPlus/releases/latest`">
                     Click here to go to the release page.
                 </ExternalLink>
             </p>

--- a/src/components/banner/ManagerUpdateBanner.vue
+++ b/src/components/banner/ManagerUpdateBanner.vue
@@ -20,6 +20,7 @@ async function isManagerUpdateAvailable() {
                     return false;
                 }
                 const releaseVersion = new VersionNumber(release.name);
+                updateTagName.value = release.tag_name;
                 return releaseVersion.isNewerThan(ManagerInformation.VERSION);
             }) !== undefined;
         }).catch(err => {


### PR DESCRIPTION
The update banner includes a clickable link which points to https://github.com/ebkr/r2modmanPlus/releases/tag/ which is a 404. It looks like a previous refactor here omitted the assignment of `updateTagName` which is supposed to be appended to the url in 
``` 
<ExternalLink :url="`https://github.com/ebkr/r2modmanPlus/releases/tag/${updateTagName}`">
```