### PR TITLE
Local icon loading is now async and reduces disk reads for performance

### DIFF
--- a/src/components/composables/ModIconComposable.ts
+++ b/src/components/composables/ModIconComposable.ts
@@ -1,0 +1,18 @@
+import { ref, watch, Ref } from 'vue';
+
+import ManifestV2 from '../../model/ManifestV2';
+import ProfileModList from '../../r2mm/mods/ProfileModList';
+import { getStore } from '../../providers/generic/store/StoreProvider';
+import { State } from '../../store';
+
+export function useModIcon(mod: () => ManifestV2): Ref<string> {
+    const store = getStore<State>();
+    const icon = ref<string>('/unknown.png');
+
+    watch(() => mod().getDependencyString(), async () => {
+        const profile = store.getters['profile/activeProfile'].asImmutableProfile();
+        icon.value = await ProfileModList.getModIcon(mod(), profile);
+    }, { immediate: true });
+
+    return icon;
+}

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -7,6 +7,7 @@ import ManifestV2 from '../../../model/ManifestV2';
 import VersionNumber from '../../../model/VersionNumber';
 import { LogSeverity } from '../../../providers/ror2/logging/LoggerProvider';
 import Dependants from '../../../r2mm/mods/Dependants';
+import { useModIcon } from '../../composables/ModIconComposable';
 import { valueToReadableDate } from '../../../utils/DateUtils';
 import { splitToNameAndVersion } from '../../../utils/DependencyUtils';
 import { computed, onMounted, ref, watch } from 'vue';
@@ -27,6 +28,7 @@ const props = defineProps<LocalModCardProps>();
 const disabledDependencies = ref<ManifestV2[]>([]);
 const missingDependencies = ref<string[]>([]);
 const disableChangePending = ref<boolean>(false);
+const icon = useModIcon(() => props.mod);
 
 // Mod loader packages can't be disabled as it's hard to define
 // what that should even do in all cases.
@@ -189,7 +191,7 @@ function dependencyStringToModName(x: string) {
         :description="mod.getDescription()"
         :enabled="mod.isEnabled()"
         :id="`${mod.getAuthorName()}-${mod.getName()}-${mod.getVersionNumber()}`"
-        :image="mod.getIcon()"
+        :image="icon"
         :allowSorting="true">
 
         <template v-slot:title>

--- a/src/components/views/LocalModList/SkeletonLocalModCard.vue
+++ b/src/components/views/LocalModList/SkeletonLocalModCard.vue
@@ -1,12 +1,15 @@
 <script lang="ts" setup>
 import { ExpandableCard } from '../../all';
 import ManifestV2 from '../../../model/ManifestV2';
+import { useModIcon } from '../../composables/ModIconComposable';
 
 type LocalModCardProps = {
     mod: ManifestV2;
 }
 
 const props = defineProps<LocalModCardProps>();
+
+const icon = useModIcon(() => props.mod);
 </script>
 
 <template>
@@ -14,7 +17,7 @@ const props = defineProps<LocalModCardProps>();
         :description="mod.getDescription()"
         :enabled="mod.isEnabled()"
         :id="`${mod.getAuthorName()}-${mod.getName()}-${mod.getVersionNumber()}`"
-        :image="mod.getIcon()">
+        :image="icon">
 
         <template v-slot:title>
             <span class="non-selectable">

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -28,7 +28,7 @@ export default class ProfileModList {
     public static readonly MAX_EXPORT_AS_CODE_SIZE = 20000000; // 20MB
 
     private static iconCache = new Map<string, string>();
-    private static iconCacheProfileName: string | undefined;
+    private static iconCacheProfilePath: string | undefined;
 
     private static lock = new AsyncLock();
 
@@ -292,9 +292,9 @@ export default class ProfileModList {
     }
 
     public static async getModIcon(mod: ManifestV2, profile: ImmutableProfile): Promise<string> {
-        if (this.iconCacheProfileName !== profile.getProfileName()) {
+        if (this.iconCacheProfilePath !== profile.getProfilePath()) {
             this.iconCache.clear();
-            this.iconCacheProfileName = profile.getProfileName();
+            this.iconCacheProfilePath = profile.getProfilePath();
         }
 
         const cacheKey = `${mod.getName()}-${mod.getVersionNumber()}`;

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -27,6 +27,9 @@ export default class ProfileModList {
     public static SUPPORTED_CONFIG_FILE_EXTENSIONS = [".cfg", ".txt", ".json", ".yml", ".yaml", ".ini"];
     public static readonly MAX_EXPORT_AS_CODE_SIZE = 20000000; // 20MB
 
+    private static iconCache = new Map<string, string>();
+    private static iconCacheProfileName: string | undefined;
+
     private static lock = new AsyncLock();
 
     public static async requestLock(fn: () => any) {
@@ -45,7 +48,6 @@ export default class ProfileModList {
                 const parsedYaml: any = parseYaml(fileContent) || [];
                 for(let modIndex in parsedYaml){
                     const mod = new ManifestV2().fromJsObject(parsedYaml[modIndex]);
-                    this.setIconPath(mod, profile);
                     parsedYaml[modIndex] = mod;
                 }
                 return parsedYaml;
@@ -240,7 +242,7 @@ export default class ProfileModList {
         if (builder instanceof R2Error) {
             return builder;
         }
-        const exportPath = path.join(dir[0], `${profile.getProfileName()}_${new Date().getTime()}.r2z`);
+        const exportPath = path.join(dir[0]!, `${profile.getProfileName()}_${new Date().getTime()}.r2z`);
         await builder.createZip(exportPath);
         LinkProvider.instance.selectFile(exportPath);
         return exportPath;
@@ -289,22 +291,35 @@ export default class ProfileModList {
         return modList.filter(value => !value.isEnabled()).length;
     }
 
-    public static async setIconPath(mod: ManifestV2, profile: ImmutableProfile): Promise<void> {
+    public static async getModIcon(mod: ManifestV2, profile: ImmutableProfile): Promise<string> {
+        if (this.iconCacheProfileName !== profile.getProfileName()) {
+            this.iconCache.clear();
+            this.iconCacheProfileName = profile.getProfileName();
+        }
+
+        const cacheKey = `${mod.getName()}-${mod.getVersionNumber()}`;
+        const cached = this.iconCache.get(cacheKey);
+        if (cached !== undefined) {
+            return cached;
+        }
+
         const paths = [
             path.join(profile.getProfilePath(), "BepInEx", "plugins", mod.getName(), "icon.png"),
             path.join(PathResolver.MOD_ROOT, "cache", mod.getName(), mod.getVersionNumber().toString(), "icon.png"),
         ]
 
+        let icon = "/unknown.png";
         for (const iconPath of paths) {
             try {
                 const content = await FsProvider.instance.base64FromZip(iconPath);
-                mod.setIcon(`data:image/png;base64,${content}`);
-                return;
+                icon = `data:image/png;base64,${content}`;
+                break;
             } catch (e) {
                 continue;
             }
         }
 
-        mod.setIcon("/unknown.png");
+        this.iconCache.set(cacheKey, icon);
+        return icon;
     }
 }

--- a/src/utils/ProfileUtils.ts
+++ b/src/utils/ProfileUtils.ts
@@ -128,7 +128,6 @@ export async function installModsToProfile(
             }
 
             manifestMod.setInstalledAtTime(Number(new Date()));
-            ProfileModList.setIconPath(manifestMod, profile);
 
             if (typeof progressCallback === "function") {
                 const progress = Math.floor(((index + 1) / comboList.length) * 100);


### PR DESCRIPTION
# Performance improvement for local icons
_Converts loading to async, and happens for each mod exactly once per profile_

## Why?

Previously every time someone would access their installed mod list, every single icon would be read from disk.

This is unnecessary as they don't change. If a mod itself has changes then the comparison key will differ and they'll be re-looked up.