### PR TITLE
feat: loader specific enabled handling

### DIFF
--- a/src/installers/LovelyInstaller.ts
+++ b/src/installers/LovelyInstaller.ts
@@ -90,15 +90,83 @@ export class LovelyPluginInstaller implements PackageInstaller {
         await addToStateFile(mod, fileRelocations, profile);
     }
 
+    async isDisabled(args: InstallArgs, lazy = true) {
+        const lovelyignore = await this.checkModLovelyIgnored(args);
+        if (lazy && lovelyignore) return { lovelyignore };
+        const blacklist = await this.checkModBlacklisted(args);
+        if (lovelyignore || blacklist) return { lovelyignore, blacklist };
+        return false
+    }
+
+    async checkModLovelyIgnored(args: InstallArgs) {
+        const {
+            mod,
+            profile,
+        } = args;
+        const lovelyignore = profile.joinToProfilePath("mods", mod.getName(), ".lovelyignore");
+
+        const fs = FsProvider.instance;
+        if (await fs.exists(lovelyignore)) return lovelyignore;
+    }
+
+    async checkModBlacklisted(args: InstallArgs) {
+        const {
+            mod,
+            profile,
+        } = args;
+        const blacklistPath = profile.joinToProfilePath("mods", "lovely", "blacklist.txt");
+
+        const fs = FsProvider.instance;
+        if (!await fs.exists(blacklistPath)) return;
+        // NOTE: Using node:fs.lines() would likely be more efficent, but I didn't
+        // want to bother implementing it for all the fs implementations
+        const fileContent = (await fs.readFile(blacklistPath)).toString();
+        for (const line of fileContent.split(/\r?\n/g)) {
+            if (line === mod.getName()) {
+                return blacklistPath;
+            }
+        }
+    }
+
     async uninstall(args: InstallArgs) {
+        await this.enable(args); // We don't want lingering disabled metadata to cause a mod to be disabled immediatly after install
         await uninstallState(args.mod, args.profile);
     }
 
     async enable(args: InstallArgs) {
-        await applyModeState(args.mod, args.profile, ModMode.ENABLED);
+        const {
+            mod,
+        } = args;
+        const info = await this.isDisabled(args, false)
+        if (!info) return console.warn("Told to enable a lovely mod (" + mod.getName() + "), but mod was not disabled?");
+        const fs = FsProvider.instance;
+        if (info.lovelyignore) {
+            await fs.unlink(info.lovelyignore);
+        }
+        if (info.blacklist) {
+            let fileContent = (await fs.readFile(info.blacklist)).toString();
+            fileContent = fileContent.split(/\r?\n/g)
+            .filter(l => l !== mod.getName())
+            .join("\n")
+            await fs.writeFile(info.blacklist, fileContent);
+        }
     }
 
     async disable(args: InstallArgs) {
-        await applyModeState(args.mod, args.profile, ModMode.DISABLED);
+        // NOTE: I elected to use .lovelyignore simply because it's simpler to implement.
+        // If we ever end up installing mods as zip files instead of extracting them
+        // we will need to use the blacklist!
+        const {
+            mod,
+            profile,
+        } = args;
+        const lovelyignore = profile.joinToProfilePath("mods", mod.getName(), ".lovelyignore");
+
+        const fs = FsProvider.instance;
+        await fs.writeFile(lovelyignore, "");
+    }
+
+    async isLoaderDisabled(args: InstallArgs) {
+        return !!(await this.isDisabled(args));
     }
 }

--- a/src/installers/PackageInstaller.ts
+++ b/src/installers/PackageInstaller.ts
@@ -22,7 +22,7 @@ export interface PackageInstaller {
     // Plugin installers only.
     enable?(args: InstallArgs): Promise<void>;
     disable?(args: InstallArgs): Promise<void>;
-    isLoaderDisabled?(args: InstallArgs): Promise<boolean>;
+    isLoaderDisabled?(args: InstallArgs): Promise<boolean | undefined>;
 }
 
 export async function disableModByRenamingFiles(folderName: string) {

--- a/src/installers/PackageInstaller.ts
+++ b/src/installers/PackageInstaller.ts
@@ -22,6 +22,7 @@ export interface PackageInstaller {
     // Plugin installers only.
     enable?(args: InstallArgs): Promise<void>;
     disable?(args: InstallArgs): Promise<void>;
+    isLoaderDisabled?(args: InstallArgs): Promise<boolean>;
 }
 
 export async function disableModByRenamingFiles(folderName: string) {

--- a/src/providers/ror2/installing/ProfileInstallerProvider.ts
+++ b/src/providers/ror2/installing/ProfileInstallerProvider.ts
@@ -4,7 +4,6 @@ import R2Error from '../../../model/errors/R2Error';
 import { ImmutableProfile } from '../../../model/Profile';
 
 export default abstract class ProfileInstallerProvider {
-
     private static provider: () => ProfileInstallerProvider;
     static provide(provided: () => ProfileInstallerProvider): void {
         this.provider = provided;
@@ -40,4 +39,17 @@ export default abstract class ProfileInstallerProvider {
      * @param mod
      */
     public abstract installMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null>;
+
+    /**
+     * Installs a mod to the profile.
+     * @param mod
+     */
+    public abstract installMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null>;
+
+    /**
+     * Returns a boolean if a mod is disabled in the loader. Returns undefined if the loader doesn't support disabling.
+     * For loaders without a disabling mechanism, this function should always return false.
+     * @param mod
+     */
+    public abstract isModLoaderDisabled(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | boolean | undefined> ;
 }

--- a/src/providers/ror2/installing/ProfileInstallerProvider.ts
+++ b/src/providers/ror2/installing/ProfileInstallerProvider.ts
@@ -41,12 +41,6 @@ export default abstract class ProfileInstallerProvider {
     public abstract installMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null>;
 
     /**
-     * Installs a mod to the profile.
-     * @param mod
-     */
-    public abstract installMod(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | null>;
-
-    /**
      * Returns a boolean if a mod is disabled in the loader. Returns undefined if the loader doesn't support disabling.
      * For loaders without a disabling mechanism, this function should always return false.
      * @param mod

--- a/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
+++ b/src/r2mm/installing/profile_installers/GenericProfileInstaller.ts
@@ -88,4 +88,24 @@ export default class GenericProfileInstaller extends ProfileInstallerProvider {
 
         return null;
     }
+
+    async isModLoaderDisabled(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | boolean | undefined> {
+        try {
+            // Mod loaders don't support disabling.
+            if (this.isModLoader(mod)) {
+                return
+            }
+
+            if (this.pluginInstaller.isLoaderDisabled === undefined) {
+                return
+            }
+
+            const args = getInstallArgs(mod, profile);
+            return await this.pluginInstaller.isLoaderDisabled(args);
+        } catch (e) {
+            console.error(e);
+            return R2Error.fromThrownValue(e);
+        }
+    }
+
 }

--- a/src/r2mm/mods/ProfileModList.ts
+++ b/src/r2mm/mods/ProfileModList.ts
@@ -21,6 +21,8 @@ import InteractionProvider from '../../providers/ror2/system/InteractionProvider
 import { ProfileApiClient } from '../profiles/ProfilesClient';
 import path from '../../providers/node/path/path';
 import Buffer from '../../providers/node/buffer/buffer';
+import ProfileInstallerProvider from '../../providers/ror2/installing/ProfileInstallerProvider';
+
 
 export default class ProfileModList {
 
@@ -46,8 +48,20 @@ export default class ProfileModList {
             try {
                 const fileContent = (await fs.readFile(profile.joinToProfilePath('mods.yml'))).toString();
                 const parsedYaml: any = parseYaml(fileContent) || [];
+                const installer = ProfileInstallerProvider.instance;
                 for(let modIndex in parsedYaml){
                     const mod = new ManifestV2().fromJsObject(parsedYaml[modIndex]);
+                    // Mod loaders don't support disabling.
+                    if (!installer.isModLoader(mod)) {
+                        const loaderDisabled = await installer.isModLoaderDisabled(mod, profile);
+                        if (loaderDisabled instanceof R2Error) {
+                            return loaderDisabled;
+                        }
+                        if (loaderDisabled)
+                            mod.disable();
+                        else if (loaderDisabled === false)
+                            mod.enable();
+                    }
                     parsedYaml[modIndex] = mod;
                 }
                 return parsedYaml;


### PR DESCRIPTION
This adds the ability for PackageInstallers to control mod enabled/disabled states. This is done via the following methods:
```ts
PackageInstaller.isLoaderDisabled?(args: InstallArgs): Promise<boolean|undefined>;
```
Which allows a package installer to indicate whether a mod is enabled or disabled (or if r2mm should handle it, `undefined`), if the method has been defined, and:
```ts
ProfileInstallerProvider.isModLoaderDisabled(mod: ManifestV2, profile: ImmutableProfile): Promise<R2Error | boolean | undefined> ;
``` 
which is used to get the value of the aformentiond isLoaderDisabled for a specific mod, handling loaders that don't define the method.
This is then used when querying the list of mods to force enable or disable a mod if isModLoaderDisabled returns true/false.

The `LovelyPluginInstaller` now provides `isLoaderDisabled`, and it now opts to rely soley on lovely's built in disabling mechanims rather than r2mm's, which improves compatbility with mods  that rely on this (for example, Steamodded's mod menu now shows disabled mods correctly, and they can be (dis/en)abled from there and sync to r2mm).

When disabling a mod it adds a .lovelyignore, and when enabling it will handle both .lovelyignore and the blacklist correctly.

This might cause some issues if a user disables a mod in an old version of r2mm, and updates to this new version as the mechanism has been changed. I didn't really know how to solve this so I just didn't