### PR TITLE
Resolve CoreCLR preloaders

### DIFF
--- a/src/r2mm/launching/instructions/GameInstructionParser.ts
+++ b/src/r2mm/launching/instructions/GameInstructionParser.ts
@@ -61,13 +61,13 @@ export default class GameInstructionParser {
                 const corePath = await FsProvider.instance.realpath(profile.joinToProfilePath("BepInEx", "core"));
                 const preloaderPath = path.join(corePath,
                     (await FsProvider.instance.readdir(corePath))
-                        .filter((x: string) => ["BepInEx.Unity.Mono.Preloader.dll", "BepInEx.Unity.IL2CPP.dll", "BepInEx.Preloader.dll", "BepInEx.IL2CPP.dll"].includes(x))[0]!);
+                        .filter((x: string) => ["BepInEx.Unity.Mono.Preloader.dll", "BepInEx.Unity.IL2CPP.dll", "BepInEx.Preloader.dll", "BepInEx.IL2CPP.dll", "BepInEx.NET.CoreCLR.dll"].includes(x))[0]!);
                 return `${isProton ? 'Z:' : ''}${preloaderPath}`;
             } else {
                 const corePath = profile.joinToProfilePath("BepInEx", "core");
                 return path.join(corePath,
                     (await FsProvider.instance.readdir(corePath))
-                        .filter((x: string) => ["BepInEx.Unity.Mono.Preloader.dll", "BepInEx.Unity.IL2CPP.dll", "BepInEx.Preloader.dll", "BepInEx.IL2CPP.dll"].includes(x))[0]!);
+                        .filter((x: string) => ["BepInEx.Unity.Mono.Preloader.dll", "BepInEx.Unity.IL2CPP.dll", "BepInEx.Preloader.dll", "BepInEx.IL2CPP.dll", "BepInEx.NET.CoreCLR.dll"].includes(x))[0]!);
             }
         } catch (e) {
             const err: Error = e as Error;


### PR DESCRIPTION
Simply adds `BepInEx.NET.CoreCLR.dll` so that CoreCLR BepInEx-based modloaders properly inject