### PR TITLE
Fixes for Flatpak setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Updates via Flatpak are also much smaller and quicker to install.
 You can install it via the included `flatpak-setup.sh` script or manually with these commands:
 
 ```bash
-flatpak remote-add --if-not-exists r2builds http://r2builds.ebkr.dev/flatpak/r2modman.flatpakrepo
-flatpak install io.github.ebkr.r2modman
+flatpak remote-add --if-not-exists r2builds https://r2builds.ebkr.dev/flatpak/r2modman.flatpakrepo
+flatpak install -y r2builds io.github.ebkr.r2modman
 ```
 
 The README has more detailed setup information for Flatpaks if needed.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ If you prefer to run the manager in desktop mode, you can use either the Flatpak
 
 The `flatpak-setup.sh` script consists of:
 ```bash
-flatpak remote-add --if-not-exists r2builds http://r2builds.ebkr.dev/flatpak/r2modman.flatpakrepo
-flatpak install io.github.ebkr.r2modman
+flatpak remote-add --if-not-exists r2builds https://r2builds.ebkr.dev/flatpak/r2modman.flatpakrepo
+flatpak install -y r2builds io.github.ebkr.r2modman
 ```
 
 You will need elevated privileges (sudo) to run the `flatpak-setup.sh` script or the commands as listed above.

--- a/scripts/flatpak-setup-dist.sh
+++ b/scripts/flatpak-setup-dist.sh
@@ -1,2 +1,2 @@
-flatpak remote-add --if-not-exists r2builds http://r2builds.ebkr.dev/flatpak/r2modman.flatpakrepo
-flatpak install io.github.ebkr.r2modman
+flatpak remote-add --if-not-exists r2builds https://r2builds.ebkr.dev/flatpak/r2modman.flatpakrepo
+flatpak install -y r2builds io.github.ebkr.r2modman


### PR DESCRIPTION
- Bump from http to https (auto redirected anyway)
- Added repository prefix to install command
- Added `-y` flag to install script