### PR TITLE
It simply replaces '_' with spaces in the displayed game titles

### DIFF
--- a/src/components/modals/DependencyStringsModal.vue
+++ b/src/components/modals/DependencyStringsModal.vue
@@ -23,7 +23,7 @@ function close() {
         <template v-slot:body>
             <ul>
                 <li v-for="(mod, index) in localModList" :key="`dep-str-${index}`">
-                    {{ mod.getName() }}-{{ mod.getVersionNumber().toString() }}
+                    {{ mod.getName().replaceAll('_', ' ') }}-{{ mod.getVersionNumber().toString() }}
                 </li>
             </ul>
         </template>

--- a/src/components/v2/OnlinePreviewPanel.vue
+++ b/src/components/v2/OnlinePreviewPanel.vue
@@ -192,7 +192,7 @@ function dragEnd(event: DragEvent) {
                     <i class="fas fa-times"/>
                 </button>
                 <h1 class="title">
-                    {{ mod.getName() }}
+                    {{ mod.getName().replaceAll('_', ' ') }}
                 </h1>
                 <h2 class="subtitle">
                     By {{ mod.getOwner() }}

--- a/src/components/views/DownloadModVersionSelectModal.vue
+++ b/src/components/views/DownloadModVersionSelectModal.vue
@@ -2,7 +2,7 @@
     <ModalCard id="download-mod-version-select-modal" :is-active="isOpen" :can-close="true" v-if="thunderstoreMod !== null" @close-modal="closeModal()">
         <template v-slot:header>
             <h2 class='modal-title' v-if="thunderstoreMod !== null">
-                Select a version of {{thunderstoreMod.getName()}} to download
+                Select a version of '{{thunderstoreMod.getName().replaceAll('_', ' ')}}' to download
             </h2>
         </template>
         <template v-slot:body>

--- a/src/components/views/LocalModList/LocalModCard.vue
+++ b/src/components/views/LocalModList/LocalModCard.vue
@@ -170,7 +170,7 @@ function openReviewModal() {
                 </span>
                 <span class="card-title selectable">
                     <component :is="mod.isEnabled() ? 'span' : 'strike'" class="selectable">
-                        {{mod.getDisplayName()}}
+                        {{mod.getDisplayName().replaceAll('_', ' ')}}
                         <span class="selectable card-byline">
                             v{{mod.getVersionNumber()}}
                         </span>

--- a/src/components/views/LocalModList/SkeletonLocalModCard.vue
+++ b/src/components/views/LocalModList/SkeletonLocalModCard.vue
@@ -28,7 +28,7 @@ const icon = useModIcon(() => props.mod);
                 </span>
                 <span class="card-title selectable">
                     <component :is="mod.isEnabled() ? 'span' : 'strike'" class="selectable">
-                        {{mod.getDisplayName()}}
+                        {{mod.getDisplayName().replaceAll('_', ' ')}}
                         <span class="selectable card-byline">
                             v{{mod.getVersionNumber()}}
                         </span>

--- a/src/components/views/OnlineModList.vue
+++ b/src/components/views/OnlineModList.vue
@@ -11,17 +11,17 @@
                           v-tooltip.right="'Pinned on Thunderstore'">
                         Pinned
                     </span>
-                    <span class="selectable">{{key.getName()}} <span class="card-byline">by {{key.getOwner()}}</span></span>
+                    <span class="selectable">{{key.getName().replaceAll('_', ' ')}} <span class="card-byline">by {{key.getOwner()}}</span></span>
                 </span>
                 <span v-else-if="isModDeprecated(key)">
                     <span class="tag is-danger margin-right margin-right--half-width"
                           v-tooltip.right="'This mod is potentially broken'">
                         Deprecated
                     </span>
-                    <strike class="selectable">{{key.getName()}} <span class="card-byline">by {{key.getOwner()}}</span></strike>
+                    <strike class="selectable">{{key.getName().replaceAll('_', ' ')}} <span class="card-byline">by {{key.getOwner()}}</span></strike>
                 </span>
                 <span v-else class='selectable'>
-                    {{key.getName()}} <span class="card-byline">by {{key.getOwner()}}</span>
+                    {{key.getName().replaceAll('_', ' ')}} <span class="card-byline">by {{key.getOwner()}}</span>
                 </span>
             </template>
             <template v-slot:other-icons>

--- a/src/components/views/OnlineModListWithPanel.vue
+++ b/src/components/views/OnlineModListWithPanel.vue
@@ -8,7 +8,7 @@
             @click="() => emitCardClick(key)">
             <template v-slot:title>
                 <div>
-                    <span class="selectable">{{key.getName()}}</span>
+                    <span class="selectable">{{key.getName().replaceAll('_', ' ')}}</span>
                     <div>
                         <span class="card-byline">{{key.getOwner()}}</span>
                     </div>


### PR DESCRIPTION
It simply replaces '_' with spaces in the displayed game titles. Thanks to this minor change, the titles are more readable. I believe I’ve applied the change everywhere necessary.