### PR TITLE
Fix Northstar profile paths on Proton and type checking after Flatpak builds

### DIFF
--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -50,6 +50,8 @@ export default defineConfig((ctx: QuasarContext) => {
                 strict: true,
                 vueShim: true,
                 extendTsConfig(tsConfig: any) {
+                    // Flatpak output includes bundled JavaScript that should not be type-checked.
+                    tsConfig.exclude.push('../flatpak/build', '../flatpak/repo', '../.flatpak-builder');
                     tsConfig.compilerOptions.paths = {
                         '@r2': ['../src'],
                         '@r2/*': ['../src/*'],

--- a/src/r2mm/launching/instructions/GameInstructionParser.ts
+++ b/src/r2mm/launching/instructions/GameInstructionParser.ts
@@ -89,7 +89,16 @@ export default class GameInstructionParser {
     }
 
     private static async northstarDirectoryResolver(game: Game, profile: Profile): Promise<string | R2Error> {
-        return profile.joinToProfilePath("R2Northstar");
+        try {
+            if (appWindow.getPlatform().toLowerCase() === "linux" && await GameInstructionParser.isProton(game)) {
+                const northstarPath = await FsProvider.instance.realpath(profile.joinToProfilePath("R2Northstar"));
+                return `Z:${northstarPath}`;
+            }
+            return profile.joinToProfilePath("R2Northstar");
+        } catch (e) {
+            const err: Error = e as Error;
+            return new R2Error("Failed to resolve Northstar directory", err.message, "Northstar may not be installed correctly. Further help may be required.");
+        }
     }
 
     private static async gdweaveFolderResolver(game: Game, profile: Profile): Promise<string | R2Error> {


### PR DESCRIPTION
This PR was created by GPT-6

Northstar receives a Unix profile path on Linux with Proton and resolves it on the game's Windows drive. Resolve the Northstar directory with `realpath()` and prefix it with `Z:` when `isProton()` applies, matching the existing loader patterns. Other platforms and launch types retain their current behavior, and failures return `R2Error`.

Also exclude generated Flatpak directories through Quasar's `extendTsConfig` hook. Type checking otherwise scans thousands of bundled JavaScript files from local builds and exhausts Node's heap.

Validation:
- `pnpm typecheck` passes with the default heap, including after a Flatpak build.
- Existing tests: 200 passed, 5 skipped, with generated Flatpak test copies excluded.
- Built a local `.flatpak`; Thomas confirmed it works with the separately patched NorthstarLauncher that supports Windows absolute profile paths.
