### PR TITLE
Auto-detect Steam snap install and launch via /snap/bin/steam Fixes

### DIFF
--- a/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
+++ b/src/r2mm/launching/runners/linux/SteamGameRunner_Linux.ts
@@ -80,7 +80,12 @@ export default class SteamGameRunner_Linux extends GameRunnerProvider {
         if (steamDir instanceof R2Error) {
             return steamDir;
         }
-        const steamExecutable = `${steamDir}/steam.sh`;
+
+        // The Steam snap's steam.sh cannot reliably be executed directly due to snap confinement.
+        // Its own wrapper at /snap/bin/steam handles entering the snap sandbox correctly.
+        const steamExecutable = LinuxGameDirectoryResolver.isSnapSteamDirectory(steamDir)
+            ? '/snap/bin/steam'
+            : `${steamDir}/steam.sh`;
 
         LoggerProvider.instance.Log(LogSeverity.INFO, `Steam executable to call is: ${steamExecutable}`);
 

--- a/src/r2mm/manager/linux/GameDirectoryResolver.ts
+++ b/src/r2mm/manager/linux/GameDirectoryResolver.ts
@@ -16,7 +16,15 @@ import EnumResolver from "../../../model/enums/_EnumResolver";
 
 const FORCE_PROTON_FILENAME = ".forceproton";
 
+// Snap's Steam package keeps its data under the snap's own "common" directory rather than $HOME directly.
+const SNAP_STEAM_COMMON_DIR = 'snap/steam/common';
+
 export default class GameDirectoryResolverImpl extends GameDirectoryResolverProvider {
+
+    // Callers use this to know when to launch via /snap/bin/steam instead of steamDir/steam.sh.
+    public static isSnapSteamDirectory(steamDir: string): boolean {
+        return steamDir.includes(SNAP_STEAM_COMMON_DIR);
+    }
 
     public async getSteamDirectory(): Promise<string | R2Error> {
         const settings = await ManagerSettings.getSingleton(GameManager.activeGame);
@@ -32,7 +40,11 @@ export default class GameDirectoryResolverImpl extends GameDirectoryResolverProv
                 path.resolve(os.homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
                 path.resolve(os.homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam', 'steam'),
                 path.resolve(os.homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam', 'root'),
-                path.resolve(os.homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam')
+                path.resolve(os.homedir(), '.var', 'app', 'com.valvesoftware.Steam', '.steam'),
+                path.resolve(os.homedir(), 'snap', 'steam', 'common', '.local', 'share', 'Steam'),
+                path.resolve(os.homedir(), 'snap', 'steam', 'common', '.steam', 'steam'),
+                path.resolve(os.homedir(), 'snap', 'steam', 'common', '.steam', 'root'),
+                path.resolve(os.homedir(), 'snap', 'steam', 'common', '.steam'),
             ];
             for (let dir of dirs) {
                 if (await FsProvider.instance.exists(dir) && (await FsProvider.instance.readdir(dir))


### PR DESCRIPTION
Steam's snap package keeps its data under ~/snap/steam/common instead of the usual ~/.local/share/Steam, so it was never found by getSteamDirectory()'s candidate list.

Add those paths as candidates, and when the resolved directory belongs to the snap, launch Steam through its own /snap/bin/steam wrapper instead of exec'ing steam.sh directly, since invoking the snap's internal script from outside its confinement doesn't reliably work.

Fixes #1046 