### PR TITLE
Add new lovely binary name to its installer

### DIFF
--- a/src/installers/LovelyInstaller.ts
+++ b/src/installers/LovelyInstaller.ts
@@ -18,11 +18,20 @@ export class LovelyInstaller implements PackageInstaller {
         const fs = FsProvider.instance;
         const fileRelocations = new Map<string, string>();
 
-        // Manually copy over version.dll
-        const dwmSrc = path.join(packagePath, "version.dll");
-        const dwmDest = profile.joinToProfilePath("version.dll");
-        await fs.copyFile(dwmSrc, dwmDest);
-        fileRelocations.set(dwmSrc, "version.dll");
+        // 0.9.0 was version.dll, 0.10.0+ is winmm.dll.
+        const dllTargets = ["version.dll", "winmm.dll"];
+
+        for (const dllTarget of dllTargets) {
+            const dwmSrc = path.join(packagePath, dllTarget);
+            const dwmDest = profile.joinToProfilePath(dllTarget);
+
+            if (!await fs.exists(dwmSrc)) {
+                continue;
+            }
+
+            await fs.copyFile(dwmSrc, dwmDest);
+            fileRelocations.set(dwmSrc, dllTarget);
+        }
 
         // Files within the lovely subdirectory need to be recursively copied into the destination.
         const lovelyTree = await FileTree.buildFromLocation(path.join(packagePath, "lovely"));


### PR DESCRIPTION
Lovely versions past 0.10.0 will be `winmm.dll`. This changes the installer to be fault-tolerant and support both the old and new binary names.